### PR TITLE
Fixing an issue where a dropped connection could still result in a co…

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -348,6 +348,9 @@ extern "C" {
 // Max signaling message payload length
 #define MAX_SIGNALING_MESSAGE_LEN                                                   (10 * 1024)
 
+// Valid name characters
+#define SIGNALING_VALID_NAME_CHARS                                                  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_.-"
+
 /**
  * Maximum size of SDP member in RtcSessionDescriptionInit
  */

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -385,7 +385,7 @@ STATUS generateJSONSafeString(PCHAR pDst, UINT32 len)
     CHK(RAND_bytes(randBuffer, len), STATUS_INTERNAL_ERROR );
 
     for (i = 0; i < len; i++) {
-        pDst[i] = VALID_CHAR_SET_FOR_JSON[randBuffer[i] % (SIZEOF(VALID_CHAR_SET_FOR_JSON) - 1)];
+        pDst[i] = VALID_CHAR_SET_FOR_JSON[randBuffer[i] % (ARRAY_SIZE(VALID_CHAR_SET_FOR_JSON) - 1)];
     }
 
 CleanUp:

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1698,13 +1698,15 @@ STATUS terminateLwsListenerLoop(PSignalingClient pSignalingClient)
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
 
-    CHK(pSignalingClient != NULL && pSignalingClient->pOngoingCallInfo, retStatus);
+    CHK(pSignalingClient != NULL, retStatus);
 
-    // Check if anything needs to be done
-    CHK(!ATOMIC_LOAD_BOOL(&pSignalingClient->listenerTracker.terminated), retStatus);
+    if (pSignalingClient->pOngoingCallInfo != NULL) {
+        // Check if anything needs to be done
+        CHK(!ATOMIC_LOAD_BOOL(&pSignalingClient->listenerTracker.terminated), retStatus);
 
-    // Terminate the listener
-    terminateConnectionWithStatus(pSignalingClient, SERVICE_CALL_RESULT_OK);
+        // Terminate the listener
+        terminateConnectionWithStatus(pSignalingClient, SERVICE_CALL_RESULT_OK);
+    }
 
     lws_context_destroy(pSignalingClient->pLwsContext);
     pSignalingClient->pLwsContext = NULL;

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1144,8 +1144,8 @@ CleanUp:
     if (STATUS_FAILED(retStatus) && pSignalingClient != NULL) {
         MUTEX_LOCK(pSignalingClient->listenerLock);
         // Trigger termination
-        if (pLwsCallInfo != NULL && pLwsCallInfo->callInfo.pRequestInfo != NULL) {
-            ATOMIC_STORE_BOOL(&pLwsCallInfo->callInfo.pRequestInfo->terminating, TRUE);
+        if (pSignalingClient->pOngoingCallInfo != NULL && pSignalingClient->pOngoingCallInfo->callInfo.pRequestInfo != NULL) {
+            ATOMIC_STORE_BOOL(&pSignalingClient->pOngoingCallInfo->callInfo.pRequestInfo->terminating, TRUE);
             lws_cancel_service(pSignalingClient->pLwsContext);
         }
 

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -119,6 +119,9 @@ STATUS createSignalingSync(PSignalingClientInfo pClientInfo, PChannelInfo pChann
     pSignalingClient->messageQueueLock = MUTEX_CREATE(TRUE);
     CHK(IS_VALID_MUTEX_VALUE(pSignalingClient->messageQueueLock), STATUS_INVALID_OPERATION);
 
+    pSignalingClient->listenerLock = MUTEX_CREATE(FALSE);
+    CHK(IS_VALID_MUTEX_VALUE(pSignalingClient->listenerLock), STATUS_INVALID_OPERATION);
+
     // Create the ongoing message list
     CHK_STATUS(stackQueueCreate(&pSignalingClient->pMessageQueue));
 
@@ -207,6 +210,10 @@ STATUS freeSignaling(PSignalingClient* ppSignalingClient)
 
     if (IS_VALID_MUTEX_VALUE(pSignalingClient->messageQueueLock)) {
         MUTEX_FREE(pSignalingClient->messageQueueLock);
+    }
+
+    if (IS_VALID_MUTEX_VALUE(pSignalingClient->listenerLock)) {
+        MUTEX_FREE(pSignalingClient->listenerLock);
     }
 
     uninitializeThreadTracker(&pSignalingClient->restarterTracker);

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -121,6 +121,9 @@ typedef struct {
     // Conditional variable for receiving response to the sent message
     CVAR receiveCvar;
 
+    // For interlocking the listener shutdown sequence
+    MUTEX listenerLock;
+
     // Execute the state machine until this time
     UINT64 stepUntil;
 

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -121,9 +121,6 @@ typedef struct {
     // Conditional variable for receiving response to the sent message
     CVAR receiveCvar;
 
-    // For interlocking the listener shutdown sequence
-    MUTEX listenerLock;
-
     // Execute the state machine until this time
     UINT64 stepUntil;
 
@@ -134,7 +131,7 @@ typedef struct {
     ThreadTracker listenerTracker;
 
     // Restarted thread handler
-    ThreadTracker restarterTracker;
+    ThreadTracker reconnecterTracker;
 
     // LWS context to use
     struct lws_context* pLwsContext;

--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -460,13 +460,20 @@ STATUS fromConnectSignalingState(UINT64 customData, PUINT64 pState)
     PSignalingClient pSignalingClient = SIGNALING_CLIENT_FROM_CUSTOM_DATA(customData);
     UINT64 state = SIGNALING_STATE_CONNECT;
     SIZE_T result;
+    BOOL connected;
 
     CHK(pSignalingClient != NULL && pState != NULL, STATUS_NULL_ARG);
 
     result = ATOMIC_LOAD(&pSignalingClient->result);
+    connected = ATOMIC_LOAD_BOOL(&pSignalingClient->connected);
     switch (result) {
         case SERVICE_CALL_RESULT_OK:
-            state = SIGNALING_STATE_CONNECTED;
+            // We also need to check whether we terminated OK and connected or
+            // simply terminated without being connected
+            if (connected) {
+                state = SIGNALING_STATE_CONNECTED;
+            }
+
             break;
 
         case SERVICE_CALL_RESOURCE_NOT_FOUND:

--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -170,6 +170,7 @@ STATUS executeNewSignalingState(UINT64 customData, UINT64 time)
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) SERVICE_CALL_RESULT_NOT_SET);
+    ATOMIC_STORE_BOOL(&pSignalingClient->clientReady, FALSE);
 
     // Nothing to do
 
@@ -209,6 +210,7 @@ STATUS executeGetTokenSignalingState(UINT64 customData, UINT64 time)
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
 
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) SERVICE_CALL_RESULT_NOT_SET);
+    ATOMIC_STORE_BOOL(&pSignalingClient->clientReady, FALSE);
 
     // Use the credential provider to get the token
     retStatus = pSignalingClient->pCredentialProvider->getCredentialsFn(pSignalingClient->pCredentialProvider,
@@ -268,6 +270,7 @@ STATUS executeDescribeSignalingState(UINT64 customData, UINT64 time)
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) SERVICE_CALL_RESULT_NOT_SET);
+    ATOMIC_STORE_BOOL(&pSignalingClient->clientReady, FALSE);
 
     // Call DescribeChannel API
     retStatus = describeChannelLws(pSignalingClient, time);
@@ -312,6 +315,7 @@ STATUS executeCreateSignalingState(UINT64 customData, UINT64 time)
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) SERVICE_CALL_RESULT_NOT_SET);
+    ATOMIC_STORE_BOOL(&pSignalingClient->clientReady, FALSE);
 
     retStatus = createChannelLws(pSignalingClient, time);
     CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
@@ -354,6 +358,7 @@ STATUS executeGetEndpointSignalingState(UINT64 customData, UINT64 time)
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) SERVICE_CALL_RESULT_NOT_SET);
+    ATOMIC_STORE_BOOL(&pSignalingClient->clientReady, FALSE);
 
     retStatus = getChannelEndpointLws(pSignalingClient, time);
     CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
@@ -396,6 +401,7 @@ STATUS executeGetIceConfigSignalingState(UINT64 customData, UINT64 time)
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) SERVICE_CALL_RESULT_NOT_SET);
+    ATOMIC_STORE_BOOL(&pSignalingClient->clientReady, FALSE);
 
     retStatus = getIceConfigLws(pSignalingClient, time);
     CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -69,7 +69,7 @@ STATUS viewerMessageReceived(UINT64 customData, PReceivedSignalingMessage pRecei
     return STATUS_SUCCESS;
 }
 
-TEST_F(SignalingApiFunctionalityTest, basicCreateConnectFree)
+TEST_F(SignalingApiFunctionalityTest, DISABLED_basicCreateConnectFree)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -115,7 +115,7 @@ TEST_F(SignalingApiFunctionalityTest, basicCreateConnectFree)
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, mockMaster)
+TEST_F(SignalingApiFunctionalityTest, DISABLED_mockMaster)
 {
     ChannelInfo channelInfo;
     SignalingClientCallbacks signalingClientCallbacks;
@@ -245,7 +245,7 @@ TEST_F(SignalingApiFunctionalityTest, mockMaster)
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, mockViewer)
+TEST_F(SignalingApiFunctionalityTest, DISABLED_mockViewer)
 {
     ChannelInfo channelInfo;
     SignalingClientCallbacks signalingClientCallbacks;
@@ -349,7 +349,7 @@ TEST_F(SignalingApiFunctionalityTest, mockViewer)
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
+TEST_F(SignalingApiFunctionalityTest, DISABLED_invalidChannelInfoInput)
 {
     ChannelInfo channelInfo;
     SignalingClientCallbacks signalingClientCallbacks;
@@ -604,7 +604,7 @@ TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
 
 }
 
-TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
+TEST_F(SignalingApiFunctionalityTest, DISABLED_iceReconnectEmulation)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -681,7 +681,7 @@ TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
+TEST_F(SignalingApiFunctionalityTest, DISABLED_goAwayEmulation)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -758,7 +758,7 @@ TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
+TEST_F(SignalingApiFunctionalityTest, DISABLED_unknownMessageTypeEmulation)
 {
     if (!mAccessKeyIdSet) {
         return;

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -69,7 +69,7 @@ STATUS viewerMessageReceived(UINT64 customData, PReceivedSignalingMessage pRecei
     return STATUS_SUCCESS;
 }
 
-TEST_F(SignalingApiFunctionalityTest, DISABLED_mockMaster)
+TEST_F(SignalingApiFunctionalityTest, mockMaster)
 {
     ChannelInfo channelInfo;
     SignalingClientCallbacks signalingClientCallbacks;
@@ -101,7 +101,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_mockMaster)
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
     channelInfo.pKmsKeyId = NULL;
     channelInfo.tagCount = 3;
     channelInfo.pTags = tags;
@@ -199,7 +199,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_mockMaster)
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, DISABLED_mockViewer)
+TEST_F(SignalingApiFunctionalityTest, mockViewer)
 {
     ChannelInfo channelInfo;
     SignalingClientCallbacks signalingClientCallbacks;
@@ -231,7 +231,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_mockViewer)
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
     channelInfo.pKmsKeyId = NULL;
     channelInfo.tagCount = 3;
     channelInfo.pTags = tags;
@@ -303,7 +303,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_mockViewer)
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, DISABLED_invalidChannelInfoInput)
+TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
 {
     ChannelInfo channelInfo;
     SignalingClientCallbacks signalingClientCallbacks;
@@ -326,7 +326,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_invalidChannelInfoInput)
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
     channelInfo.pChannelArn = (PCHAR) "Channel ARN";
     channelInfo.pRegion = (PCHAR) "us-east-1";
     channelInfo.pControlPlaneUrl = (PCHAR) "Test Control plane URI";
@@ -506,7 +506,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_invalidChannelInfoInput)
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
     channelInfo.pChannelArn = (PCHAR) "Channel ARN";
 
     // Reset the params for proper stream creation
@@ -522,7 +522,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_invalidChannelInfoInput)
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
     channelInfo.pKmsKeyId = NULL;
     channelInfo.tagCount = 0;
     channelInfo.pTags = NULL;
@@ -539,7 +539,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_invalidChannelInfoInput)
                                           (PAwsCredentialProvider) mTestCredentialProvider, &signalingHandle);
     EXPECT_EQ(mAccessKeyIdSet ? STATUS_SIGNALING_DESCRIBE_CALL_FAILED : STATUS_NULL_ARG, retStatus);
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
 
     // ClientId Validation error - name with spaces
     clientInfo.clientId[4] = ' ';
@@ -553,7 +553,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_invalidChannelInfoInput)
 
 }
 
-TEST_F(SignalingApiFunctionalityTest, DISABLED_iceReconnectEmulation)
+TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -577,7 +577,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_iceReconnectEmulation)
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
     channelInfo.pKmsKeyId = NULL;
     channelInfo.tagCount = 0;
     channelInfo.pTags = NULL;
@@ -630,7 +630,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_iceReconnectEmulation)
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, DISABLED_goAwayEmulation)
+TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -654,7 +654,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_goAwayEmulation)
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
     channelInfo.pKmsKeyId = NULL;
     channelInfo.tagCount = 0;
     channelInfo.pTags = NULL;
@@ -707,7 +707,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_goAwayEmulation)
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, DISABLED_unknownMessageTypeEmulation)
+TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -731,7 +731,7 @@ TEST_F(SignalingApiFunctionalityTest, DISABLED_unknownMessageTypeEmulation)
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
-    channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+    channelInfo.pChannelName = mChannelName;
     channelInfo.pKmsKeyId = NULL;
     channelInfo.tagCount = 0;
     channelInfo.pTags = NULL;

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -111,8 +111,8 @@ TEST_F(SignalingApiTest, signalingClientConnectSync)
 
     // Connect again
     expectedStatus = mAccessKeyIdSet ? STATUS_INVALID_STREAM_STATE : STATUS_NULL_ARG;
-    EXPECT_EQ(expectedStatus, signalingClientConnectSync(mSignalingClientHandle));
-    EXPECT_EQ(expectedStatus, signalingClientConnectSync(mSignalingClientHandle));
+    EXPECT_EQ(STATUS_SUCCESS, signalingClientConnectSync(mSignalingClientHandle));
+    EXPECT_EQ(STATUS_SUCCESS, signalingClientConnectSync(mSignalingClientHandle));
 
 
     deinitialize();

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -70,7 +70,7 @@ public:
     SIGNALING_CLIENT_HANDLE mSignalingClientHandle;
 };
 
-TEST_F(SignalingApiTest, signalingSendMessageSync)
+TEST_F(SignalingApiTest, DISABLED_signalingSendMessageSync)
 {
     STATUS expectedStatus;
     SignalingMessage signalingMessage;

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -37,7 +37,7 @@ public:
 
         MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
         channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
-        channelInfo.pChannelName = TEST_SIGNALING_CHANNEL_NAME;
+        channelInfo.pChannelName = mChannelName;
         channelInfo.pKmsKeyId = NULL;
         channelInfo.tagCount = 3;
         channelInfo.pTags = tags;
@@ -61,10 +61,16 @@ public:
         return retStatus;
     }
 
+    STATUS deinitialize() {
+        EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&mSignalingClientHandle));
+
+        return STATUS_SUCCESS;
+    }
+
     SIGNALING_CLIENT_HANDLE mSignalingClientHandle;
 };
 
-TEST_F(SignalingApiTest, DISABLED_signalingSendMessageSync)
+TEST_F(SignalingApiTest, signalingSendMessageSync)
 {
     STATUS expectedStatus;
     SignalingMessage signalingMessage;
@@ -91,10 +97,10 @@ TEST_F(SignalingApiTest, DISABLED_signalingSendMessageSync)
     EXPECT_EQ(expectedStatus, signalingClientConnectSync(mSignalingClientHandle));
     EXPECT_EQ(expectedStatus, signalingClientSendMessageSync(mSignalingClientHandle, &signalingMessage));
 
-    EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&mSignalingClientHandle));
+    deinitialize();
 }
 
-TEST_F(SignalingApiTest, DISABLED_signalingClientConnectSync)
+TEST_F(SignalingApiTest, signalingClientConnectSync)
 {
     STATUS expectedStatus;
 
@@ -109,10 +115,10 @@ TEST_F(SignalingApiTest, DISABLED_signalingClientConnectSync)
     EXPECT_EQ(expectedStatus, signalingClientConnectSync(mSignalingClientHandle));
 
 
-    EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&mSignalingClientHandle));
+    deinitialize();
 }
 
-TEST_F(SignalingApiTest, DISABLED_signalingClientGetIceConfigInfoCout)
+TEST_F(SignalingApiTest, signalingClientGetIceConfigInfoCout)
 {
     STATUS expectedStatus;
     UINT32 count;
@@ -129,10 +135,10 @@ TEST_F(SignalingApiTest, DISABLED_signalingClientGetIceConfigInfoCout)
         EXPECT_GE(MAX_ICE_CONFIG_COUNT, count);
     }
 
-    EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&mSignalingClientHandle));
+    deinitialize();
 }
 
-TEST_F(SignalingApiTest, DISABLED_signalingClientGetIceConfigInfo)
+TEST_F(SignalingApiTest, signalingClientGetIceConfigInfo)
 {
     UINT32 i, j, count;
     PIceConfigInfo pIceConfigInfo;
@@ -165,7 +171,7 @@ TEST_F(SignalingApiTest, DISABLED_signalingClientGetIceConfigInfo)
         }
     }
 
-    EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&mSignalingClientHandle));
+    deinitialize();
 }
 
 }

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -74,6 +74,28 @@ void WebRtcClientTestBase::SetUp()
         mTestCredentialProvider = nullptr;
     }
 
+    // Prepare the test channel name by prefixing the host name with test channel name
+    // replacing a potentially bad characters with '.'
+    STRCPY(mChannelName, TEST_SIGNALING_CHANNEL_NAME);
+    UINT32 testNameLen = STRLEN(TEST_SIGNALING_CHANNEL_NAME);
+    gethostname(mChannelName + testNameLen, MAX_CHANNEL_NAME_LEN - testNameLen);
+
+    // Replace any potentially "bad" characters
+    PCHAR pCur = &mChannelName[testNameLen];
+    while (*pCur != '\0') {
+        BOOL found = FALSE;
+        for (UINT32 i = 0; !found && i < ARRAY_SIZE(SIGNALING_VALID_NAME_CHARS) - 1; i++) {
+            if (*pCur == SIGNALING_VALID_NAME_CHARS[i]) {
+                found = TRUE;
+            }
+        }
+
+        if (!found) {
+            *pCur = '.';
+        }
+
+        pCur++;
+    }
 }
 
 void WebRtcClientTestBase::TearDown()

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -8,7 +8,7 @@
 #define TEST_JITTER_BUFFER_CLOCK_RATE                           (1000)
 #define TEST_SIGNALING_MASTER_CLIENT_ID                         (PCHAR) "Test_Master_ClientId"
 #define TEST_SIGNALING_VIEWER_CLIENT_ID                         (PCHAR) "Test_Viewer_ClientId"
-#define TEST_SIGNALING_CHANNEL_NAME                             (PCHAR) "ScaryTestChannel"
+#define TEST_SIGNALING_CHANNEL_NAME                             (PCHAR) "ScaryTestChannel_"
 #define SIGNAING_TEST_CORRELATION_ID                            (PCHAR) "Test_correlation_id"
 
 //
@@ -162,6 +162,7 @@ public:
         LEAVES();
         return retStatus;
     }
+
 protected:
 
     virtual void SetUp();
@@ -188,6 +189,7 @@ protected:
 
     CHAR mDefaultRegion[MAX_REGION_NAME_LEN + 1];
     BOOL mAccessKeyIdSet;
+    CHAR mChannelName[MAX_CHANNEL_NAME_LEN + 1];
 
     PJitterBuffer mJitterBuffer;
     PBYTE mFrame;


### PR DESCRIPTION
…nnected state

Enabling test fixture to use a mangled channel name by appending the host name and ensuring valid chars
Re-enabling the integ tests

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
