### PR TITLE
add option to compare clientPeerId when checking existing message

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1552,7 +1552,7 @@ STATUS receiveLwsMessage(PSignalingClient pSignalingClient, PCHAR pMessage, UINT
     if (pMessage == NULL || messageLen == 0) {
         if (BLOCK_ON_CORRELATION_ID) {
             // Get empty correlation id message from the ongoing if exists
-            CHK_STATUS(signalingGetOngoingMessage(pSignalingClient, EMPTY_STRING, &pOngoingMessage));
+            CHK_STATUS(signalingGetOngoingMessage(pSignalingClient, EMPTY_STRING, EMPTY_STRING, &pOngoingMessage));
             if (pOngoingMessage == NULL) {
                 DLOGW("Received an empty body for a message with no correlation id which has been already removed from the queue. Warning 0x%08x",
                       STATUS_SIGNALING_RECEIVE_EMPTY_DATA_NOT_SUPPORTED);

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -167,7 +167,7 @@ STATUS validateIceConfiguration(PSignalingClient);
 
 STATUS signalingStoreOngoingMessage(PSignalingClient, PSignalingMessage);
 STATUS signalingRemoveOngoingMessage(PSignalingClient, PCHAR);
-STATUS signalingGetOngoingMessage(PSignalingClient, PCHAR, PSignalingMessage*);
+STATUS signalingGetOngoingMessage(PSignalingClient, PCHAR, PCHAR, PSignalingMessage*);
 
 STATUS refreshIceConfigurationCallback(UINT32, UINT64, UINT64);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

add option to compare clientPeerId when checking existing message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
