### PR TITLE
Fix memory leak from gst sample

### DIFF
--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -364,5 +364,9 @@ CleanUp:
         CHK_LOG_ERR(freeSampleConfiguration(&pSampleConfiguration));
     }
 
+    if (pGstAppSrcs != NULL) {
+        SAFE_MEMFREE(pGstAppSrcs);
+    }
+
     return (INT32) retStatus;
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Not freeing the memory allocated to hold video app src and audio app src before.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
