### PR TITLE
[Issue #51] Accept path to cert in AWS_KVS_CACERT_PATH

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -470,6 +470,65 @@ CleanUp:
     return retStatus;
 }
 
+STATUS lookForSslCert(PSampleConfiguration* ppSampleConfiguration)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    struct stat pathStat;
+    UINT32 length = 0;
+    DIR *dp;
+    struct dirent *entry;
+    BOOL certFound = FALSE;
+    PSampleConfiguration pSampleConfiguration = *ppSampleConfiguration;
+
+    pSampleConfiguration->pCaCertPath = getenv(CACERT_PATH_ENV_VAR);
+
+    // if ca cert path is not set from the environment, try to use the one that cmake detected
+    if (pSampleConfiguration->pCaCertPath == NULL) {
+        CHK_ERR(STRNLEN(DEFAULT_KVS_CACERT_PATH, MAX_PATH_LEN) > 0, STATUS_INVALID_OPERATION, "No ca cert path given (error:%s)", strerror(errno));
+        pSampleConfiguration->pCaCertPath = DEFAULT_KVS_CACERT_PATH;
+    } else {
+        // Check if the environment variable is a path
+        CHK(0 == FSTAT(pSampleConfiguration->pCaCertPath, &pathStat), STATUS_DIRECTORY_ENTRY_STAT_ERROR);
+
+        // If CaCertPath is a directory, check for a file with .pem extension in this directory
+        if(S_ISDIR(pathStat.st_mode)) {
+            CHK_ERR((dp = opendir(pSampleConfiguration->pCaCertPath)) != NULL, STATUS_DIRECTORY_OPEN_FAILED, "Cannot open directory");
+
+            while((entry = readdir(dp)) != NULL) {
+                if(entry->d_type != DT_DIR) {
+                    // Get length of detected filename
+                    length = (UINT32) STRLEN(entry->d_name);
+                    CHK(length > (ARRAY_SIZE(CA_CERT_PEM_FILE_EXTENSION) - 1), STATUS_INVALID_ARG_LEN);
+                    if((0 == STRCMPI(CA_CERT_PEM_FILE_EXTENSION, &entry->d_name[length - ARRAY_SIZE(CA_CERT_PEM_FILE_EXTENSION) + 1]))) {
+                        // Check if the length of path and filename together is less than MAX_PATH_LEN
+                        CHK((length + STRLEN(pSampleConfiguration->pCaCertPath) + 1) <= MAX_PATH_LEN, STATUS_INVALID_ARG_LEN);
+                        // If the length checks out, it means we can form a valid absolute path to file
+                        STRCAT(pSampleConfiguration->pCaCertPath, entry->d_name);
+                        certFound = TRUE;
+                        break;
+                    }
+                }
+            }
+
+            // If cert is not found in given path, consider the path given by CMake
+            if(certFound == FALSE) {
+                DLOGW("Cert not found in path set...checking if CMake detected a path\n");
+                CHK_ERR(STRNLEN(DEFAULT_KVS_CACERT_PATH, MAX_PATH_LEN) > 0, STATUS_INVALID_OPERATION, "No ca cert path given (error:%s)", strerror(errno));
+                DLOGI("CMake detected cert path\n");
+                pSampleConfiguration->pCaCertPath = DEFAULT_KVS_CACERT_PATH;
+            }
+            closedir(dp);
+        } else {
+            CHK_ERR(length !=  MAX_PATH_LEN, STATUS_INVALID_OPERATION, "No ca cert path given");
+        }
+    }
+
+CleanUp:
+
+    CHK_LOG_ERR_NV(retStatus);
+    return retStatus;
+}
+
 STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE roleType, BOOL trickleIce, BOOL useTurn, PSampleConfiguration* ppSampleConfiguration)
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -488,11 +547,7 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
         pSampleConfiguration->channelInfo.pRegion = DEFAULT_AWS_REGION;
     }
 
-    // if ca cert path is not set from the environment, try to use the one that cmake detected
-    if ((pSampleConfiguration->pCaCertPath = getenv(CACERT_PATH_ENV_VAR)) == NULL) {
-        CHK_ERR(STRNLEN(DEFAULT_KVS_CACERT_PATH, MAX_PATH_LEN) > 0, STATUS_INVALID_OPERATION, "No ca cert path given");
-        pSampleConfiguration->pCaCertPath = DEFAULT_KVS_CACERT_PATH;
-    }
+    CHK_STATUS(lookForSslCert(&pSampleConfiguration));
 
     CHK_STATUS(createStaticCredentialProvider(pAccessKey, 0,
                                               pSecretKey, 0,

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -24,6 +24,7 @@ extern "C" {
 #define SAMPLE_AUDIO_FRAME_DURATION                                             (20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 #define SAMPLE_VIDEO_FRAME_DURATION                                             (HUNDREDS_OF_NANOS_IN_A_SECOND / DEFAULT_FPS_VALUE)
 
+#define CA_CERT_PEM_FILE_EXTENSION                                              ".pem"
 typedef enum {
     SAMPLE_STREAMING_VIDEO_ONLY,
     SAMPLE_STREAMING_AUDIO_VIDEO,
@@ -100,6 +101,7 @@ STATUS handleAnswer(PSampleConfiguration, PSampleStreamingSession, PSignalingMes
 STATUS handleOffer(PSampleConfiguration, PSampleStreamingSession, PSignalingMessage);
 STATUS handleRemoteCandidate(PSampleStreamingSession, PSignalingMessage);
 STATUS initializePeerConnection(PSampleConfiguration, PRtcPeerConnection*);
+STATUS lookForSslCert(PSampleConfiguration*);
 STATUS createSampleStreamingSession(PSampleConfiguration, PCHAR, BOOL, PSampleStreamingSession*);
 STATUS freeSampleStreamingSession(PSampleStreamingSession*);
 STATUS streamingSessionOnShutdown(PSampleStreamingSession, UINT64, StreamSessionShutdownCallback);


### PR DESCRIPTION
*Issue #, if available: #51 *

*Description of changes:*

- Added logic to allow detection of paths in AWS_KVS_CA_CERT environment variable.
- Logic:
1. First, a check is performed to see if the env variable is set
2. If not, CMAKE default path is checked. If Cmake detected a cert, the cert is used, else, we bail out because no cert is found
3. If env is set, a check is performed to see if it is an direct path to the file or a path which contains the file
4. If it is a direct path, a check is performed to see if it has a file extension .pem. 
5. If not, the path is searched for a file with extension .pem. 
6. If no such file is available, step 2 is performed again.
7. If the file is found, the file look up succeeds.

Resolves #51 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
