### PR TITLE
Fix off-by-one in RtcIceCandidateInit parsing

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -642,9 +642,8 @@ STATUS deserializeRtcIceCandidateInit(PCHAR pJson, UINT32 jsonLen, PRtcIceCandid
     tokenCount = jsmn_parse(&parser, pJson, jsonLen, tokens, ICE_CANDIDATE_INIT_TOKENS);
     CHK(tokenCount > 1, STATUS_INVALID_API_CALL_RETURN_JSON);
     CHK(tokens[0].type == JSMN_OBJECT, STATUS_ICE_CANDIDATE_INIT_MALFORMED);
-    CHK(tokenCount == ICE_CANDIDATE_INIT_TOKENS, STATUS_ICE_CANDIDATE_INIT_MALFORMED);
 
-    for (i = 1; i < tokenCount; i++) {
+    for (i = 1; i < (tokenCount - 1); i++) {
         if (STRNCMP(CANDIDATE_KEY, pJson + tokens[i].start, ARRAY_SIZE(CANDIDATE_KEY) - 1) == 0) {
             STRNCPY(pRtcIceCandidateInit->candidate, pJson + tokens[i + 1].start, (tokens[i + 1].end - tokens[i + 1].start));
         }

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -1,0 +1,35 @@
+#include "WebRTCClientTestFixture.h"
+
+namespace com { namespace amazonaws { namespace kinesis { namespace video { namespace webrtcclient {
+
+class PeerConnectionApiTest : public WebRtcClientTestBase {
+};
+
+TEST_F(PeerConnectionApiTest, deserializeRtcIceCandidateInit)
+{
+    RtcIceCandidateInit rtcIceCandidateInit;
+
+    MEMSET(&rtcIceCandidateInit, 0x00, SIZEOF(rtcIceCandidateInit));
+
+    auto notAnObject = "helloWorld";
+    EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) notAnObject, STRLEN(notAnObject), &rtcIceCandidateInit), STATUS_INVALID_API_CALL_RETURN_JSON);
+
+    auto emptyObject = "{}";
+    EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) emptyObject, STRLEN(emptyObject), &rtcIceCandidateInit), STATUS_INVALID_API_CALL_RETURN_JSON);
+
+    auto noCandidate = "{randomKey: \"randomValue\"}";
+    EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) noCandidate, STRLEN(noCandidate), &rtcIceCandidateInit), STATUS_ICE_CANDIDATE_MISSING_CANDIDATE);
+
+    auto keyNoValue = "{1,2,3,4,5}candidate";
+    EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) keyNoValue, STRLEN(keyNoValue), &rtcIceCandidateInit), STATUS_ICE_CANDIDATE_MISSING_CANDIDATE);
+
+    auto validCandidate = "{candidate: \"foobar\"}";
+    EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) validCandidate, STRLEN(validCandidate), &rtcIceCandidateInit), STATUS_SUCCESS);
+    EXPECT_STREQ(rtcIceCandidateInit.candidate, "foobar");
+}
+
+}
+}
+}
+}
+}


### PR DESCRIPTION
```
==18070==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffee67b67b4 at pc 0x00010983f1cf bp 0x7ffee67b6710 sp 0x7ffee67b6708
READ of size 4 at 0x7ffee67b67b4 thread T0
    #0 0x10983f1ce in deserializeRtcIceCandidateInit SessionDescription.c:648
    #1 0x1094946e4 in com::amazonaws::kinesis::video::webrtcclient::PeerConnectionApiTest_deserializeRtcIceCandidateInit_Test::TestBody() PeerConnectionApiTest.cpp:24
```
