### PR TITLE
do not wait for srflx candidate in gathering state. Proceed to connec…

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -124,7 +124,7 @@ extern "C" {
 #define STATUS_ICE_URL_TURN_MISSING_USERNAME                                        STATUS_ICE_BASE  + 0x00000008
 #define STATUS_ICE_URL_TURN_MISSING_CREDENTIAL                                      STATUS_ICE_BASE  + 0x00000009
 #define STATUS_ICE_AGENT_STATE_CHANGE_FAILED                                        STATUS_ICE_BASE  + 0x0000000a
-#define STATUS_ICE_NO_LOCAL_CANDIDATE_AVAILABLE_AFTER_GATHERING_TIMEOUT             STATUS_ICE_BASE  + 0x0000000b
+#define STATUS_ICE_NO_LOCAL_CANDIDATE_AVAILABLE                                     STATUS_ICE_BASE  + 0x0000000b
 #define STATUS_ICE_AGENT_TERMINATED_ALREADY                                         STATUS_ICE_BASE  + 0x0000000c
 #define STATUS_ICE_NO_CONNECTED_CANDIDATE_PAIR                                      STATUS_ICE_BASE  + 0x0000000d
 #define STATUS_ICE_CANDIDATE_PAIR_LIST_EMPTY                                        STATUS_ICE_BASE  + 0x0000000e

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -114,6 +114,7 @@ struct __TurnConnection {
     IceServer turnServer;
 
     MUTEX lock;
+    MUTEX sendLock;
 
     volatile TURN_CONNECTION_STATE state;
 

--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -221,31 +221,6 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
         EXPECT_EQ(priority, computeCandidatePairPriority(&iceCandidatePair, TRUE));
     }
 
-    TEST_F(IceFunctionalityTest, IceAgentUpdateCandidateAddressUnitTest)
-    {
-        IceCandidate localCandidate;
-        KvsIpAddress newIpAddress;
-
-        MEMSET(&newIpAddress, 0x0, SIZEOF(KvsIpAddress));
-
-        newIpAddress.port = 8080;
-        newIpAddress.family = KVS_IP_FAMILY_TYPE_IPV4;
-        newIpAddress.isPointToPoint = FALSE;
-        MEMSET(newIpAddress.address, 0x11, ARRAY_SIZE(newIpAddress.address));
-
-        localCandidate.state = ICE_CANDIDATE_STATE_NEW;
-
-        EXPECT_NE(STATUS_SUCCESS, updateCandidateAddress(NULL, &newIpAddress));
-        EXPECT_NE(STATUS_SUCCESS, updateCandidateAddress(&localCandidate, NULL));
-        localCandidate.iceCandidateType = ICE_CANDIDATE_TYPE_HOST;
-        EXPECT_NE(STATUS_SUCCESS, updateCandidateAddress(&localCandidate, &newIpAddress));
-        localCandidate.iceCandidateType = ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE;
-        EXPECT_EQ(STATUS_SUCCESS, updateCandidateAddress(&localCandidate, &newIpAddress));
-
-        EXPECT_EQ(localCandidate.ipAddress.port, newIpAddress.port);
-        EXPECT_EQ(0, MEMCMP(localCandidate.ipAddress.address, newIpAddress.address, IPV4_ADDRESS_LENGTH));
-    }
-
     TEST_F(IceFunctionalityTest, IceAgentIceAgentAddIceServerUnitTest)
     {
         IceServer iceServer;


### PR DESCRIPTION
…tion check with host candidate if any, otherwise error out.

*Issue #, if available:*

*Description of changes:*
do not wait for srflx candidate in gathering state. Proceed to connection check with host candidate if any, otherwise error out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
