### PR TITLE
Fix stack-buffer-overflow in setRtpPacketFromBytes

### DIFF
--- a/src/source/Rtp/RtpPacket.h
+++ b/src/source/Rtp/RtpPacket.h
@@ -13,7 +13,7 @@ extern "C" {
 // For tight packing
 #pragma pack(push, include_i, 1) // for byte alignment
 
-#define MIN_HEADER_LENGTH 4
+#define MIN_HEADER_LENGTH 12
 #define VERSION_SHIFT 6
 #define VERSION_MASK 0x3
 #define PADDING_SHIFT 5

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -30,6 +30,19 @@ CleanUp:
     return retStatus;
 }
 
+TEST_F(RtpFunctionalityTest, packetUnderflow)
+{
+    BYTE rawPacket[] = {0x00, 0x00, 0x00, 0x00};
+    RtpPacket rtpPacket;
+
+    MEMSET(&rtpPacket, 0x00, SIZEOF(RtpPacket));
+
+    for (auto i = 0; i <= 12; i++) {
+        ASSERT_EQ(setRtpPacketFromBytes(rawPacket, SIZEOF(rawPacket), &rtpPacket), STATUS_RTP_INPUT_PACKET_TOO_SMALL);
+    }
+}
+
+
 TEST_F(RtpFunctionalityTest, marshallUnmarshallGettingSameData)
 {
     BYTE payload[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};


### PR DESCRIPTION
```
==39931==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffee2919e24 at pc 0x00010d6ecf6b bp 0x7ffee2919bc0 sp 0x7ffee2919bb8
READ of size 4 at 0x7ffee2919e24 thread T0
    #0 0x10d6ecf6a in setRtpPacketFromBytes RtpPacket.c:138
    #1 0x10d355af5 in com::amazonaws::kinesis::video::webrtcclient::RtpFunctionalityTest_packetUnderflow_Test::TestBody() RtpFunctionalityTest.cpp:40
```
