### PR TITLE
Set logging level for the sample application to default log level.

### DIFF
--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -49,7 +49,7 @@ INT32 main(INT32 argc, CHAR *argv[])
     signalingClientCallbacks.customData = (UINT64) pSampleConfiguration;
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
-    clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.loggingLevel = loggerGetLogLevel();
     STRCPY(clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 
     CHK_STATUS(createSignalingClientSync(&clientInfo,

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -331,7 +331,7 @@ INT32 main(INT32 argc, CHAR *argv[])
     signalingClientCallbacks.customData = (UINT64) pSampleConfiguration;
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
-    clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.loggingLevel = loggerGetLogLevel();
     STRCPY(clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 
     CHK_STATUS(createSignalingClientSync(&clientInfo,

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -29,7 +29,7 @@ INT32 main(INT32 argc, CHAR *argv[])
     signalingClientCallbacks.stateChangeFn = signalingClientStateChanged;
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
-    clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.loggingLevel = loggerGetLogLevel();
     STRCPY(clientInfo.clientId, SAMPLE_VIEWER_CLIENT_ID);
 
     CHK_STATUS(createSignalingClientSync(&clientInfo,


### PR DESCRIPTION
*Issue #, if available: #66 *

*Description of changes:*

- The current implementation has a hard coded verbosity level `VERBOSE`
- The patch changes this level to the default log level `WARN`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
