### PR TITLE
[Issue-#123] Remove setting default log level in samples

### DIFF
--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -49,7 +49,6 @@ INT32 main(INT32 argc, CHAR *argv[])
     signalingClientCallbacks.customData = (UINT64) pSampleConfiguration;
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
-    clientInfo.loggingLevel = loggerGetLogLevel();
     STRCPY(clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 
     CHK_STATUS(createSignalingClientSync(&clientInfo,

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -331,7 +331,6 @@ INT32 main(INT32 argc, CHAR *argv[])
     signalingClientCallbacks.customData = (UINT64) pSampleConfiguration;
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
-    clientInfo.loggingLevel = loggerGetLogLevel();
     STRCPY(clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 
     CHK_STATUS(createSignalingClientSync(&clientInfo,

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -29,7 +29,6 @@ INT32 main(INT32 argc, CHAR *argv[])
     signalingClientCallbacks.stateChangeFn = signalingClientStateChanged;
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
-    clientInfo.loggingLevel = loggerGetLogLevel();
     STRCPY(clientInfo.clientId, SAMPLE_VIEWER_CLIENT_ID);
 
     CHK_STATUS(createSignalingClientSync(&clientInfo,


### PR DESCRIPTION
*Issue #, if available: #123 *

*Description of changes:*

- Removed setting of log level in samples
- For more logging information, run the application by setting env variable `AWS_KVS_LOG_LEVEL`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
