### PR TITLE
Enable compiler warnings when building tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
 - directories:
   - $HOME/.cache
 
-before_script:
-  - mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
 
 script:
   - make
@@ -25,9 +23,13 @@ matrix:
     - name: "OSX GCC"
       os: osx
       compiler: gcc
+      before_script:
+        - mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE
     - name: "OSX Clang"
       os: osx
       compiler: clang
+      before_script:
+        - mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
 
     # Code Coverage
     - name: "Linux GCC Code Coverage"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,8 +432,8 @@ target_link_libraries(kvsWebrtcClientViewer kvsWebrtcClient
                       kvsWebrtcSignalingClient)
 
 if(COMPILER_WARNINGS)
-  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -pedantic -Wextra)
-  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -pedantic -Wextra)
+  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)
 endif()
 
 if(GST_FOUND)

--- a/src/source/Dtls/Dtls.c
+++ b/src/source/Dtls/Dtls.c
@@ -37,11 +37,13 @@ STATUS dtlsTransmissionTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 
     STATUS retStatus = STATUS_SUCCESS;
     PDtlsSession pDtlsSession = (PDtlsSession) customData;
     BOOL locked = FALSE;
-    struct timeval timeout = {0};
+    struct timeval timeout;
     UINT64 timeoutValDefaultTimeUnit = 0;
     LONG dtlsTimeoutRet = 0;
 
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+
+    MEMSET(&timeout, 0x00, SIZEOF(struct timeval));
 
     MUTEX_LOCK(pDtlsSession->sslLock);
     locked = TRUE;

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -296,10 +296,12 @@ STATUS iceAgentAddRemoteCandidate(PIceAgent pIceAgent, PCHAR pIceCandidateString
     PCHAR curr, tail, next;
     UINT32 tokenLen, portValue, remoteCandidateCount;
     BOOL foundIpAndPort = FALSE, freeIceCandidateIfFail = TRUE;
-    KvsIpAddress candidateIpAddr = {0};
+    KvsIpAddress candidateIpAddr;
 
     CHK(pIceAgent != NULL && pIceCandidateString != NULL, STATUS_NULL_ARG);
     CHK(!IS_EMPTY_STRING(pIceCandidateString), STATUS_INVALID_ARG);
+
+    MEMSET(&candidateIpAddr, 0x00, SIZEOF(KvsIpAddress));
 
     MUTEX_LOCK(pIceAgent->lock);
     locked = TRUE;

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -79,7 +79,7 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSessi
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PSctpSession pSctpSession = NULL;
-    struct sockaddr_conn localConn = {0}, remoteConn = {0};
+    struct sockaddr_conn localConn, remoteConn;
     struct sctp_paddrparams params;
     INT32 connectStatus = 0;
 
@@ -87,6 +87,10 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSessi
 
     pSctpSession = (PSctpSession) MEMALLOC(SIZEOF(SctpSession));
     CHK(pSctpSession != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    MEMSET(&params, 0x00, SIZEOF(struct sctp_paddrparams));
+    MEMSET(&localConn, 0x00, SIZEOF(struct sockaddr_conn));
+    MEMSET(&remoteConn, 0x00, SIZEOF(struct sockaddr_conn));
 
     pSctpSession->sctpSessionCallbacks = *pSctpSessionCallbacks;
 
@@ -102,7 +106,6 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSessi
     connectStatus = usrsctp_connect(pSctpSession->socket, (struct sockaddr*) &remoteConn, SIZEOF(remoteConn));
     CHK(connectStatus >= 0 || errno == EINPROGRESS, STATUS_SCTP_SESSION_SETUP_FAILED);
 
-    MEMSET(&params, 0x00, SIZEOF(struct sctp_paddrparams));
     memcpy(&params.spp_address, &remoteConn, SIZEOF(remoteConn));
     params.spp_flags = SPP_PMTUD_DISABLE;
     params.spp_pathmtu = SCTP_MTU;
@@ -150,9 +153,11 @@ STATUS sctpSessionWriteMessage(PSctpSession pSctpSession, UINT32 streamId, BOOL 
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    struct sctp_sendv_spa spa = {0};
+    struct sctp_sendv_spa spa;
 
     CHK(pSctpSession != NULL && pMessage != NULL, STATUS_NULL_ARG);
+
+    MEMSET(&spa, 0x00, SIZEOF(struct sctp_sendv_spa));
     spa.sendv_flags |= SCTP_SEND_SNDINFO_VALID;
     spa.sendv_sndinfo.snd_sid = streamId;
 

--- a/tst/IceApiTest.cpp
+++ b/tst/IceApiTest.cpp
@@ -8,7 +8,9 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
     TEST_F(IceApiTest, ConnectionListenerApiTest)
     {
         PConnectionListener pConnectionListener = NULL;
-        SocketConnection dummySocketConnection = {0};
+        SocketConnection dummySocketConnection;
+
+        MEMSET(&dummySocketConnection, 0x0, SIZEOF(SocketConnection));
 
         EXPECT_NE(STATUS_SUCCESS, createConnectionListener(NULL));
         EXPECT_NE(STATUS_SUCCESS, freeConnectionListener(NULL));
@@ -35,9 +37,13 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
         BYTE testBuffer[1000], testPassword[30];
         UINT32 testBufferLen = ARRAY_SIZE(testBuffer), testPasswordLen = ARRAY_SIZE(testPassword);
         PStunPacket pStunPacket;
-        KvsIpAddress testIpAddr = {0};
-        SocketConnection testSocketConn = {0};
-        TurnConnection testTurnConn = {0};
+        KvsIpAddress testIpAddr;
+        SocketConnection testSocketConn;
+        TurnConnection testTurnConn;
+
+        MEMSET(&testIpAddr, 0x0, SIZEOF(KvsIpAddress));
+        MEMSET(&testSocketConn, 0x0, SIZEOF(SocketConnection));
+        MEMSET(&testTurnConn, 0x0, SIZEOF(TurnConnection));
 
         EXPECT_NE(STATUS_SUCCESS, createTransactionIdStore(20, NULL));
         EXPECT_NE(STATUS_SUCCESS, createTransactionIdStore(0, &pTransactionIdStore));
@@ -73,12 +79,14 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
 
     TEST_F(IceApiTest, IceUtilPopulateIpFromStringTest)
     {
-        KvsIpAddress kvsIpAddress = {0};
+        KvsIpAddress kvsIpAddress;
         PCHAR ipString = (PCHAR) "16.213.65.123";
         BYTE expectIpAddr[IPV4_ADDRESS_LENGTH] = {0x10, 0xD5, 0x41, 0x7B};
         PCHAR ipString2 = (PCHAR) "255.255.255.255";
         PCHAR ipString2Longer = (PCHAR) "255.255.255.255 34388 222.222.222.222";
         BYTE expectIpAddr2[IPV4_ADDRESS_LENGTH] = {0xFF, 0xFF, 0xFF, 0xFF};
+
+        MEMSET(&kvsIpAddress, 0x0, SIZEOF(KvsIpAddress));
 
         EXPECT_NE(STATUS_SUCCESS, populateIpFromString(NULL, NULL));
         EXPECT_NE(STATUS_SUCCESS, populateIpFromString(&kvsIpAddress, NULL));

--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -98,7 +98,9 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
         UINT32 i;
         UINT64 randomDelay;
         PSocketConnection pSocketConnection = NULL;
-        KvsIpAddress localhost = {0};
+        KvsIpAddress localhost;
+
+        MEMSET(&localhost, 0x00, SIZEOF(KvsIpAddress));
 
         localhost.family = KVS_IP_FAMILY_TYPE_IPV4;
         localhost.isPointToPoint = FALSE;
@@ -122,13 +124,16 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
     TEST_F(IceFunctionalityTest, connectionListenerFunctionalityTest)
     {
         PConnectionListener pConnectionListener;
-        ConnectionListenerTestCustomData routine1CustomData = {0};
-        ConnectionListenerTestCustomData routine2CustomData = {0};
+        ConnectionListenerTestCustomData routine1CustomData, routine2CustomData;
         TID routine1, routine2;
         UINT32 connectionCount = 0, newConnectionCount = 0;
         PSocketConnection pSocketConnection = NULL;
-        KvsIpAddress localhost = {0};
+        KvsIpAddress localhost;
         PDoubleListNode pCurNode;
+
+        MEMSET(&routine1CustomData, 0x0, SIZEOF(ConnectionListenerTestCustomData));
+        MEMSET(&routine2CustomData, 0x0, SIZEOF(ConnectionListenerTestCustomData));
+        MEMSET(&localhost, 0x0, SIZEOF(KvsIpAddress));
 
         localhost.family = KVS_IP_FAMILY_TYPE_IPV4;
         localhost.isPointToPoint = FALSE;
@@ -207,7 +212,9 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
     TEST_F(IceFunctionalityTest, IceAgentUpdateCandidateAddressUnitTest)
     {
         IceCandidate localCandidate;
-        KvsIpAddress newIpAddress = {0};
+        KvsIpAddress newIpAddress;
+
+        MEMSET(&newIpAddress, 0x0, SIZEOF(KvsIpAddress));
 
         newIpAddress.port = 8080;
         newIpAddress.family = KVS_IP_FAMILY_TYPE_IPV4;

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -8,7 +8,6 @@ class RtcpFunctionalityTest : public WebRtcClientTestBase {
 TEST_F(RtcpFunctionalityTest, setRtpPacketFromBytes)
 {
     RtcpPacket rtcpPacket;
-    STATUS retStatus = STATUS_SUCCESS;
 
     MEMSET(&rtcpPacket, 0x00, SIZEOF(RtcpPacket));
 

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -4,7 +4,7 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
 
 #define NUMBER_OF_FRAME_FILES               403
 #define DEFAULT_FPS_VALUE                   25
-static BYTE start4ByteCode[] = {0x00, 0x00, 0x00, 0x01};
+BYTE start4ByteCode[] = {0x00, 0x00, 0x00, 0x01};
 
 class RtpFunctionalityTest : public WebRtcClientTestBase {
 };
@@ -54,7 +54,6 @@ TEST_F(RtpFunctionalityTest, marshallUnmarshallGettingSameData)
     PBYTE rawPacket = NULL;
     UINT32 packetLen = 0;
     UINT32 i = 0;
-    INT32 status = 0;
 
     payloadArray.payloadBuffer = payload;
     payloadArray.payloadLength = payloadLen;
@@ -96,12 +95,9 @@ TEST_F(RtpFunctionalityTest, marshallUnmarshallH264Data)
     PRtpPacket pPacketList = NULL;
     PRtpPacket pRtpPacket = NULL;
     PBYTE rawPacket = NULL;
-    PRtpPacket pNewRtpPacket = NULL;
     UINT32 packetLen = 0;
-    INT32 status = 0;
     UINT64 curTime = GETTIME();
     UINT32 fileIndex = 0;
-    UINT32 clockRate = 90000; // 90kHz for h264
     UINT16 seqNum = 0;
     UINT64 startTimeStamp = curTime;
     UINT32 i = 0;

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -43,8 +43,7 @@ STATUS masterMessageReceived(UINT64 customData, PReceivedSignalingMessage pRecei
 
 STATUS signalingClientStateChanged(UINT64 customData, SIGNALING_CLIENT_STATE state)
 {
-    SignalingApiFunctionalityTest *pTest = (SignalingApiFunctionalityTest*) customData;
-
+    UNUSED_PARAM(customData);
     DLOGV("Signaling client state changed to %d", state);
 
     return STATUS_SUCCESS;
@@ -52,8 +51,7 @@ STATUS signalingClientStateChanged(UINT64 customData, SIGNALING_CLIENT_STATE sta
 
 STATUS viewerMessageReceived(UINT64 customData, PReceivedSignalingMessage pReceivedSignalingMessage)
 {
-    SignalingApiFunctionalityTest *pTest = (SignalingApiFunctionalityTest*) customData;
-    STATUS status;
+    UNUSED_PARAM(customData);
 
     DLOGI("Message received:\ntype: %u\npeer client id: %s\npayload len: %u\npayload: %s\nCorrelationId: %s\nErrorType: %s\nStatusCode: %u\nDescription: %s",
           pReceivedSignalingMessage->signalingMessage.messageType,

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -11,7 +11,6 @@ public:
         ChannelInfo channelInfo;
         SignalingClientCallbacks signalingClientCallbacks;
         SignalingClientInfo clientInfo;
-        PSignalingClient pSignalingClient;
         Tag tags[3];
         STATUS retStatus;
 

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -13,12 +13,12 @@ UINT64 gTotalWebRtcClientMemoryUsage = 0;
 MUTEX gTotalWebRtcClientMemoryMutex;
 
 WebRtcClientTestBase::WebRtcClientTestBase() :
-        mAccessKeyIdSet(FALSE),
-        mCaCertPath(NULL),
         mAccessKey(NULL),
         mSecretKey(NULL),
         mSessionToken(NULL),
-        mRegion(NULL)
+        mRegion(NULL),
+        mCaCertPath(NULL),
+        mAccessKeyIdSet(FALSE)
 {
     // Initialize the endianness of the library
     initializeEndianness();


### PR DESCRIPTION
Before we only built our samples/library code with warnings, this builds
the tests with them enabled as well
