### PR TITLE
Handle case when Rtx payload type doesn't exist in offer/answer

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -493,8 +493,6 @@ typedef enum {
     RTC_CODEC_VP8 = 3,
     RTC_CODEC_MULAW = 4,
     RTC_CODEC_ALAW = 5,
-    RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE = 6,
-    RTC_RTX_CODEC_VP8 = 7,
 } RTC_CODEC;
 
 /* ICE_TRANSPORT_POLICY restrict which ICE candidates are used in a session.

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -427,6 +427,7 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
 
     CHK_STATUS(hashTableCreateWithParams(CODEC_HASH_TABLE_BUCKET_COUNT, CODEC_HASH_TABLE_BUCKET_LENGTH, &pKvsPeerConnection->pCodecTable));
     CHK_STATUS(hashTableCreateWithParams(CODEC_HASH_TABLE_BUCKET_COUNT, CODEC_HASH_TABLE_BUCKET_LENGTH, &pKvsPeerConnection->pDataChannels));
+    CHK_STATUS(hashTableCreateWithParams(RTX_HASH_TABLE_BUCKET_COUNT, RTX_HASH_TABLE_BUCKET_LENGTH, &pKvsPeerConnection->pRtxTable));
     CHK_STATUS(doubleListCreate(&(pKvsPeerConnection->pTransceievers)));
 
     if ((logLevelStr = GETENV(DEBUG_LOG_LEVEL_ENV_VAR)) != NULL) {
@@ -495,6 +496,7 @@ STATUS freePeerConnection(PRtcPeerConnection *ppPeerConnection)
     CHK_LOG_ERR(doubleListFree(pKvsPeerConnection->pTransceievers));
     CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pDataChannels));
     CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pCodecTable));
+    CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pRtxTable));
     if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->pSrtpSessionLock)) {
         MUTEX_FREE(pKvsPeerConnection->pSrtpSessionLock);
     }
@@ -671,9 +673,9 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     CHK_STATUS(dtlsSessionStart(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->dtlsIsServer));
     CHK_STATUS(iceAgentStartAgent(pKvsPeerConnection->pIceAgent, remoteIceUfrag, remoteIcePwd, pKvsPeerConnection->isOffer));
     if (!pKvsPeerConnection->isOffer) {
-        CHK_STATUS(setPayloadTypesFromOffer(pKvsPeerConnection->pCodecTable, pSessionDescription));
+        CHK_STATUS(setPayloadTypesFromOffer(pKvsPeerConnection->pCodecTable, pKvsPeerConnection->pRtxTable, pSessionDescription));
     }
-    CHK_STATUS(setTransceiverPayloadTypes(pKvsPeerConnection->pCodecTable, pKvsPeerConnection->pTransceievers));
+    CHK_STATUS(setTransceiverPayloadTypes(pKvsPeerConnection->pCodecTable, pKvsPeerConnection->pRtxTable, pKvsPeerConnection->pTransceievers));
     CHK_STATUS(setReceiversSsrc(pSessionDescription, pKvsPeerConnection->pTransceievers));
 
 CleanUp:

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -28,9 +28,16 @@ extern "C" {
 
 #define CODEC_HASH_TABLE_BUCKET_COUNT                   50
 #define CODEC_HASH_TABLE_BUCKET_LENGTH                  2
+#define RTX_HASH_TABLE_BUCKET_COUNT                   50
+#define RTX_HASH_TABLE_BUCKET_LENGTH                  2
 
 #define DATA_CHANNEL_HASH_TABLE_BUCKET_COUNT            200
 #define DATA_CHANNEL_HASH_TABLE_BUCKET_LENGTH           2
+
+typedef enum {
+    RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE = 1,
+    RTC_RTX_CODEC_VP8 = 2,
+} RTX_CODEC;
 
 typedef struct {
     RtcPeerConnection peerConnection;
@@ -64,6 +71,10 @@ typedef struct {
     // When offering we generate values starting from 96
     // When answering this is populated from the remote offer
     PHashTable pCodecTable;
+
+    // Payload types that we use to retransmit data
+    // When answering this is populated from the remote offer
+    PHashTable pRtxTable;
 
     // DataChannels keyed by streamId
     PHashTable pDataChannels;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -135,7 +135,7 @@ CleanUp:
 /*
  * Populate map with PayloadTypes for codecs a KvsPeerConnection has enabled.
  */
-STATUS setPayloadTypesFromOffer(PHashTable codecTable, PSessionDescription pSessionDescription)
+STATUS setPayloadTypesFromOffer(PHashTable codecTable, PHashTable rtxTable, PSessionDescription pSessionDescription)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -208,7 +208,7 @@ STATUS setPayloadTypesFromOffer(PHashTable codecTable, PSessionDescription pSess
                     if (supportCodec) {
                         CHK_STATUS(hashTableGet(codecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &hashmapPayloadType));
                         if (parsedPayloadType == hashmapPayloadType) {
-                            CHK_STATUS(hashTableUpsert(codecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, rtxPayloadType));
+                            CHK_STATUS(hashTableUpsert(rtxTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, rtxPayloadType));
                         }
                     }
 
@@ -216,7 +216,7 @@ STATUS setPayloadTypesFromOffer(PHashTable codecTable, PSessionDescription pSess
                     if (supportCodec) {
                         CHK_STATUS(hashTableGet(codecTable, RTC_CODEC_VP8, &hashmapPayloadType));
                         if (parsedPayloadType == hashmapPayloadType) {
-                            CHK_STATUS(hashTableUpsert(codecTable, RTC_RTX_CODEC_VP8, rtxPayloadType));
+                            CHK_STATUS(hashTableUpsert(rtxTable, RTC_RTX_CODEC_VP8, rtxPayloadType));
                         }
                     }
                 }
@@ -230,7 +230,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS setTransceiverPayloadTypes(PHashTable codecTable, PDoubleList pTransceiver) {
+STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PDoubleList pTransceivers) {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PDoubleListNode pCurNode = NULL;
@@ -239,7 +239,7 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PDoubleList pTransceive
 
     // Loop over Transceivers and set the payloadType (which what we got from the other side)
     // If a codec we want to send wasn't supported by the other return an error
-    CHK_STATUS(doubleListGetHeadNode(pTransceiver, &pCurNode));
+    CHK_STATUS(doubleListGetHeadNode(pTransceivers, &pCurNode));
     while (pCurNode != NULL) {
         CHK_STATUS(doubleListGetNodeData(pCurNode, &data));
         pCurNode = pCurNode->pNext;
@@ -253,11 +253,11 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PDoubleList pTransceive
             pKvsRtpTransceiver->sender.payloadType = (UINT8) data;
             switch (pKvsRtpTransceiver->sender.track.codec) {
                 case RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE:
-                    retStatus = hashTableGet(codecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &data);
+                    retStatus = hashTableGet(rtxTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &data);
                     CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT, retStatus);
                     break;
                 case RTC_CODEC_VP8:
-                    retStatus = hashTableGet(codecTable, RTC_RTX_CODEC_VP8, &data);
+                    retStatus = hashTableGet(rtxTable, RTC_RTX_CODEC_VP8, &data);
                     CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT, retStatus);
                     break;
                 default:
@@ -293,9 +293,9 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
 
     if (pRtcMediaStreamTrack->codec == RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE || pRtcMediaStreamTrack->codec == RTC_CODEC_VP8) {
         if (pRtcMediaStreamTrack->codec == RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE) {
-            retStatus = hashTableGet(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &rtxPayloadType);
+            retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &rtxPayloadType);
         } else {
-            retStatus = hashTableGet(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_VP8, &rtxPayloadType);
+            retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_VP8, &rtxPayloadType);
         }
         CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT, retStatus);
         containRtx = (retStatus == STATUS_SUCCESS);
@@ -425,7 +425,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         attributeCount++;
 
         if (containRtx) {
-            CHK_STATUS(hashTableGet(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_VP8, &rtxPayloadType));
+            CHK_STATUS(hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_VP8, &rtxPayloadType));
             STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtpmap");
             SPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "%"PRId64" "RTX_VALUE, rtxPayloadType);
             attributeCount++;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -230,7 +230,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS setTransceiverPayloadTypes(PHashTable codecTable, PDoubleList pTransceievers) {
+STATUS setTransceiverPayloadTypes(PHashTable codecTable, PDoubleList pTransceiver) {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PDoubleListNode pCurNode = NULL;
@@ -239,7 +239,7 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PDoubleList pTransceiev
 
     // Loop over Transceivers and set the payloadType (which what we got from the other side)
     // If a codec we want to send wasn't supported by the other return an error
-    CHK_STATUS(doubleListGetHeadNode(pTransceievers, &pCurNode));
+    CHK_STATUS(doubleListGetHeadNode(pTransceiver, &pCurNode));
     while (pCurNode != NULL) {
         CHK_STATUS(doubleListGetNodeData(pCurNode, &data));
         pCurNode = pCurNode->pNext;
@@ -253,16 +253,21 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PDoubleList pTransceiev
             pKvsRtpTransceiver->sender.payloadType = (UINT8) data;
             switch (pKvsRtpTransceiver->sender.track.codec) {
                 case RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE:
-                    CHK_STATUS(hashTableGet(codecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &data));
-                    pKvsRtpTransceiver->sender.rtxPayloadType = (UINT8) data;
+                    retStatus = hashTableGet(codecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &data);
+                    CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT, retStatus);
                     break;
                 case RTC_CODEC_VP8:
-                    CHK_STATUS(hashTableGet(codecTable, RTC_RTX_CODEC_VP8, &data));
-                    pKvsRtpTransceiver->sender.rtxPayloadType = (UINT8) data;
+                    retStatus = hashTableGet(codecTable, RTC_RTX_CODEC_VP8, &data);
+                    CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT, retStatus);
                     break;
                 default:
+                    retStatus = STATUS_HASH_KEY_NOT_PRESENT;
                     break;
             }
+            if (retStatus == STATUS_SUCCESS) {
+                pKvsRtpTransceiver->sender.rtxPayloadType = (UINT8) data;
+            }
+            retStatus = STATUS_SUCCESS;
         }
     }
 
@@ -288,12 +293,13 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
 
     if (pRtcMediaStreamTrack->codec == RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE || pRtcMediaStreamTrack->codec == RTC_CODEC_VP8) {
         if (pRtcMediaStreamTrack->codec == RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE) {
-            CHK_STATUS(hashTableContains(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &containRtx));
-            CHK_STATUS(hashTableGet(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &rtxPayloadType));
+            retStatus = hashTableGet(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, &rtxPayloadType);
         } else {
-            CHK_STATUS(hashTableContains(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_VP8, &containRtx));
-            CHK_STATUS(hashTableGet(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_VP8, &rtxPayloadType));
+            retStatus = hashTableGet(pKvsPeerConnection->pCodecTable, RTC_RTX_CODEC_VP8, &rtxPayloadType);
         }
+        CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT, retStatus);
+        containRtx = (retStatus == STATUS_SUCCESS);
+        retStatus = STATUS_SUCCESS;
         if (containRtx) {
             SPRINTF(pSdpMediaDescription->mediaName, "video 9 UDP/TLS/RTP/SAVPF %"PRId64" %"PRId64, payloadType, rtxPayloadType);
         } else {

--- a/src/source/PeerConnection/SessionDescription.h
+++ b/src/source/PeerConnection/SessionDescription.h
@@ -57,10 +57,10 @@ extern "C" {
 #define OPUS_CLOCKRATE (UINT64) 48000
 #define PCM_CLOCKRATE (UINT64) 8000
 
-STATUS setPayloadTypesFromOffer(PHashTable, PSessionDescription);
+STATUS setPayloadTypesFromOffer(PHashTable, PHashTable, PSessionDescription);
 STATUS setPayloadTypesForOffer(PHashTable);
 
-STATUS setTransceiverPayloadTypes(PHashTable, PDoubleList);
+STATUS setTransceiverPayloadTypes(PHashTable, PHashTable, PDoubleList);
 STATUS populateSessionDescription(PKvsPeerConnection, PSessionDescription, PSessionDescription);
 STATUS reorderTransceiverByRemoteDescription(PKvsPeerConnection, PSessionDescription);
 STATUS setReceiversSsrc(PSessionDescription, PDoubleList);

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -178,35 +178,41 @@ t=0 0
 
 TEST_F(SdpApiTest, setTransceiverPayloadTypes_NoRtxType) {
     PHashTable pCodecTable;
+    PHashTable pRtxTable;
     PDoubleList pTransceivers;
     KvsRtpTransceiver transceiver;
     transceiver.sender.track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
     transceiver.transceiver.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pCodecTable));
     EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 1));
+    EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pRtxTable));
     EXPECT_EQ(STATUS_SUCCESS, doubleListCreate(&pTransceivers));
     EXPECT_EQ(STATUS_SUCCESS, doubleListInsertItemHead(pTransceivers, (UINT64) (&transceiver)));
-    EXPECT_EQ(STATUS_SUCCESS, setTransceiverPayloadTypes(pCodecTable, pTransceivers));
+    EXPECT_EQ(STATUS_SUCCESS, setTransceiverPayloadTypes(pCodecTable, pRtxTable, pTransceivers));
     EXPECT_EQ(1, transceiver.sender.payloadType);
     hashTableFree(pCodecTable);
+    hashTableFree(pRtxTable);
     doubleListFree(pTransceivers);
 }
 
 TEST_F(SdpApiTest, setTransceiverPayloadTypes_HasRtxType) {
     PHashTable pCodecTable;
+    PHashTable pRtxTable;
     PDoubleList pTransceivers;
     KvsRtpTransceiver transceiver;
     transceiver.sender.track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
     transceiver.transceiver.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pCodecTable));
     EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 1));
-    EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 2));
+    EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pRtxTable));
+    EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pRtxTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 2));
     EXPECT_EQ(STATUS_SUCCESS, doubleListCreate(&pTransceivers));
     EXPECT_EQ(STATUS_SUCCESS, doubleListInsertItemHead(pTransceivers, (UINT64) (&transceiver)));
-    EXPECT_EQ(STATUS_SUCCESS, setTransceiverPayloadTypes(pCodecTable, pTransceivers));
+    EXPECT_EQ(STATUS_SUCCESS, setTransceiverPayloadTypes(pCodecTable, pRtxTable, pTransceivers));
     EXPECT_EQ(1, transceiver.sender.payloadType);
     EXPECT_EQ(2, transceiver.sender.rtxPayloadType);
     hashTableFree(pCodecTable);
+    hashTableFree(pRtxTable);
     doubleListFree(pTransceivers);
 }
 

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -176,6 +176,40 @@ t=0 0
     EXPECT_EQ(serializeSessionDescription(&sessionDescription, (PCHAR) sessionDescriptionNoMedia.c_str()), STATUS_SDP_ATTRIBUTE_MAX_EXCEEDED);
 }
 
+TEST_F(SdpApiTest, setTransceiverPayloadTypes_NoRtxType) {
+    PHashTable pCodecTable;
+    PDoubleList pTransceivers;
+    KvsRtpTransceiver transceiver;
+    transceiver.sender.track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    transceiver.transceiver.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+    EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pCodecTable));
+    EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 1));
+    EXPECT_EQ(STATUS_SUCCESS, doubleListCreate(&pTransceivers));
+    EXPECT_EQ(STATUS_SUCCESS, doubleListInsertItemHead(pTransceivers, (UINT64) (&transceiver)));
+    EXPECT_EQ(STATUS_SUCCESS, setTransceiverPayloadTypes(pCodecTable, pTransceivers));
+    EXPECT_EQ(1, transceiver.sender.payloadType);
+    hashTableFree(pCodecTable);
+    doubleListFree(pTransceivers);
+}
+
+TEST_F(SdpApiTest, setTransceiverPayloadTypes_HasRtxType) {
+    PHashTable pCodecTable;
+    PDoubleList pTransceivers;
+    KvsRtpTransceiver transceiver;
+    transceiver.sender.track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    transceiver.transceiver.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+    EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pCodecTable));
+    EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 1));
+    EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 2));
+    EXPECT_EQ(STATUS_SUCCESS, doubleListCreate(&pTransceivers));
+    EXPECT_EQ(STATUS_SUCCESS, doubleListInsertItemHead(pTransceivers, (UINT64) (&transceiver)));
+    EXPECT_EQ(STATUS_SUCCESS, setTransceiverPayloadTypes(pCodecTable, pTransceivers));
+    EXPECT_EQ(1, transceiver.sender.payloadType);
+    EXPECT_EQ(2, transceiver.sender.rtxPayloadType);
+    hashTableFree(pCodecTable);
+    doubleListFree(pTransceivers);
+}
+
 
 }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Update code logic to accept case when rtx payload type doesn't exist, it can still continue to check other codecs instead of exiting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
