### PR TITLE
Decouple rtp rolling buffer logic from rolling buffer

### DIFF
--- a/src/source/PeerConnection/Retransimitter.c
+++ b/src/source/PeerConnection/Retransimitter.c
@@ -83,9 +83,9 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
     validIndexListLen = pRetransmitter->validIndexListLen;
     CHK_STATUS(rtpRollingBufferGetValidSeqIndexList(pSenderTranceiver->sender.packetBuffer,
                                                     pRetransmitter->sequenceNumberList,
-                                                    &filledLen, pRetransmitter->validIndexList, &validIndexListLen));
+                                                    filledLen, pRetransmitter->validIndexList, &validIndexListLen));
     for (index = 0; index < validIndexListLen; index++) {
-        retStatus = rollingBufferExtractData(pSenderTranceiver->sender.packetBuffer, pRetransmitter->validIndexList[index], &item);
+        retStatus = rollingBufferExtractData(pSenderTranceiver->sender.packetBuffer->pRollingBuffer, pRetransmitter->validIndexList[index], &item);
         pRtpPacket = (PRtpPacket) item;
         CHK(retStatus == STATUS_SUCCESS, retStatus);
 
@@ -103,7 +103,7 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
                         pRtpPacket->header.sequenceNumber, pRtxRtpPacket->header.sequenceNumber, retStatus);
             }
             // putBackPacketToRollingBuffer
-            retStatus = rollingBufferInsertData(pSenderTranceiver->sender.packetBuffer, pRetransmitter->sequenceNumberList[index], item);
+            retStatus = rollingBufferInsertData(pSenderTranceiver->sender.packetBuffer->pRollingBuffer, pRetransmitter->sequenceNumberList[index], item);
             CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_ROLLING_BUFFER_NOT_IN_RANGE, retStatus);
 
             // free the packet if it is not in the valid range any more

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -176,7 +176,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     CHK_STATUS(rtpPayloadFunc(DEFAULT_MTU_SIZE, (PBYTE) pFrame->frameData, pFrame->size, pPayloadArray->payloadBuffer, &(pPayloadArray->payloadLength), pPayloadArray->payloadSubLength, &(pPayloadArray->payloadSubLenSize)));
     pPacketList = (PRtpPacket) MEMALLOC(pPayloadArray->payloadSubLenSize * SIZEOF(RtpPacket));
     CHK_STATUS(constructRtpPackets(pPayloadArray, pKvsRtpTransceiver->sender.payloadType, pKvsRtpTransceiver->sender.sequenceNumber, rtpTimestamp, pKvsRtpTransceiver->sender.ssrc, pPacketList, pPayloadArray->payloadSubLenSize));
-    pKvsRtpTransceiver->sender.sequenceNumber = (pKvsRtpTransceiver->sender.sequenceNumber + pPayloadArray->payloadSubLenSize) % MAX_UINT16;
+    pKvsRtpTransceiver->sender.sequenceNumber = GET_UINT16_SEQ_NUM(pKvsRtpTransceiver->sender.sequenceNumber + pPayloadArray->payloadSubLenSize);
 
     for (i = 0; i < pPayloadArray->payloadSubLenSize; i++) {
         pRtpPacket = pPacketList + i;

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -27,7 +27,7 @@ typedef struct {
     PayloadArray payloadArray;
 
     RtcMediaStreamTrack track;
-    PRollingBuffer packetBuffer;
+    PRtpRollingBuffer packetBuffer;
     PRetransmitter retransmitter;
 } RtcRtpSender, *PRtcRtpSender;
 

--- a/src/source/Rtcp/RollingBuffer.h
+++ b/src/source/Rtcp/RollingBuffer.h
@@ -34,10 +34,11 @@ typedef struct {
 
 STATUS createRollingBuffer(UINT32, FreeDataFunc, PRollingBuffer*);
 STATUS freeRollingBuffer(PRollingBuffer*);
-STATUS rollingBufferAppendData(PRollingBuffer, UINT64);
+STATUS rollingBufferAppendData(PRollingBuffer, UINT64, PUINT64);
 STATUS rollingBufferInsertData(PRollingBuffer, UINT64, UINT64);
 STATUS rollingBufferExtractData(PRollingBuffer, UINT64, PUINT64);
-UINT32 rollingBufferMapIndex(PRollingBuffer, UINT64);
+STATUS rollingBufferGetSize(PRollingBuffer, PUINT32);
+STATUS rollingBufferIsEmpty(PRollingBuffer, PBOOL);
 
 #pragma pack(pop, include_i)
 

--- a/src/source/Rtcp/RtpRollingBuffer.h
+++ b/src/source/Rtcp/RtpRollingBuffer.h
@@ -10,11 +10,22 @@ RTCP Rolling Buffer include file
 extern "C" {
 #endif
 
-STATUS createRtpRollingBuffer(UINT32, PRollingBuffer*);
-STATUS freeRtpRollingBuffer(PRollingBuffer*);
+// For tight packing
+#pragma pack(push, include_i, 1) // for byte alignment
+
+typedef struct {
+    PRollingBuffer pRollingBuffer;
+    // index of last rtp packet in rolling buffer
+    UINT64 lastIndex;
+} RtpRollingBuffer, *PRtpRollingBuffer;
+
+STATUS createRtpRollingBuffer(UINT32, PRtpRollingBuffer*);
+STATUS freeRtpRollingBuffer(PRtpRollingBuffer*);
 STATUS freeRtpRollingBufferData(PUINT64);
-STATUS rtpRollingBufferAddRtpPacket(PRollingBuffer pRollingBuffer, PRtpPacket pRtpPacket);
-STATUS rtpRollingBufferGetValidSeqIndexList(PRollingBuffer pRollingBuffer, PUINT16 pSequenceNumberList, PUINT32 pSequenceNumberListLen, PUINT64 pValidSeqIndexList, PUINT32 pValidIndexListLen);
+STATUS rtpRollingBufferAddRtpPacket(PRtpRollingBuffer, PRtpPacket);
+STATUS rtpRollingBufferGetValidSeqIndexList(PRtpRollingBuffer, PUINT16, UINT32, PUINT64, PUINT32);
+
+#pragma pack(pop, include_i)
 
 #ifdef  __cplusplus
 

--- a/src/source/Rtp/RtpPacket.c
+++ b/src/source/Rtp/RtpPacket.c
@@ -346,7 +346,7 @@ STATUS constructRtpPackets(PPayloadArray pPayloadArray, UINT8 payloadType, UINT1
                         payloadType, sequenceNumber, timestamp, ssrc, NULL,
                         0, 0, NULL, curPtrInPayload, *curPtrInPayloadSubLen, pPackets + i));
 
-        sequenceNumber = (sequenceNumber + 1) % MAX_UINT16;
+        sequenceNumber = GET_UINT16_SEQ_NUM(sequenceNumber + 1);
 
         curPtrInPayload += *curPtrInPayloadSubLen;
     }

--- a/src/source/Rtp/RtpPacket.h
+++ b/src/source/Rtp/RtpPacket.h
@@ -101,6 +101,8 @@ STATUS createBytesFromRtpPacket(PRtpPacket, PBYTE*, PUINT32);
 STATUS setBytesFromRtpPacket(PRtpPacket, PBYTE, UINT32);
 STATUS constructRtpPackets(PPayloadArray, UINT8, UINT16, UINT32, UINT32, PRtpPacket, UINT32);
 
+#define GET_UINT16_SEQ_NUM(seqIndex) ((UINT16) ((seqIndex) % (MAX_UINT16 + 1)))
+
 #pragma pack(pop, include_i)
 
 #ifdef  __cplusplus

--- a/tst/RollingBufferFunctionalityTest.cpp
+++ b/tst/RollingBufferFunctionalityTest.cpp
@@ -17,28 +17,33 @@ TEST_F(RollingBufferFunctionalityTest, appendDataToBufferAndVerify)
 {
     PRollingBuffer pRollingBuffer;
     UINT64 first = (UINT64) 1, second = (UINT64) 2, third = (UINT64) 3, fourth = (UINT64) 4;
+    UINT64 index;
     EXPECT_EQ(STATUS_SUCCESS, createRollingBuffer(2, RollingBufferFunctionalityTestFreeBufferFunc, &pRollingBuffer));
     EXPECT_EQ(0, pRollingBuffer->headIndex);
     EXPECT_EQ(0, pRollingBuffer->tailIndex);
-    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, first));
+    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, first, &index));
     EXPECT_EQ(1, pRollingBuffer->headIndex);
     EXPECT_EQ(0, pRollingBuffer->tailIndex);
     EXPECT_EQ(first, pRollingBuffer->dataBuffer[0]);
-    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, second));
+    EXPECT_EQ(0, index);
+    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, second, &index));
     EXPECT_EQ(2, pRollingBuffer->headIndex);
     EXPECT_EQ(0, pRollingBuffer->tailIndex);
     EXPECT_EQ(first, pRollingBuffer->dataBuffer[0]);
     EXPECT_EQ(second, pRollingBuffer->dataBuffer[1]);
-    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, third));
+    EXPECT_EQ(1, index);
+    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, third, &index));
     EXPECT_EQ(3, pRollingBuffer->headIndex);
     EXPECT_EQ(1, pRollingBuffer->tailIndex);
     EXPECT_EQ(third, pRollingBuffer->dataBuffer[0]);
     EXPECT_EQ(second, pRollingBuffer->dataBuffer[1]);
-    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, fourth));
+    EXPECT_EQ(2, index);
+    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, fourth, &index));
     EXPECT_EQ(4, pRollingBuffer->headIndex);
     EXPECT_EQ(2, pRollingBuffer->tailIndex);
     EXPECT_EQ(third, pRollingBuffer->dataBuffer[0]);
     EXPECT_EQ(fourth, pRollingBuffer->dataBuffer[1]);
+    EXPECT_EQ(3, index);
     EXPECT_EQ(STATUS_SUCCESS, freeRollingBuffer(&pRollingBuffer));
 }
 
@@ -77,11 +82,12 @@ TEST_F(RollingBufferFunctionalityTest, extractDataFromBufferAndInsertBack)
     PRollingBuffer pRollingBuffer;
     UINT64 first = (UINT64) 1, second = (UINT64) 2, third = (UINT64) 3, fourth = (UINT64) 4;
     UINT64 data;
+    UINT64 index;
     EXPECT_EQ(STATUS_SUCCESS, createRollingBuffer(3, RollingBufferFunctionalityTestFreeBufferFunc, &pRollingBuffer));
-    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, first));
-    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, second));
-    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, third));
-    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, fourth));
+    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, first, &index));
+    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, second, &index));
+    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, third, &index));
+    EXPECT_EQ(STATUS_SUCCESS, rollingBufferAppendData(pRollingBuffer, fourth, &index));
 
     EXPECT_EQ(4, pRollingBuffer->headIndex);
     EXPECT_EQ(1, pRollingBuffer->tailIndex);

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -168,7 +168,7 @@ TEST_F(RtpFunctionalityTest, marshallUnmarshallH264Data)
                             pPacketList,
                             payloadArray.payloadSubLenSize);
 
-        seqNum = (UINT16) ((seqNum + payloadArray.payloadSubLenSize) % MAX_UINT16);
+        seqNum = GET_UINT16_SEQ_NUM(seqNum + payloadArray.payloadSubLenSize);
 
         for (i = 0; i < payloadArray.payloadSubLenSize; i++)
         {

--- a/tst/RtpRollingBufferFunctionalityTest.cpp
+++ b/tst/RtpRollingBufferFunctionalityTest.cpp
@@ -1,0 +1,172 @@
+#include "WebRTCClientTestFixture.h"
+
+namespace com { namespace amazonaws { namespace kinesis { namespace video { namespace webrtcclient {
+
+class RtpRollingBufferFunctionalityTest : public WebRtcClientTestBase {
+};
+
+STATUS createRtpPacketWithSeqNum(UINT16 seqNum, PRtpPacket *ppRtpPacket) {
+    STATUS retStatus = STATUS_SUCCESS;
+    PBYTE payload = NULL;
+
+    payload = (PBYTE) MEMALLOC(10);
+    CHK_STATUS(createRtpPacket(2, FALSE, FALSE, 0, FALSE,
+            96, seqNum, 100, 0x1234ABCD, NULL, 0, 0, NULL, payload, 10, ppRtpPacket));
+    CHK_STATUS(createBytesFromRtpPacket(*ppRtpPacket, &(*ppRtpPacket)->pRawPacket, &(*ppRtpPacket)->rawPacketLength));
+    SAFE_MEMFREE(payload);
+CleanUp:
+    return retStatus;
+}
+
+VOID updateRtpPacketSeqNum(PRtpPacket pRtpPacket, UINT16 seqNum) {
+    pRtpPacket->header.sequenceNumber = seqNum;
+}
+
+VOID pushConsecutiveRtpPacketsIntoBuffer(UINT32 packetCount, UINT32 bufferCapacity, PRtpRollingBuffer *ppRtpRollingBuffer, PRtpPacket *ppRtpPacket) {
+    PRtpPacket pRtpPacket;
+    PRtpRollingBuffer pRtpRollingBuffer;
+    UINT32 i;
+
+    EXPECT_EQ(STATUS_SUCCESS, createRtpRollingBuffer(bufferCapacity, &pRtpRollingBuffer));
+
+    EXPECT_EQ(STATUS_SUCCESS, createRtpPacketWithSeqNum(0, &pRtpPacket));
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferAddRtpPacket(pRtpRollingBuffer, pRtpPacket));
+    for (i = 1; i < packetCount; i++) {
+        updateRtpPacketSeqNum(pRtpPacket, GET_UINT16_SEQ_NUM(i));
+        EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferAddRtpPacket(pRtpRollingBuffer, pRtpPacket));
+    }
+
+    *ppRtpPacket = pRtpPacket;
+    *ppRtpRollingBuffer = pRtpRollingBuffer;
+}
+
+TEST_F(RtpRollingBufferFunctionalityTest, appendDataToBufferAndVerify)
+{
+    PRtpRollingBuffer pRtpRollingBuffer;
+    PRtpPacket pRtpPacket;
+
+    EXPECT_EQ(STATUS_SUCCESS, createRtpRollingBuffer(2, &pRtpRollingBuffer));
+
+    EXPECT_EQ(STATUS_SUCCESS, createRtpPacketWithSeqNum(0, &pRtpPacket));
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferAddRtpPacket(pRtpRollingBuffer, pRtpPacket));
+    EXPECT_EQ(0, pRtpRollingBuffer->lastIndex);
+    updateRtpPacketSeqNum(pRtpPacket, 1);
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferAddRtpPacket(pRtpRollingBuffer, pRtpPacket));
+    EXPECT_EQ(1, pRtpRollingBuffer->lastIndex);
+    updateRtpPacketSeqNum(pRtpPacket, 2);
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferAddRtpPacket(pRtpRollingBuffer, pRtpPacket));
+    EXPECT_EQ(2, pRtpRollingBuffer->lastIndex);
+    updateRtpPacketSeqNum(pRtpPacket, 3);
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferAddRtpPacket(pRtpRollingBuffer, pRtpPacket));
+    EXPECT_EQ(3, pRtpRollingBuffer->lastIndex);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+}
+
+TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnEmptyList)
+{
+    PRtpRollingBuffer pRtpRollingBuffer;
+    PRtpPacket pRtpPacket = NULL;
+    UINT16 seqList[] = {0, 1, 2, 6, 7, 8, 10000, 65535};
+    UINT32 seqListLen = ARRAY_SIZE(seqList);
+    PUINT64 indexList = (PUINT64) MEMALLOC(SIZEOF(UINT64) * seqListLen);
+    UINT32 filledIndexListLen = seqListLen;
+
+    // add 0 1 2 3 4 5, capacity is 3, 0 1 2 are out of rolling buffer, 3 4 5 are in
+    pushConsecutiveRtpPacketsIntoBuffer(6, 3, &pRtpRollingBuffer, &pRtpPacket);
+
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferGetValidSeqIndexList(pRtpRollingBuffer, seqList, seqListLen, indexList, &filledIndexListLen));
+    EXPECT_EQ(0, filledIndexListLen);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
+    SAFE_MEMFREE(indexList);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+}
+
+TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnCorrectIndexs)
+{
+    PRtpRollingBuffer pRtpRollingBuffer;
+    PRtpPacket pRtpPacket = NULL;
+    UINT16 seqList[] = {0, 1, 2, 4, 5, 6, 7, 8, 10000, 65535};
+    UINT32 seqListLen = ARRAY_SIZE(seqList);
+    PUINT64 indexList = (PUINT64) MEMALLOC(SIZEOF(UINT64) * seqListLen);
+    UINT32 filledIndexListLen = seqListLen;
+
+    // add 0 1 2 3 4 5, capacity is 3, 0 1 2 are out of rolling buffer, 3 4 5 are in
+    pushConsecutiveRtpPacketsIntoBuffer(6, 3, &pRtpRollingBuffer, &pRtpPacket);
+
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferGetValidSeqIndexList(pRtpRollingBuffer, seqList, seqListLen, indexList, &filledIndexListLen));
+    EXPECT_EQ(2, filledIndexListLen);
+    EXPECT_EQ(4, indexList[0]);
+    EXPECT_EQ(5, indexList[1]);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
+    SAFE_MEMFREE(indexList);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+}
+
+TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnIndexsFitIntoSmallBuffer)
+{
+    PRtpRollingBuffer pRtpRollingBuffer;
+    PRtpPacket pRtpPacket = NULL;
+    UINT16 seqList[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 10000, 65535};
+    UINT32 seqListLen = ARRAY_SIZE(seqList);
+    PUINT64 indexList = (PUINT64) MEMALLOC(SIZEOF(UINT64) * 2);
+    UINT32 filledIndexListLen = 2;
+
+    // add 0 1 2 3 4 5, capacity is 3, 0 1 2 are out of rolling buffer, 3 4 5 are in
+    pushConsecutiveRtpPacketsIntoBuffer(6, 3, &pRtpRollingBuffer, &pRtpPacket);
+
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferGetValidSeqIndexList(pRtpRollingBuffer, seqList, seqListLen, indexList, &filledIndexListLen));
+    EXPECT_EQ(2, filledIndexListLen);
+    EXPECT_EQ(3, indexList[0]);
+    EXPECT_EQ(4, indexList[1]);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
+    SAFE_MEMFREE(indexList);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+}
+
+TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnCorrectIndexsWhenSeqNumGetOver65535)
+{
+    PRtpRollingBuffer pRtpRollingBuffer;
+    PRtpPacket pRtpPacket = NULL;
+    UINT16 seqList[] = {0, 1, 2, 3, 4, 5, 65532, 65533, 65534, 65535};
+    UINT32 seqListLen = ARRAY_SIZE(seqList);
+    PUINT64 indexList = (PUINT64) MEMALLOC(SIZEOF(UINT64) * 5);
+    UINT32 filledIndexListLen = 5;
+
+    // add 0 - 65538, capacity is 5, 65534 65535 0(65536) 1(65537) 2(65538) are in rolling buffer
+    pushConsecutiveRtpPacketsIntoBuffer(65539, 5, &pRtpRollingBuffer, &pRtpPacket);
+
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferGetValidSeqIndexList(pRtpRollingBuffer, seqList, seqListLen, indexList, &filledIndexListLen));
+    EXPECT_EQ(5, filledIndexListLen);
+    EXPECT_EQ(65536, indexList[0]);
+    EXPECT_EQ(65537, indexList[1]);
+    EXPECT_EQ(65538, indexList[2]);
+    EXPECT_EQ(65534, indexList[3]);
+    EXPECT_EQ(65535, indexList[4]);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
+    SAFE_MEMFREE(indexList);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+
+    indexList = (PUINT64) MEMALLOC(SIZEOF(UINT64) * 5);
+    // add 0 - 131074(65538 + 65536), capacity is 5, 65534(131070) 65335(131071) 0(131072) 1(131073) 2(131074) are in rolling buffer
+    pushConsecutiveRtpPacketsIntoBuffer(131075, 5, &pRtpRollingBuffer, &pRtpPacket);
+
+    EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferGetValidSeqIndexList(pRtpRollingBuffer, seqList, seqListLen, indexList, &filledIndexListLen));
+    EXPECT_EQ(5, filledIndexListLen);
+    EXPECT_EQ(131072, indexList[0]);
+    EXPECT_EQ(131073, indexList[1]);
+    EXPECT_EQ(131074, indexList[2]);
+    EXPECT_EQ(131070, indexList[3]);
+    EXPECT_EQ(131071, indexList[4]);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
+    SAFE_MEMFREE(indexList);
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+}
+
+
+}
+}
+}
+}
+}
+

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -192,7 +192,7 @@ TEST_F(SdpApiTest, setTransceiverPayloadTypes_NoRtxType) {
     EXPECT_EQ(STATUS_SUCCESS, doubleListInsertItemHead(pTransceivers, (UINT64) (&transceiver)));
     EXPECT_EQ(STATUS_SUCCESS, setTransceiverPayloadTypes(pCodecTable, pRtxTable, pTransceivers));
     EXPECT_EQ(1, transceiver.sender.payloadType);
-    EXPECT_EQ((PRollingBuffer) NULL, transceiver.sender.packetBuffer);
+    EXPECT_EQ((PRtpRollingBuffer) NULL, transceiver.sender.packetBuffer);
     EXPECT_EQ((PRetransmitter) NULL, transceiver.sender.retransmitter);
     hashTableFree(pCodecTable);
     hashTableFree(pRtxTable);
@@ -219,7 +219,7 @@ TEST_F(SdpApiTest, setTransceiverPayloadTypes_HasRtxType) {
     EXPECT_EQ(STATUS_SUCCESS, setTransceiverPayloadTypes(pCodecTable, pRtxTable, pTransceivers));
     EXPECT_EQ(1, transceiver.sender.payloadType);
     EXPECT_EQ(2, transceiver.sender.rtxPayloadType);
-    EXPECT_NE((PRollingBuffer) NULL, transceiver.sender.packetBuffer);
+    EXPECT_NE((PRtpRollingBuffer) NULL, transceiver.sender.packetBuffer);
     EXPECT_NE((PRetransmitter) NULL, transceiver.sender.retransmitter);
     hashTableFree(pCodecTable);
     hashTableFree(pRtxTable);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Previous impl of RTP rolling buffer rely on the header index and tail index impl of rolling buffer. Refactor to decouple two implementations. 
1. Add last index to track which index to look at for the rtp rolling buffer.
2. Bug fix of  sequence number % MAX_UINT16 which results in sequence number lands in a range of [0..65534]. 
3. Add unit test for rtp rolling buffer and fix other tests due to refactoring.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
