### PR TITLE
[KinesisVideo-5381] Enable LWS hexdump only for certain log levels

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -26,6 +26,7 @@ INT32 lwsHttpCallbackRoutine(struct lws *wsi, enum lws_callback_reasons reason,
     PSingleListNode pCurNode;
     UINT64 item;
     UINT32 headerCount;
+    UINT32 logLevel;
     PRequestHeader pRequestHeader;
     PSignalingClient pSignalingClient = NULL;
     BOOL locked = FALSE;
@@ -47,6 +48,7 @@ INT32 lwsHttpCallbackRoutine(struct lws *wsi, enum lws_callback_reasons reason,
     pRequestInfo = pLwsCallInfo->callInfo.pRequestInfo;
     pBuffer = pLwsCallInfo->buffer + LWS_PRE;
 
+    logLevel = loggerGetLogLevel();
     switch (reason) {
         case LWS_CALLBACK_CLIENT_CONNECTION_ERROR:
             MUTEX_LOCK(pSignalingClient->lwsServiceLock);
@@ -100,7 +102,10 @@ INT32 lwsHttpCallbackRoutine(struct lws *wsi, enum lws_callback_reasons reason,
             locked = TRUE;
 
             DLOGD("Received client http read: %d bytes", (INT32) dataSize);
-            lwsl_hexdump_notice(pDataIn, dataSize);
+
+            if(logLevel > LOG_LEVEL_INFO && logLevel < LOG_LEVEL_SILENT) {
+                lwsl_hexdump_notice(pDataIn, dataSize);
+            }
 
             if (dataSize != 0) {
                 CHK(NULL != (pLwsCallInfo->callInfo.responseData = (PCHAR) MEMALLOC(dataSize)),


### PR DESCRIPTION
*Issue #, if available: KinesisVideo-5381*

*Description of changes:*
- Removed mandatory hexdump of AWS and channel information while running samples
- Hexdump will now be available for log levels WARN, ERROR and FATAL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
