### PR TITLE
fix compiler warning. Add find Thread to CMakeLists. Fix code indenta…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ if("${CMAKE_C_COMPILER_ID}" MATCHES "GNU|Clang")
     enableSanitizer("undefined")
   endif()
 
+  find_package(Threads)
   find_package(PkgConfig REQUIRED)
   set(ENV{PKG_CONFIG_PATH}
       "$ENV{PKG_CONFIG_PATH}:${KINESIS_VIDEO_OPEN_SOURCE_SRC}/lib/pkgconfig")

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -41,22 +41,21 @@ STATUS getLocalhostIpAddresses(PKvsIpAddress destIpList, PUINT32 pDestIpListLen,
 
             // If filter is set, ensure the details are collected for the interface
             if(filterSet == TRUE) {
-                 if (ifa->ifa_addr->sa_family == AF_INET) {
+                if (ifa->ifa_addr->sa_family == AF_INET) {
                     destIpList[ipCount].family = KVS_IP_FAMILY_TYPE_IPV4;
                     destIpList[ipCount].port = 0;
                     pIpv4Addr = (struct sockaddr_in *) ifa->ifa_addr;
                     MEMCPY(destIpList[ipCount].address, &pIpv4Addr->sin_addr, IPV4_ADDRESS_LENGTH);
 
-                 } else {
+                } else {
                     destIpList[ipCount].family = KVS_IP_FAMILY_TYPE_IPV6;
                     destIpList[ipCount].port = 0;
                     pIpv6Addr = (struct sockaddr_in6 *) ifa->ifa_addr;
                     MEMCPY(destIpList[ipCount].address, &pIpv6Addr->sin6_addr, IPV6_ADDRESS_LENGTH);
+                }
 
-                 }
-
-                 // in case of overfilling destIpList
-                 ipCount++;
+                // in case of overfilling destIpList
+                ipCount++;
             }
         }
     }

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -874,7 +874,6 @@ STATUS turnConnectionStepState(PTurnConnection pTurnConnection)
     switch (pTurnConnection->state) {
         case TURN_STATE_NEW:
             // find a host address to create new socket
-            // TODO currently we use the first address found. Need to handle case when VPN is involved.
             CHK_STATUS(getLocalhostIpAddresses(localhostIps,
                                                &localhostIpsLen,
                                                pTurnConnection->iceSetInterfaceFilterFunc,

--- a/src/source/Sdp/Deserialize.c
+++ b/src/source/Sdp/Deserialize.c
@@ -9,7 +9,7 @@ STATUS deserializeVersion(UINT64 version, PCHAR *ppOutputData, PUINT32 pTotalWri
 
     currentWriteSize = SNPRINTF(*ppOutputData,
                            (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                           SDP_VERSION_MARKER"%llu\n",
+                           SDP_VERSION_MARKER"%" PRIu64 "\n",
                            version);
 
     CHK(*ppOutputData == NULL || ((*pBufferSize - *pTotalWritten) >= currentWriteSize), STATUS_BUFFER_TOO_SMALL);
@@ -40,7 +40,7 @@ STATUS deserializeOrigin(PSdpOrigin pSDPOrigin, PCHAR *ppOutputData, PUINT32 pTo
 
         currentWriteSize = SNPRINTF(*ppOutputData,
                                (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                               SDP_ORIGIN_MARKER"%s %llu %llu %s %s %s\n",
+                               SDP_ORIGIN_MARKER"%s %" PRIu64 " %" PRIu64 " %s %s %s\n",
                                pSDPOrigin->userName,
                                pSDPOrigin->sessionId,
                                pSDPOrigin->sessionVersion,
@@ -94,7 +94,7 @@ STATUS deserializeTimeDescription(PSdpTimeDescription pSDPTimeDescription, PCHAR
 
     currentWriteSize = SNPRINTF(*ppOutputData,
                            (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                           SDP_TIME_DESCRIPTION_MARKER"%llu %llu\n",
+                           SDP_TIME_DESCRIPTION_MARKER"%" PRIu64 " %" PRIu64 "\n",
                            pSDPTimeDescription->startTime,
                            pSDPTimeDescription->stopTime);
 

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -83,6 +83,9 @@ public:
         channelInfo.reconnect = TRUE;
         channelInfo.pCertPath = mCaCertPath;
         channelInfo.messageTtl = TEST_SIGNALING_MESSAGE_TTL;
+        if ((channelInfo.pRegion = getenv(DEFAULT_REGION_ENV_VAR)) == NULL) {
+            channelInfo.pRegion = (PCHAR) TEST_DEFAULT_REGION;
+        }
 
         retStatus = createSignalingClientSync(&clientInfo, &channelInfo, &signalingClientCallbacks,
                 (PAwsCredentialProvider) mTestCredentialProvider,


### PR DESCRIPTION
…tion

*Issue #, if available:*

*Description of changes:*
fix clang warning: 
/home/ubuntu/workspace/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sdp/Deserialize.c:13:28: warning: format specifies type 'unsigned long long' but the argument has type 'UINT64' (aka 'unsigned long') [-Wformat]
                           version);
                           ^~~~~~~
/home/ubuntu/workspace/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sdp/Deserialize.c:45:32: warning: format specifies type 'unsigned long long' but the argument has type 'UINT64' (aka 'unsigned long') [-Wformat]
                               pSDPOrigin->sessionId,
                               ^~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/workspace/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sdp/Deserialize.c:46:32: warning: format specifies type 'unsigned long long' but the argument has type 'UINT64' (aka 'unsigned long') [-Wformat]
                               pSDPOrigin->sessionVersion,
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/workspace/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sdp/Deserialize.c:98:28: warning: format specifies type 'unsigned long long' but the argument has type 'UINT64' (aka 'unsigned long') [-Wformat]
                           pSDPTimeDescription->startTime,
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ubuntu/workspace/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sdp/Deserialize.c:99:28: warning: format specifies type 'unsigned long long' but the argument has type 'UINT64' (aka 'unsigned long') [-Wformat]
                           pSDPTimeDescription->stopTime);


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
