### PR TITLE
Update CMake to make cross-compiles easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cmake-build-debug/
 cmake-build-release/
 open-source/libgtest
 open-source/libjsmn
+open-source/libopenssl
 open-source/libsrtp
 open-source/libusrsctp
 open-source/libwebsockets

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ cache:
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.4
       - gdb
 
 script:
@@ -102,5 +99,20 @@ matrix:
             - gcc-4.4
             - gdb
       compiler: gcc
+      before_script: export CC=gcc-4.4 && mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE
+
+    # Cross-compilation to ARM, no tests are run
+    - name: "ARM Cross-compilation"
+      os: linux
+      addons:
+        apt:
+          packages:
+            - gcc-arm-linux-gnueabi
+            - g++-arm-linux-gnueabi
+            - binutils-arm-linux-gnueabi
+      compiler: gcc
       before_script:
-        - export CC=gcc-4.4 && mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE
+        - export CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++
+        - mkdir build && cd build
+        - cmake .. -DBUILD_TEST=TRUE -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+      script: make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(KinesisVideoWebRTCClient LANGUAGES C)
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
 option(BUILD_DEPENDENCIES "Whether or not to build depending libraries from source" ON)
 option(BUILD_OPENSSL "If building dependencies, whether or not building openssl from source" OFF)
+option(BUILD_OPENSSL_PLATFORM "If buildng OpenSSL what is the target platform" OFF)
+option(BUILD_LIBSRTP_HOST_PLATFORM "If buildng LibSRTP what is the current platform" OFF)
+option(BUILD_LIBSRTP_DESTINATION_PLATFORM "If buildng LibSRTP what is the destination platform" OFF)
 
 # Developer Flags
 option(BUILD_TEST "Build the testing tree." OFF)
@@ -108,7 +111,7 @@ if(BUILD_DEPENDENCIES)
               ${CMAKE_SOURCE_DIR}/cmake-scripts/libopenssl-CMakeLists.txt
               ${OPEN_SOURCE_DIR}/libopenssl/CMakeLists.txt COPYONLY)
       execute_process(
-              COMMAND ${CMAKE_COMMAND} -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -G ${CMAKE_GENERATOR} .
+              COMMAND ${CMAKE_COMMAND} -DBUILD_OPENSSL_PLATFORM=${BUILD_OPENSSL_PLATFORM} -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -G ${CMAKE_GENERATOR} .
               RESULT_VARIABLE result
               WORKING_DIRECTORY ${OPEN_SOURCE_DIR}/libopenssl)
       if(result)
@@ -168,7 +171,7 @@ if(BUILD_DEPENDENCIES)
     configure_file(${CMAKE_SOURCE_DIR}/cmake-scripts/libsrtp-CMakeLists.txt
                    ${OPEN_SOURCE_DIR}/libsrtp/CMakeLists.txt COPYONLY)
     execute_process(
-      COMMAND ${CMAKE_COMMAND} -DOPENSSL_DIR=${OPENSSL_DIR} -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -G ${CMAKE_GENERATOR} .
+      COMMAND ${CMAKE_COMMAND} -DOPENSSL_DIR=${OPENSSL_DIR} -DBUILD_LIBSRTP_HOST_PLATFORM=${BUILD_LIBSRTP_HOST_PLATFORM} -DBUILD_LIBSRTP_DESTINATION_PLATFORM=${BUILD_LIBSRTP_DESTINATION_PLATFORM} -DOPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -G ${CMAKE_GENERATOR} .
       RESULT_VARIABLE result
       WORKING_DIRECTORY ${OPEN_SOURCE_DIR}/libsrtp)
     if(result)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 * Portable
   - Tested on Linux/MacOS
   - Tested on x64, ARMv5
+  - Build system designed for pleasant cross-compilation
 * Small Install Size
   - Sub 200k library size
   - OpenSSL, libsrtp, libjsmn, libusrsctp and libwebsockets dependencies.
@@ -60,11 +61,21 @@ GStreamer is installed on your system.
 By default we download all the libraries from GitHub and build them locally, so should require nothing to be installed ahead of time.
 If you do wish to link to existing libraries you can use the following flags to customize your build.
 
+
+#### Cross-Compilation
+
+If you wish to cross-compile `CC` and `CXX` are respected when building the library and all its dependencies. You will also need to set `BUILD_OPENSSL_PLATFORM`, `BUILD_LIBSRTP_HOST_PLATFORM` and `BUILD_LIBSRTP_DESTINATION_PLATFORM`. See our [.travis.yml](.travis.yml) for an example of this. Every commit is cross compiled to ensure that it continues to work.
+
+
+#### CMake Arguments
 You can pass the following options to `cmake ..`.
 
 * `-DADD_MUCLIBC` -- Add -muclibc c flag
 * `-DBUILD_DEPENDENCIES` -- Whether or not to build depending libraries from source
 * `-DBUILD_OPENSSL` -- If building dependencies, whether or not building openssl from source
+* `-DBUILD_OPENSSL_PLATFORM` -- If buildng OpenSSL what is the target platform
+* `-DBUILD_LIBSRTP_HOST_PLATFORM` -- If buildng LibSRTP what is the current platform
+* `-DBUILD_LIBSRTP_DESTINATION_PLATFORM` -- If buildng LibSRTP what is the destination platform
 * `-DBUILD_TEST=TRUE` -- Build unit/integration tests, may be useful for confirm support for your device. `./tst/webrtc_client_test`
 * `-DCODE_COVERAGE` --  Enable coverage reporting
 * `-DCOMPILER_WARNINGS` -- Enable all compiler warnings

--- a/cmake-scripts/libopenssl-CMakeLists.txt
+++ b/cmake-scripts/libopenssl-CMakeLists.txt
@@ -4,12 +4,18 @@ project(libopenssl-download NONE)
 
 find_program(MAKE_EXE NAMES make)
 
+if (DEFINED BUILD_OPENSSL_PLATFORM AND NOT BUILD_OPENSSL_PLATFORM STREQUAL OFF)
+  SET(CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libopenssl/Configure --prefix=${OPEN_SRC_INSTALL_PREFIX} --openssldir=${OPEN_SRC_INSTALL_PREFIX} ${BUILD_OPENSSL_PLATFORM})
+else()
+  SET(CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libopenssl/config --prefix=${OPEN_SRC_INSTALL_PREFIX} --openssldir=${OPEN_SRC_INSTALL_PREFIX})
+endif()
+
 include(ExternalProject)
 ExternalProject_Add(project_libopenssl
     GIT_REPOSITORY    https://github.com/openssl/openssl.git
     GIT_TAG           OpenSSL_1_1_0l
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libopenssl/config --prefix=${OPEN_SRC_INSTALL_PREFIX} --openssldir=${OPEN_SRC_INSTALL_PREFIX}
+    CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
     BUILD_COMMAND     ${MAKE_EXE} -j 4
     BUILD_IN_SOURCE   TRUE
     INSTALL_COMMAND   ${MAKE_EXE} install_sw

--- a/cmake-scripts/libsrtp-CMakeLists.txt
+++ b/cmake-scripts/libsrtp-CMakeLists.txt
@@ -4,6 +4,11 @@ project(libsrtp-download NONE)
 
 find_program(MAKE_EXE NAMES make)
 
+SET(CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libsrtp/configure "CFLAGS=${CMAKE_C_FLAGS}" --prefix=${OPEN_SRC_INSTALL_PREFIX})
+if (DEFINED BUILD_LIBSRTP_DESTINATION_PLATFORM AND NOT BUILD_LIBSRTP_DESTINATION_PLATFORM STREQUAL OFF)
+  set(CONFIGURE_COMMAND ${CONFIGURE_COMMAND} --build=${BUILD_LIBSRTP_HOST_PLATFORM} --host=${BUILD_LIBSRTP_DESTINATION_PLATFORM})
+endif()
+
 if (DEFINED CMAKE_OSX_SYSROOT AND NOT CMAKE_OSX_SYSROOT STREQUAL "")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isysroot${CMAKE_OSX_SYSROOT}")
 endif()
@@ -13,7 +18,7 @@ ExternalProject_Add(project_libsrtp
     GIT_REPOSITORY    https://github.com/cisco/libsrtp.git
     GIT_TAG           v2.2.0
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
-    CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libsrtp/configure "CFLAGS=${CMAKE_C_FLAGS}" --prefix=${OPEN_SRC_INSTALL_PREFIX} --enable-openssl --with-openssl-dir=${OPENSSL_DIR}
+    CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
     BUILD_COMMAND     ${MAKE_EXE} shared_library
     BUILD_IN_SOURCE   TRUE
     INSTALL_COMMAND   ${MAKE_EXE} install


### PR DESCRIPTION
* CC/CXX is now respected across all dependencies
* OpenSSL and LibSRTP can now be configured via arguments to CMake
* Add travis build that ensures cross compiles do not regress