### PR TITLE
Add test for receving compound rtcp packet

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -9,6 +9,7 @@ STATUS onRtcpPacket(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuff, INT32 pB
 
     CHK(pKvsPeerConnection != NULL && pBuff != NULL, STATUS_NULL_ARG);
 
+    MEMSET(&rtcpPacket, 0x00, SIZEOF(rtcpPacket));
     CHK_STATUS(setRtcpPacketFromBytes(pBuff, pBuffLen, &rtcpPacket));
 
     if (rtcpPacket.header.packetType == RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -86,6 +86,13 @@ TEST_F(RtcpFunctionalityTest, rtcpNackListCompound) {
     EXPECT_EQ(compoundBuffer[1], 3327);
 }
 
+TEST_F(RtcpFunctionalityTest, onRtcpPacketCompound) {
+    KvsPeerConnection peerConnection;
+
+    BYTE compound[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0xa8, 0x00, 0x00, 0x0c, 0xff, 0x00, 0x00};
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(&peerConnection, compound, SIZEOF(compound)));
+}
+
 }
 }
 }


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/156

*Description of changes:*
* Add test for validating if variables get initialized. 
* Add initialization to avoid crash. 
* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/45 will be the follow up for actually respect the compound packets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
