### PR TITLE
in iceAgent, pre-allocate stun packets needed to establish connection…

### DIFF
--- a/src/source/Ice/ConnectionListener.h
+++ b/src/source/Ice/ConnectionListener.h
@@ -65,6 +65,15 @@ STATUS connectionListenerAddConnection(PConnectionListener, PSocketConnection);
 STATUS connectionListenerRemoveConnection(PConnectionListener, PSocketConnection);
 
 /**
+ * remove all listening PSocketConnection
+ *
+ * @param - PConnectionListener      - IN - the ConnectionListener struct to use
+ *
+ * @return - STATUS status of execution
+ */
+STATUS connectionListenerRemoveAllConnection(PConnectionListener);
+
+/**
  * Spin off a listener thread that listen for incoming traffic for all PSocketConnection stored in connectionList.
  * Whenever a PSocketConnection receives data, invoke ConnectionDataAvailableFunc passed in.
  *

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -155,6 +155,10 @@ typedef struct {
 
     ICE_TRANSPORT_POLICY iceTransportPolicy;
     KvsRtcConfiguration kvsRtcConfiguration;
+
+    // Pre-allocated stun packets
+    PStunPacket pBindingIndication;
+    PStunPacket pBindingRequest;
 } IceAgent, *PIceAgent;
 
 

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -84,7 +84,9 @@ STATUS freeTurnConnection(PTurnConnection* ppTurnConnection)
 
     // tear down control channel
     if (pTurnConnection->pControlChannel != NULL) {
-        connectionListenerRemoveConnection(pTurnConnection->pConnectionListener, pTurnConnection->pControlChannel);
+        if (pTurnConnection->pConnectionListener != NULL) {
+            connectionListenerRemoveConnection(pTurnConnection->pConnectionListener, pTurnConnection->pControlChannel);
+        }
         freeSocketConnection(&pTurnConnection->pControlChannel);
     }
 


### PR DESCRIPTION
…. Fix deadlock when using turn.

*Issue #, if available:*

*Description of changes:*

in iceAgent, pre-allocate stun packets needed to establish connection. Fix deadlock when using turn.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
