### PR TITLE
[#125] Print friendly success messages while executing sample applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Run any of the sample applications by passing to it the name that you want to gi
 ./kvsWebrtcClientMaster myChannel
 ```
 
-When the command line application prints "[KVS Master] Signaling client connection to socket established", you can proceed to the next step.
+When the command line application prints "Signaling client connection to socket established", you can proceed to the next step.
 
 Now that your signaling channel is created and the connected master is streaming media to it, you can view this stream. To do so, open the [WebRTC SDK Test Page](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html) using the steps in Using the Kinesis Video Streams with WebRTC Test Page and set the following values using the same AWS credentials and the same signaling channel that you specified for the master above:
 * Access key ID

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Run any of the sample applications by passing to it the name that you want to gi
 ./kvsWebrtcClientMaster myChannel
 ```
 
-When the command line application prints Connection established, you can proceed to the next step.
+When the command line application prints "[KVS Master] Signaling client connection to socket established", you can proceed to the next step.
 
 Now that your signaling channel is created and the connected master is streaming media to it, you can view this stream. To do so, open the [WebRTC SDK Test Page](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html) using the steps in Using the Kinesis Video Streams with WebRTC Test Page and set the following values using the same AWS credentials and the same signaling channel that you specified for the master above:
 * Access key ID

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -44,6 +44,7 @@ INT32 main(INT32 argc, CHAR *argv[])
 
     CHK_STATUS(readFrameFromDisk(NULL, &frameSize, "./h264SampleFrames/frame-001.h264"));
     printf("[KVS Master] Checked sample video frame availability....available\n");
+
     CHK_STATUS(readFrameFromDisk(NULL, &frameSize, "./opusSampleFrames/sample-001.opus"));
     printf("[KVS Master] Checked sample audio frame availability....available\n");
 

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -317,8 +317,7 @@ INT32 main(INT32 argc, CHAR *argv[])
             printf("[KVS Gstreamer Master] Streaming video only\n");
         }
     }
-    else
-    {
+    else {
         printf("[KVS Gstreamer Master] Streaming video only\n");
     }
 

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -286,12 +286,14 @@ INT32 main(INT32 argc, CHAR *argv[])
     PSampleStreamingSession pSampleStreamingSession = NULL;
 
     // do trickle-ice by default
+    printf("[KVS GStreamer Master] Using trickleICE by default\n");
+
     CHK_STATUS(createSampleConfiguration(argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME,
             SIGNALING_CHANNEL_ROLE_TYPE_MASTER,
             TRUE,
             TRUE,
             &pSampleConfiguration));
-
+    printf("[KVS GStreamer Master] Created signaling channel %s\n", (argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME));
 
     pSampleConfiguration->videoSource = sendGstreamerAudioVideo;
     pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
@@ -301,15 +303,23 @@ INT32 main(INT32 argc, CHAR *argv[])
 
     /* Initialize GStreamer */
     gst_init(&argc, &argv);
+    printf("[KVS Gstreamer Master] Finished initializing GStreamer\n");
 
     if (argc > 2) {
         if (STRCMP(argv[2], "video-only") == 0) {
             pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
+            printf("[KVS Gstreamer Master] Streaming video only\n");
         } else if (STRCMP(argv[2], "audio-video") == 0) {
             pSampleConfiguration->mediaType = SAMPLE_STREAMING_AUDIO_VIDEO;
+            printf("[KVS Gstreamer Master] Streaming audio and video\n");
         } else {
             DLOGD("Unrecognized streaming type. Default to video-only");
+            printf("[KVS Gstreamer Master] Streaming video only\n");
         }
+    }
+    else
+    {
+        printf("[KVS Gstreamer Master] Streaming video only\n");
     }
 
     switch (pSampleConfiguration->mediaType) {
@@ -323,6 +333,7 @@ INT32 main(INT32 argc, CHAR *argv[])
 
     // Initalize KVS WebRTC. This must be done before anything else, and must only be done once.
     CHK_STATUS(initKvsWebRtc());
+    printf("[KVS GStreamer Master] KVS WebRTC initialization completed successfully\n");
 
     signalingClientCallbacks.version = SIGNALING_CLIENT_CALLBACKS_CURRENT_VERSION;
     signalingClientCallbacks.messageReceivedFn = masterMessageReceived;
@@ -338,9 +349,14 @@ INT32 main(INT32 argc, CHAR *argv[])
             &signalingClientCallbacks,
             pSampleConfiguration->pCredentialProvider,
             &pSampleConfiguration->signalingClientHandle));
+    printf("[KVS GStreamer Master] Signaling client created successfully\n");
 
     // Enable the processing of the messages
     CHK_STATUS(signalingClientConnectSync(pSampleConfiguration->signalingClientHandle));
+    printf("[KVS GStreamer Master] Signaling client connection to socket established\n");
+
+    printf("[KVS Gstreamer Master] Beginning streaming...check the stream over channel %s\n",
+            (argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME));
 
     // Checking for termination
     while(!ATOMIC_LOAD_BOOL(&pSampleConfiguration->interrupted)) {
@@ -367,9 +383,11 @@ INT32 main(INT32 argc, CHAR *argv[])
         // periodically wake up and clean up terminated streaming session
         CVAR_WAIT(pSampleConfiguration->cvar, pSampleConfiguration->sampleConfigurationObjLock, 5 * HUNDREDS_OF_NANOS_IN_A_SECOND);
     }
+    printf("[KVS GStreamer Master] Streaming session terminated\n");
 
 CleanUp:
 
+    printf("[KVS GStreamer Master] Cleaning up....\n");
     CHK_LOG_ERR_NV(retStatus);
 
     if (pSampleConfiguration != NULL) {
@@ -385,6 +403,6 @@ CleanUp:
         CHK_LOG_ERR_NV(freeSignalingClient(&pSampleConfiguration->signalingClientHandle));
         CHK_LOG_ERR_NV(freeSampleConfiguration(&pSampleConfiguration));
     }
-
+    printf("[KVS Gstreamer Master] Cleanup done\n");
     return (INT32) retStatus;
 }

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -45,9 +45,8 @@ INT32 main(INT32 argc, CHAR *argv[])
     MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
     locked = TRUE;
 
-    printf("[KVS Viewer] Creating streaming session...");
     CHK_STATUS(createSampleStreamingSession(pSampleConfiguration, NULL, FALSE, &pSampleStreamingSession));
-    printf("Completed\n");
+    printf("[KVS Viewer] Creating streaming session...completed\n");
     pSampleConfiguration->sampleStreamingSessionList[pSampleConfiguration->streamingSessionCount++] = pSampleStreamingSession;
 
     MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
@@ -59,7 +58,7 @@ INT32 main(INT32 argc, CHAR *argv[])
 
     MEMSET(&offerSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
     CHK_STATUS(createOffer(pSampleStreamingSession->pPeerConnection, &offerSessionDescriptionInit));
-    printf("[KVS Viewer] Offer creation successful");
+    printf("[KVS Viewer] Offer creation successful\n");
 
     CHK_STATUS(setLocalDescription(pSampleStreamingSession->pPeerConnection, &offerSessionDescriptionInit));
     printf("[KVS Viewer] Completed setting local description\n");

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -13,14 +13,17 @@ INT32 main(INT32 argc, CHAR *argv[])
     BOOL locked = FALSE;
 
     // do trickle-ice by default
+    printf("[KVS Viewer] Using trickleICE by default\n");
     CHK_STATUS(createSampleConfiguration(argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME,
             SIGNALING_CHANNEL_ROLE_TYPE_VIEWER,
             TRUE,
             TRUE,
             &pSampleConfiguration));
+    printf("[KVS Viewer] Created signaling channel %s\n", (argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME));
 
     // Initalize KVS WebRTC. This must be done before anything else, and must only be done once.
     CHK_STATUS(initKvsWebRtc());
+    printf("[KVS Viewer] KVS WebRTC initialization completed successfully\n");
 
     signalingClientCallbacks.version = SIGNALING_CLIENT_CALLBACKS_CURRENT_VERSION;
     signalingClientCallbacks.customData = (UINT64) pSampleConfiguration;
@@ -36,12 +39,15 @@ INT32 main(INT32 argc, CHAR *argv[])
             &signalingClientCallbacks,
             pSampleConfiguration->pCredentialProvider,
             &pSampleConfiguration->signalingClientHandle));
+    printf("[KVS Viewer] Signaling client created successfully\n");
 
     // Initialize streaming session
     MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
     locked = TRUE;
 
+    printf("[KVS Viewer] Creating streaming session...");
     CHK_STATUS(createSampleStreamingSession(pSampleConfiguration, NULL, FALSE, &pSampleStreamingSession));
+    printf("Completed\n");
     pSampleConfiguration->sampleStreamingSessionList[pSampleConfiguration->streamingSessionCount++] = pSampleStreamingSession;
 
     MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
@@ -49,17 +55,24 @@ INT32 main(INT32 argc, CHAR *argv[])
 
     // Enable the processing of the messages
     CHK_STATUS(signalingClientConnectSync(pSampleConfiguration->signalingClientHandle));
+    printf("[KVS Viewer] Signaling client connection to socket established\n");
 
     MEMSET(&offerSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
     CHK_STATUS(createOffer(pSampleStreamingSession->pPeerConnection, &offerSessionDescriptionInit));
+    printf("[KVS Viewer] Offer creation successful");
+
     CHK_STATUS(setLocalDescription(pSampleStreamingSession->pPeerConnection, &offerSessionDescriptionInit));
+    printf("[KVS Viewer] Completed setting local description\n");
+
     CHK_STATUS(transceiverOnFrame(pSampleStreamingSession->pAudioRtcRtpTransceiver,
                                   (UINT64) pSampleStreamingSession,
                                   sampleFrameHandler));
 
+    printf("[KVS Viewer] Generate JSON of session description....");
     CHK_STATUS(serializeSessionDescriptionInit(&offerSessionDescriptionInit, NULL, &buffLen));
     CHK(buffLen < SIZEOF(message.payload), STATUS_INVALID_OPERATION);
     CHK_STATUS(serializeSessionDescriptionInit(&offerSessionDescriptionInit, message.payload, &buffLen));
+    printf("Completed\n");
 
     message.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     message.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
@@ -68,12 +81,11 @@ INT32 main(INT32 argc, CHAR *argv[])
     message.correlationId[0] = '\0';
 
     CHK_STATUS(signalingClientSendMessageSync(pSampleConfiguration->signalingClientHandle, &message));
-
     // Block forever
     THREAD_SLEEP(MAX_UINT64);
 
 CleanUp:
-
+    printf("[KVS Viewer] Cleaning up....\n");
     CHK_LOG_ERR_NV(retStatus);
 
     if (locked) {
@@ -85,6 +97,6 @@ CleanUp:
         CHK_LOG_ERR_NV(freeSampleStreamingSession(&pSampleStreamingSession));
         CHK_LOG_ERR_NV(freeSampleConfiguration(&pSampleConfiguration));
     }
-
+    printf("[KVS Viewer] Cleanup done\n");
     return (INT32) retStatus;
 }


### PR DESCRIPTION
…pplications

*Issue #, if available: #125 *

*Description of changes:*
- Print friendly messages to indicate code flow instead of cluttering the output with logs
- Logs can still be enabled by setting the env variable

Resolves #125 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
