### PR TITLE
Allow MTU to be configured via public API

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -597,6 +597,21 @@ typedef struct {
 } RtcIceServer, *PRtcIceServer;
 
 /**
+ *  KvsRtcConfiguration is a collection of non-standard extensions to RTCConfiguration
+ *  these exist to serve use cases that currently aren't being served by the W3C standard
+ *
+ *  These options will be removed/modified as the WebRTC standard changes, and exist to unblock
+ *  issues that we have today.
+ */
+typedef struct {
+    // maximumTransmissionUnit (MTU) controls the size of the largest packet the WebRTC SDK will send
+    // Some networks may drop packets if they exceed a certain size, and is useful in those conditions.
+    // A smaller MTU will incur higher bandwidth usage however since more packets will be generated with smaller payloads
+    // If unset DEFAULT_MTU_SIZE will be used
+    UINT16 maximumTransmissionUnit;
+} KvsRtcConfiguration, *PKvsRtcConfiguration;
+
+/**
  *  The Configuration defines a set of parameters to configure how the peer-to-peer
  *  communication established via RtcPeerConnection is established or re-established.
  *  https://www.w3.org/TR/webrtc/#rtcconfiguration-dictionary
@@ -605,7 +620,11 @@ typedef struct {
     // Indicates which candidates the ICE Agent is allowed to use.
     ICE_TRANSPORT_POLICY iceTransportPolicy;
 
+    // servers available to be used by ICE, such as STUN and TURN servers.
     RtcIceServer iceServers[MAX_ICE_SERVERS_COUNT];
+
+    // non-standard configuration options
+    KvsRtcConfiguration kvsRtcConfiguration;
 } RtcConfiguration, *PRtcConfiguration;
 
 /*

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -441,6 +441,7 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     pKvsPeerConnection->pSrtpSessionLock = MUTEX_CREATE(TRUE);
     pKvsPeerConnection->peerConnectionObjLock = MUTEX_CREATE(FALSE);
     pKvsPeerConnection->previousConnectionState = RTC_PEER_CONNECTION_STATE_NONE;
+    pKvsPeerConnection->MTU = pConfiguration->kvsRtcConfiguration.maximumTransmissionUnit == 0 ? DEFAULT_MTU_SIZE : pConfiguration->kvsRtcConfiguration.maximumTransmissionUnit;
 
     iceAgentCallbacks.customData = (UINT64) pKvsPeerConnection;
     iceAgentCallbacks.inboundPacketFn = onInboundPacket;

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -88,6 +88,7 @@ typedef struct {
     RtcOnConnectionStateChange onConnectionStateChange;
     RTC_PEER_CONNECTION_STATE previousConnectionState;
 
+    UINT16 MTU;
 } KvsPeerConnection, *PKvsPeerConnection;
 
 STATUS onFrameReadyFunc(UINT64, UINT16, UINT16, UINT32);

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -158,7 +158,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             CHK(FALSE, STATUS_NOT_IMPLEMENTED);
     }
 
-    CHK_STATUS(rtpPayloadFunc(DEFAULT_MTU_SIZE, (PBYTE) pFrame->frameData, pFrame->size, NULL, &(pPayloadArray->payloadLength), NULL, &(pPayloadArray->payloadSubLenSize)));
+    CHK_STATUS(rtpPayloadFunc(pKvsPeerConnection->MTU, (PBYTE) pFrame->frameData, pFrame->size, NULL, &(pPayloadArray->payloadLength), NULL, &(pPayloadArray->payloadSubLenSize)));
     if (pPayloadArray->payloadLength > pPayloadArray->maxPayloadLength) {
         if (pPayloadArray->payloadBuffer != NULL) {
             SAFE_MEMFREE(pPayloadArray->payloadBuffer);
@@ -173,7 +173,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         pPayloadArray->payloadSubLength = (PUINT32) MEMALLOC(pPayloadArray->payloadSubLenSize * SIZEOF(UINT32));
         pPayloadArray->maxPayloadSubLenSize = pPayloadArray->payloadSubLenSize;
     }
-    CHK_STATUS(rtpPayloadFunc(DEFAULT_MTU_SIZE, (PBYTE) pFrame->frameData, pFrame->size, pPayloadArray->payloadBuffer, &(pPayloadArray->payloadLength), pPayloadArray->payloadSubLength, &(pPayloadArray->payloadSubLenSize)));
+    CHK_STATUS(rtpPayloadFunc(pKvsPeerConnection->MTU, (PBYTE) pFrame->frameData, pFrame->size, pPayloadArray->payloadBuffer, &(pPayloadArray->payloadLength), pPayloadArray->payloadSubLength, &(pPayloadArray->payloadSubLenSize)));
     pPacketList = (PRtpPacket) MEMALLOC(pPayloadArray->payloadSubLenSize * SIZEOF(RtpPacket));
 
     CHK_STATUS(constructRtpPackets(pPayloadArray, pKvsRtpTransceiver->sender.payloadType, pKvsRtpTransceiver->sender.sequenceNumber, rtpTimestamp, pKvsRtpTransceiver->sender.ssrc, pPacketList, pPayloadArray->payloadSubLenSize));


### PR DESCRIPTION
Add KvsRtcConfiguration to public API that will allow users to configure
things that aren't available via WebRTC standard. Add single member for MTU.

Resolves #64