### PR TITLE
remove max len check in populateIpFromString because we pass sdp cand…

### DIFF
--- a/src/source/Ice/IceUtils.c
+++ b/src/source/Ice/IceUtils.c
@@ -179,8 +179,7 @@ STATUS populateIpFromString(PKvsIpAddress pKvsIpAddress, PCHAR pBuff)
     UINT32 ipValue;
 
     CHK(pKvsIpAddress != NULL && pBuff != NULL, STATUS_NULL_ARG);
-    CHK(STRNLEN(pBuff, KVS_MAX_IPV4_ADDRESS_STRING_LEN) > 0 &&
-        STRNLEN(pBuff, KVS_MAX_IPV4_ADDRESS_STRING_LEN) < KVS_MAX_IPV4_ADDRESS_STRING_LEN, STATUS_INVALID_ARG);
+    CHK(STRNLEN(pBuff, KVS_MAX_IPV4_ADDRESS_STRING_LEN) > 0, STATUS_INVALID_ARG);
 
     curr = pBuff;
     tail = pBuff + STRLEN(pBuff);
@@ -192,10 +191,12 @@ STATUS populateIpFromString(PKvsIpAddress pKvsIpAddress, PCHAR pBuff)
         curr = next + 1;
     }
 
-    CHK_STATUS(STRTOUI32(curr, NULL, 10, &ipValue));
-    pKvsIpAddress->address[octet] = (UINT8) ipValue;
-    octet++;
-
+    // work with string containing just ip address and string that has ip address as substring
+    if ((next = STRNCHR(curr, tail - curr, ' ')) != NULL || (next = STRNCHR(curr, tail - curr, '\0')) != NULL) {
+        CHK_STATUS(STRTOUI32(curr, curr + (next - curr), 10, &ipValue));
+        pKvsIpAddress->address[octet] = (UINT8) ipValue;
+        octet++;
+    }
 
     CHK(octet == 4, STATUS_ICE_CANDIDATE_STRING_INVALID_IP); // IPv4 MUST have 4 octets
 CleanUp:


### PR DESCRIPTION
…idate strings directly to populateIpFromString

*Issue #, if available:*

*Description of changes:*

if the max len check is not removed, we cant add any candidates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
