### PR TITLE
fix sctp lifecycle handling

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -130,7 +130,6 @@ STATUS handleOffer(PSampleConfiguration pSampleConfiguration, PSignalingMessage 
              "Dropping offer as peerConnection already received offer");
 
     RtcSessionDescriptionInit offerSessionDescriptionInit;
-    PBYTE rawOfferSessionDescriptionInit = NULL;
 
     MEMSET(&offerSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
     MEMSET(&pSampleConfiguration->answerSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
@@ -181,7 +180,6 @@ STATUS handleOffer(PSampleConfiguration pSampleConfiguration, PSignalingMessage 
 CleanUp:
 
     CHK_LOG_ERR(retStatus);
-    SAFE_MEMFREE(rawOfferSessionDescriptionInit);
 
     if (locked) {
         MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
@@ -423,6 +421,8 @@ STATUS freeSampleConfiguration(PSampleConfiguration* ppSampleConfiguration)
     pSampleConfiguration = *ppSampleConfiguration;
 
     CHK(pSampleConfiguration != NULL, retStatus);
+
+    deinitKvsWebRtc();
 
     SAFE_MEMFREE(pSampleConfiguration->pVideoFrameBuffer);
     SAFE_MEMFREE(pSampleConfiguration->pAudioFrameBuffer);

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1175,6 +1175,13 @@ PUBLIC_API STATUS freeTransceiver(PRtcRtpTransceiver*);
 PUBLIC_API STATUS initKvsWebRtc(VOID);
 
 /*
+ * deinitKvsWebRtc deinitializes global state needed for all RtcPeerConnection's it must only be called once
+ *
+ * @return - STATUS code of the execution
+ */
+PUBLIC_API STATUS deinitKvsWebRtc(VOID);
+
+/*
  * addSupportedCodec adds to the list of codecs we support receiving. The remote MUST only send codecs we declare
  *
  * @param - RTC_CODEC - IN - Codec that we support receiving.

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -866,10 +866,20 @@ STATUS initKvsWebRtc(VOID)
     // SSL_library_init() always returns "1", so it is safe to discard the return value.
     UNUSED_PARAM(SSL_library_init());
 
-    usrsctp_init(0, &onSctpOutboundPacket, NULL);
+    CHK_STATUS(initSctpSession());
+CleanUp:
 
-    // Disable Explicit Congestion Notification
-    usrsctp_sysctl_set_sctp_ecn_enable(0);
+    LEAVES();
+    return retStatus;
+
+}
+
+STATUS deinitKvsWebRtc(VOID)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    deinitSctpSession();
 
 CleanUp:
 

--- a/src/source/Sctp/Sctp.h
+++ b/src/source/Sctp/Sctp.h
@@ -56,6 +56,8 @@ typedef struct {
     SctpSessionCallbacks sctpSessionCallbacks;
 } SctpSession, *PSctpSession;
 
+STATUS initSctpSession();
+VOID deinitSctpSession();
 STATUS createSctpSession(PSctpSessionCallbacks, PSctpSession*);
 STATUS freeSctpSession(PSctpSession*);
 STATUS putSctpPacket(PSctpSession, PBYTE, UINT32);


### PR DESCRIPTION
*Issue #, if available:*
#56 
*Description of changes:*
Properly manage sctp life cycle. Now multiple peerConnection with sctp should work. And sctp is shutdown when its parent peerConnection is freed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
