### PR TITLE
[Issue-113] Allow interface filtering while gathering local ICE candidates

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -298,6 +298,9 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
 
     MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
 
+    // Set this to custom callback to enable filtering of interfaces
+    configuration.kvsRtcConfiguration.iceSetInterfaceFilterFunc = NULL;
+
     // Set the  STUN server
     SNPRINTF(configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, pSampleConfiguration->channelInfo.pRegion);
 

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -458,6 +458,12 @@ typedef VOID (*RtcOnDataChannel)(UINT64, struct __RtcDataChannel*);
 typedef VOID (*RtcOnIceCandidate)(UINT64, PCHAR);
 
 /*
+ * IceSetInterfaceFilterFunc is fired when a callback function to filter network interfaces is assigned.
+ * The callback function is expected to check for specific interface names to be whitelisted/blacklisted
+ */
+typedef BOOL (*IceSetInterfaceFilterFunc) (UINT64, PCHAR);
+
+/*
  * https://www.w3.org/TR/webrtc/#rtcpeerconnectionstate-enum
  */
 typedef enum {
@@ -644,6 +650,8 @@ typedef struct {
     // If unset GENERATED_CERTIFICATE_BITS will be used
     INT32 generatedCertificateBits;
 
+    UINT64 filterCustomData;
+    IceSetInterfaceFilterFunc iceSetInterfaceFilterFunc;
 } KvsRtcConfiguration, *PKvsRtcConfiguration;
 
 /**

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -364,8 +364,10 @@ STATUS iceAgentGatherLocalCandidate(PIceAgent pIceAgent)
     KvsIpAddress localIpAddresses[MAX_LOCAL_NETWORK_INTERFACE_COUNT];
     UINT32 localIpAddressesCount = MAX_LOCAL_NETWORK_INTERFACE_COUNT, i;
     PSocketConnection pSocketConnection = NULL;
-
-    CHK_STATUS(getLocalhostIpAddresses(localIpAddresses, &localIpAddressesCount));
+    CHK_STATUS(getLocalhostIpAddresses(localIpAddresses,
+                                       &localIpAddressesCount,
+                                       pIceAgent->kvsRtcConfiguration.iceSetInterfaceFilterFunc,
+                                       pIceAgent->kvsRtcConfiguration.filterCustomData));
 
     for(i = 0; i < localIpAddressesCount; ++i) {
         pIpAddress = localIpAddresses + i;

--- a/src/source/Ice/IceAgentStateMachine.c
+++ b/src/source/Ice/IceAgentStateMachine.c
@@ -371,7 +371,7 @@ STATUS executeGatheringIceAgentState(UINT64 customData, UINT64 time)
 
             CHK_STATUS(createTurnConnection(&pIceAgent->iceServers[j], pIceAgent->timerQueueHandle,
                                             pIceAgent->pConnectionListener, TURN_CONNECTION_DATA_TRANSFER_MODE_SEND_INDIDATION,
-                                            KVS_ICE_DEFAULT_TURN_PROTOCOL, &turnConnectionCallbacks, &pIceAgent->pTurnConnection));
+                                            KVS_ICE_DEFAULT_TURN_PROTOCOL, &turnConnectionCallbacks, &pIceAgent->pTurnConnection, pIceAgent->kvsRtcConfiguration.iceSetInterfaceFilterFunc));
 
             // when connecting with non-trickle peer, when remote candidates are added, turnConnection would not be created
             // yet. So we need to add them here. turnConnectionAddPeer does ignore duplicates

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -4,11 +4,12 @@
 #define LOG_CLASS "Network"
 #include "../Include_i.h"
 
-STATUS getLocalhostIpAddresses(PKvsIpAddress destIpList, PUINT32 pDestIpListLen)
+STATUS getLocalhostIpAddresses(PKvsIpAddress destIpList, PUINT32 pDestIpListLen, IceSetInterfaceFilterFunc filter, UINT64 customData)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     UINT32 ipCount = 0, destIpListLen;
+    BOOL filterSet = TRUE;
 
     struct ifaddrs *ifaddr = NULL, *ifa = NULL;
     struct sockaddr_in *pIpv4Addr = NULL;
@@ -28,21 +29,35 @@ STATUS getLocalhostIpAddresses(PKvsIpAddress destIpList, PUINT32 pDestIpListLen)
             // mark vpn interface
             destIpList[ipCount].isPointToPoint = ((ifa->ifa_flags & IFF_POINTOPOINT) != 0);
 
-            if (ifa->ifa_addr->sa_family == AF_INET) {
-                destIpList[ipCount].family = KVS_IP_FAMILY_TYPE_IPV4;
-                destIpList[ipCount].port = 0;
-                pIpv4Addr = (struct sockaddr_in *) ifa->ifa_addr;
-                MEMCPY(destIpList[ipCount].address, &pIpv4Addr->sin_addr, IPV4_ADDRESS_LENGTH);
+            if(filter != NULL) {
+                DLOGI("Callback set to allow network interface filtering");
+                // The callback evaluates to a FALSE if the application is interested in black listing an interface
+                if(filter(customData, ifa->ifa_name) == FALSE) {
+                    filterSet = FALSE;
+                } else {
+                    filterSet = TRUE;
+                }
+             }
 
-            } else {
-                destIpList[ipCount].family = KVS_IP_FAMILY_TYPE_IPV6;
-                destIpList[ipCount].port = 0;
-                pIpv6Addr = (struct sockaddr_in6 *) ifa->ifa_addr;
-                MEMCPY(destIpList[ipCount].address, &pIpv6Addr->sin6_addr, IPV6_ADDRESS_LENGTH);
+            // If filter is set, ensure the details are collected for the interface
+            if(filterSet == TRUE) {
+                 if (ifa->ifa_addr->sa_family == AF_INET) {
+                    destIpList[ipCount].family = KVS_IP_FAMILY_TYPE_IPV4;
+                    destIpList[ipCount].port = 0;
+                    pIpv4Addr = (struct sockaddr_in *) ifa->ifa_addr;
+                    MEMCPY(destIpList[ipCount].address, &pIpv4Addr->sin_addr, IPV4_ADDRESS_LENGTH);
+
+                 } else {
+                    destIpList[ipCount].family = KVS_IP_FAMILY_TYPE_IPV6;
+                    destIpList[ipCount].port = 0;
+                    pIpv6Addr = (struct sockaddr_in6 *) ifa->ifa_addr;
+                    MEMCPY(destIpList[ipCount].address, &pIpv6Addr->sin6_addr, IPV6_ADDRESS_LENGTH);
+
+                 }
+
+                 // in case of overfilling destIpList
+                 ipCount++;
             }
-
-            // in case of overfilling destIpList
-            ipCount++;
         }
     }
 

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -32,9 +32,12 @@ typedef enum {
  *                                   will be in network byte order.
  * @param - UINT32 - IN/OUT - length of the array, upon return it will be updated to the actual number of ips in the array
  *
+ *@param - IceSetInterfaceFilterFunc - IN - set to custom interface filter callback
+ *
+ *@param - UINT64 - IN - Set to custom data that can be used in the callback later
  * @return - STATUS status of execution
  */
-STATUS getLocalhostIpAddresses(PKvsIpAddress, PUINT32);
+STATUS getLocalhostIpAddresses(PKvsIpAddress, PUINT32, IceSetInterfaceFilterFunc, UINT64);
 
 /**
  * @param - PKvsIpAddress - IN - Attempt to create an udp socket with the ip address given. Upon success, fill PKvsIpAddress'

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -121,6 +121,7 @@ struct __TurnConnection {
     volatile TURN_CONNECTION_STATE state;
 
     UINT64 stateTimeoutTime;
+    UINT64 filterCustomData;
 
     STATUS errorStatus;
 
@@ -156,11 +157,13 @@ struct __TurnConnection {
     UINT64 nextAllocationRefreshTime;
 
     UINT64 currentTimerCallingPeriod;
+
+    IceSetInterfaceFilterFunc iceSetInterfaceFilterFunc;
 };
 typedef struct __TurnConnection* PTurnConnection;
 
 STATUS createTurnConnection(PIceServer, TIMER_QUEUE_HANDLE, PConnectionListener, TURN_CONNECTION_DATA_TRANSFER_MODE,
-                            KVS_SOCKET_PROTOCOL, PTurnConnectionCallbacks , PTurnConnection*);
+                            KVS_SOCKET_PROTOCOL, PTurnConnectionCallbacks , PTurnConnection*, IceSetInterfaceFilterFunc);
 STATUS freeTurnConnection(PTurnConnection*);
 STATUS turnConnectionAddPeer(PTurnConnection, PKvsIpAddress);
 STATUS turnConnectionSendData(PTurnConnection, PBYTE, UINT32, PKvsIpAddress);

--- a/tst/TurnConnectionFunctionalityTest.cpp
+++ b/tst/TurnConnectionFunctionalityTest.cpp
@@ -40,7 +40,7 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
             EXPECT_EQ(STATUS_SUCCESS, connectionListenerStart(pConnectionListener));
             EXPECT_EQ(STATUS_SUCCESS, createTurnConnection(pTurnServer, timerQueueHandle, pConnectionListener,
                                                            TURN_CONNECTION_DATA_TRANSFER_MODE_DATA_CHANNEL,
-                                                           KVS_SOCKET_PROTOCOL_UDP, NULL, &pTurnConnection));
+                                                           KVS_SOCKET_PROTOCOL_UDP, NULL, &pTurnConnection, NULL));
 
             *ppTurnConnection = pTurnConnection;
         }


### PR DESCRIPTION
*Issue #, if available: #113*

*Description of changes:*

- Added provision to set callback to whitelist/blacklist specific network interfaces
- This will give the user more flexibility to choose known interfaces to scan for ICE candidate gathering
- The callback can be set by setting the setFilterFn member of RtcConfiguration to the user's custom filter function

Resolve #113 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
