### PR TITLE
Terminate the listener thread on connection timeout.

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1280,6 +1280,7 @@ CleanUp:
         if (!ATOMIC_LOAD_BOOL(&pSignalingClient->listenerTracker.terminated) &&
             pSignalingClient->pOngoingCallInfo != NULL &&
             pSignalingClient->pOngoingCallInfo->callInfo.pRequestInfo != NULL) {
+            ATOMIC_STORE_BOOL(&pLwsCallInfo->callInfo.pRequestInfo->terminating, TRUE);
             terminateConnectionWithStatus(pSignalingClient, SERVICE_CALL_UNKNOWN);
         }
 


### PR DESCRIPTION
When the service doesn't error out but we timeout to connect the termination doesn't trigger a termination of the service driving listener thread. This is tested by manual fault injection yet. Will be following up with automated injection test.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
