### PR TITLE
change createIceAgent to take a PConnectionListener instead of creati…

### DIFF
--- a/src/source/Ice/ConnectionListener.c
+++ b/src/source/Ice/ConnectionListener.c
@@ -16,6 +16,7 @@ STATUS createConnectionListener(PConnectionListener* ppConnectionListener)
 
     CHK_STATUS(doubleListCreate(&pConnectionListener->connectionList));
     ATOMIC_STORE_BOOL(&pConnectionListener->terminate, FALSE);
+    ATOMIC_STORE_BOOL(&pConnectionListener->started, FALSE);
     pConnectionListener->receiveDataRoutine = INVALID_TID_VALUE;
     pConnectionListener->lock = MUTEX_CREATE(FALSE);
     pConnectionListener->connectionRemovalLock = MUTEX_CREATE(FALSE);
@@ -157,8 +158,9 @@ STATUS connectionListenerStart(PConnectionListener pConnectionListener)
     STATUS retStatus = STATUS_SUCCESS;
 
     CHK(pConnectionListener != NULL, STATUS_NULL_ARG);
-    CHK(!ATOMIC_LOAD_BOOL(&pConnectionListener->terminate) && !IS_VALID_TID_VALUE(pConnectionListener->receiveDataRoutine), retStatus);
+    CHK(!ATOMIC_LOAD_BOOL(&pConnectionListener->terminate) && !ATOMIC_LOAD_BOOL(&pConnectionListener->started), retStatus);
 
+    ATOMIC_STORE_BOOL(&pConnectionListener->started, TRUE);
     CHK_STATUS(THREAD_CREATE(&pConnectionListener->receiveDataRoutine,
                              connectionListenerReceiveDataRoutine,
                              (PVOID) pConnectionListener));

--- a/src/source/Ice/ConnectionListener.h
+++ b/src/source/Ice/ConnectionListener.h
@@ -20,6 +20,7 @@ extern "C" {
 
 typedef struct {
     volatile ATOMIC_BOOL terminate;
+    volatile ATOMIC_BOOL started;
     PDoubleList connectionList;
     MUTEX lock;
     MUTEX connectionRemovalLock;

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -8,7 +8,8 @@ extern StateMachineState ICE_AGENT_STATE_MACHINE_STATES[];
 extern UINT32 ICE_AGENT_STATE_MACHINE_STATE_COUNT;
 
 STATUS createIceAgent(PCHAR username, PCHAR password, UINT64 customData, PIceAgentCallbacks pIceAgentCallbacks,
-                      PRtcConfiguration pRtcConfiguration, TIMER_QUEUE_HANDLE timerQueueHandle, PIceAgent* ppIceAgent)
+                      PRtcConfiguration pRtcConfiguration, TIMER_QUEUE_HANDLE timerQueueHandle,
+                      PConnectionListener pConnectionListener, PIceAgent* ppIceAgent)
 {
     ENTERS();
 
@@ -16,7 +17,7 @@ STATUS createIceAgent(PCHAR username, PCHAR password, UINT64 customData, PIceAge
     PIceAgent pIceAgent = NULL;
     UINT32 i, turnServerCount = 0;
 
-    CHK(ppIceAgent != NULL && username != NULL && password != NULL, STATUS_NULL_ARG);
+    CHK(ppIceAgent != NULL && username != NULL && password != NULL && pConnectionListener != NULL, STATUS_NULL_ARG);
     CHK(STRNLEN(username, MAX_ICE_CONFIG_USER_NAME_LEN + 1) <= MAX_ICE_CONFIG_USER_NAME_LEN &&
         STRNLEN(password, MAX_ICE_CONFIG_CREDENTIAL_LEN + 1) <= MAX_ICE_CONFIG_CREDENTIAL_LEN, STATUS_INVALID_ARG);
 
@@ -55,12 +56,11 @@ STATUS createIceAgent(PCHAR username, PCHAR password, UINT64 customData, PIceAge
     pIceAgent->lastDataReceivedTime = INVALID_TIMESTAMP_VALUE;
     pIceAgent->detectedDisconnection = FALSE;
     pIceAgent->disconnectionGracePeriodEndTime = INVALID_TIMESTAMP_VALUE;
+    pIceAgent->pConnectionListener = pConnectionListener;
 
     CHK_STATUS(doubleListCreate(&pIceAgent->localCandidates));
     CHK_STATUS(doubleListCreate(&pIceAgent->remoteCandidates));
     CHK_STATUS(stackQueueCreate(&pIceAgent->triggeredCheckQueue));
-
-    CHK_STATUS(createConnectionListener(&pIceAgent->pConnectionListener));
 
     for (i = 0; i < MAX_ICE_SERVERS_COUNT; i++) {
         if (pRtcConfiguration->iceServers[i].urls[0] != '\0') {

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -182,7 +182,7 @@ typedef struct {
  *
  * @return - STATUS - status of execution
  */
-STATUS createIceAgent(PCHAR, PCHAR, UINT64, PIceAgentCallbacks, PRtcConfiguration, TIMER_QUEUE_HANDLE, PIceAgent*);
+STATUS createIceAgent(PCHAR, PCHAR, UINT64, PIceAgentCallbacks, PRtcConfiguration, TIMER_QUEUE_HANDLE, PConnectionListener, PIceAgent*);
 
 /**
  * deallocate the PIceAgent object and all its resources.

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -404,6 +404,7 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     DtlsSessionCallbacks dtlsSessionCallbacks;
     UINT32 logLevel = LOG_LEVEL_DEBUG;
     PCHAR logLevelStr = NULL;
+    PConnectionListener pConnectionListener = NULL;
 
     CHK(pConfiguration != NULL && ppPeerConnection != NULL, STATUS_NULL_ARG);
 
@@ -443,9 +444,11 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     iceAgentCallbacks.inboundPacketFn = onInboundPacket;
     iceAgentCallbacks.connectionStateChangedFn = onIceConnectionStateChange;
     iceAgentCallbacks.newLocalCandidateFn = onNewIceLocalCandidate;
+    CHK_STATUS(createConnectionListener(&pConnectionListener));
+    // IceAgent will own the lifecycle of pConnectionListener;
     CHK_STATUS(createIceAgent(pKvsPeerConnection->localIceUfrag, pKvsPeerConnection->localIcePwd,
                               iceAgentCallbacks.customData, &iceAgentCallbacks, pConfiguration,
-                              pKvsPeerConnection->timerQueueHandle, &pKvsPeerConnection->pIceAgent));
+                              pKvsPeerConnection->timerQueueHandle, pConnectionListener, &pKvsPeerConnection->pIceAgent));
 
     *ppPeerConnection = (PRtcPeerConnection) pKvsPeerConnection;
 


### PR DESCRIPTION
…ng one in its own for unit testing. Make connectionListenerStart more securely idempotent

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
