### PR TITLE
Deadlock fix in Turn Connection.

### DIFF
--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -159,6 +159,15 @@ struct __TurnConnection {
 };
 typedef struct __TurnConnection* PTurnConnection;
 
+typedef struct {
+    UINT64 customData;
+    PTurnConnection pTurnConnection;
+    PBYTE pData;
+    UINT32 dataSize;
+    UINT16 channelNumber;
+    KvsIpAddress address;
+} ConnectionDataAvailableWrapper, *PConnectionDataAvailableWrapper;
+
 STATUS createTurnConnection(PIceServer, TIMER_QUEUE_HANDLE, PConnectionListener, TURN_CONNECTION_DATA_TRANSFER_MODE,
                             KVS_SOCKET_PROTOCOL, PTurnConnectionCallbacks , PTurnConnection*);
 STATUS freeTurnConnection(PTurnConnection*);
@@ -183,7 +192,7 @@ STATUS turnConnectionIncomingDataHandler(UINT64, PSocketConnection, PBYTE, UINT3
 STATUS turnConnectionHandleStun(PTurnConnection, PSocketConnection, PBYTE, UINT32);
 STATUS turnConnectionHandleStunError(PTurnConnection, PSocketConnection, PBYTE, UINT32);
 STATUS turnConnectionHandleChannelDataTcpMode(PTurnConnection, PBYTE, UINT32);
-
+PVOID turnDataAvailableWrapper(PVOID);
 #ifdef  __cplusplus
 }
 #endif


### PR DESCRIPTION
Issue: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/165

*Issue #165 , if available:*

Circular lock dependency leading to a dead lock. Traced most of the codepaths which seem to be OK with the exception of the callback. The cross-dependency of ICE and Turn connection are hard to break as both are low-level layers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
