### PR TITLE
[Issue-124] Remove use of PIC from samples

### DIFF
--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -2,6 +2,8 @@
 
 extern PSampleConfiguration gSampleConfiguration;
 
+// #define VERBOSE
+
 INT32 main(INT32 argc, CHAR *argv[])
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -15,11 +17,16 @@ INT32 main(INT32 argc, CHAR *argv[])
     // do tricketIce by default
     printf("[KVS Master] Using trickleICE by default\n");
 
-    CHK_STATUS(createSampleConfiguration(argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME,
-            SIGNALING_CHANNEL_ROLE_TYPE_MASTER,
-            TRUE,
-            TRUE,
-            &pSampleConfiguration));
+    retStatus = createSampleConfiguration(argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME,
+                                          SIGNALING_CHANNEL_ROLE_TYPE_MASTER,
+                                          TRUE,
+                                          TRUE,
+                                          &pSampleConfiguration);
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] createSampleConfiguration(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
+
     printf("[KVS Master] Created signaling channel %s\n", (argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME));
 
     // Set the audio and video handlers
@@ -32,14 +39,26 @@ INT32 main(INT32 argc, CHAR *argv[])
 
     // Check if the samples are present
 
-    CHK_STATUS(readFrameFromDisk(NULL, &frameSize, "./h264SampleFrames/frame-001.h264"));
+    retStatus = readFrameFromDisk(NULL, &frameSize, "./h264SampleFrames/frame-001.h264");
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] readFrameFromDisk(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
     printf("[KVS Master] Checked sample video frame availability....available\n");
 
-    CHK_STATUS(readFrameFromDisk(NULL, &frameSize, "./opusSampleFrames/sample-001.opus"));
+    retStatus = readFrameFromDisk(NULL, &frameSize, "./opusSampleFrames/sample-001.opus");
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] readFrameFromDisk(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
     printf("[KVS Master] Checked sample audio frame availability....available\n");
 
     // Initialize KVS WebRTC. This must be done before anything else, and must only be done once.
-    CHK_STATUS(initKvsWebRtc());
+    retStatus = initKvsWebRtc();
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] initKvsWebRtc(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
     printf("[KVS Master] KVS WebRTC initialization completed successfully\n");
 
     signalingClientCallbacks.version = SIGNALING_CLIENT_CALLBACKS_CURRENT_VERSION;
@@ -49,17 +68,24 @@ INT32 main(INT32 argc, CHAR *argv[])
     signalingClientCallbacks.customData = (UINT64) pSampleConfiguration;
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
-    STRCPY(clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
+    strcpy(clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 
-    CHK_STATUS(createSignalingClientSync(&clientInfo,
-            &pSampleConfiguration->channelInfo,
-            &signalingClientCallbacks,
-            pSampleConfiguration->pCredentialProvider,
-            &pSampleConfiguration->signalingClientHandle));
+    retStatus = createSignalingClientSync(&clientInfo, &pSampleConfiguration->channelInfo,
+                                          &signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,
+                                          &pSampleConfiguration->signalingClientHandle);
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] createSignalingClientSync(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+
+    }
     printf("[KVS Master] Signaling client created successfully\n");
 
     // Enable the processing of the messages
-    CHK_STATUS(signalingClientConnectSync(pSampleConfiguration->signalingClientHandle));
+    retStatus = signalingClientConnectSync(pSampleConfiguration->signalingClientHandle);
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] signalingClientConnectSync(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
     printf("[KVS Master] Signaling client connection to socket established\n");
 
     gSampleConfiguration = pSampleConfiguration;
@@ -68,29 +94,41 @@ INT32 main(INT32 argc, CHAR *argv[])
             (argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME));
 
     // Checking for termination
-    CHK_STATUS(sessionCleanupWait(pSampleConfiguration));
+    retStatus = sessionCleanupWait(pSampleConfiguration);
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] sessionCleanupWait(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
 
     printf("[KVS Master] Streaming session terminated\n");
 
 CleanUp:
     printf("[KVS Master] Cleaning up....\n");
-    CHK_LOG_ERR_NV(retStatus);
 
     if (pSampleConfiguration != NULL) {
         // Kick of the termination sequence
         ATOMIC_STORE_BOOL(&pSampleConfiguration->appTerminateFlag, TRUE);
 
         // Join the threads
-        if (IS_VALID_TID_VALUE(pSampleConfiguration->videoSenderTid)) {
-            THREAD_JOIN(pSampleConfiguration->videoSenderTid, NULL);
+        if (pSampleConfiguration->videoSenderTid != (UINT64) NULL) {
+           // Join the threads
+           THREAD_JOIN(pSampleConfiguration->videoSenderTid, NULL);
         }
 
-        if (IS_VALID_TID_VALUE(pSampleConfiguration->audioSenderTid)) {
+        if (pSampleConfiguration->audioSenderTid != (UINT64) NULL) {
+            // Join the threads
             THREAD_JOIN(pSampleConfiguration->audioSenderTid, NULL);
         }
 
-        CHK_LOG_ERR_NV(freeSignalingClient(&pSampleConfiguration->signalingClientHandle));
-        CHK_LOG_ERR_NV(freeSampleConfiguration(&pSampleConfiguration));
+        retStatus = freeSignalingClient(&pSampleConfiguration->signalingClientHandle);
+        if(retStatus != STATUS_SUCCESS) {
+            printf("[KVS Master] freeSignalingClient(): operation returned status code: 0x%08x", retStatus);
+        }
+
+        retStatus = freeSampleConfiguration(&pSampleConfiguration);
+        if(retStatus != STATUS_SUCCESS) {
+            printf("[KVS Master] freeSampleConfiguration(): operation returned status code: 0x%08x", retStatus);
+        }
     }
     printf("[KVS Master] Cleanup done\n");
     return (INT32) retStatus;
@@ -101,11 +139,19 @@ STATUS readFrameFromDisk(PBYTE pFrame, PUINT32 pSize, PCHAR frameFilePath)
     STATUS retStatus = STATUS_SUCCESS;
     UINT64 size = 0;
 
-    CHK(pSize != NULL, STATUS_NULL_ARG);
+    if(pSize == NULL) {
+       printf("[KVS Master] readFrameFromDisk(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+       goto CleanUp;
+    }
+
     size = *pSize;
 
     // Get the size and read into frame
-    CHK_STATUS(readFile(frameFilePath, TRUE, pFrame, &size));
+    retStatus = readFile(frameFilePath, TRUE, pFrame, &size);
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] readFile(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
 
 CleanUp:
 
@@ -126,25 +172,44 @@ PVOID sendVideoPackets(PVOID args)
     STATUS status;
     UINT32 i;
 
-    CHK(pSampleConfiguration != NULL, STATUS_NULL_ARG);
+    if(pSampleConfiguration == NULL) {
+        printf("[KVS Master] sendVideoPackets(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+        goto CleanUp;
+    }
 
     frame.presentationTs = 0;
 
     while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->appTerminateFlag)) {
         fileIndex = fileIndex % NUMBER_OF_H264_FRAME_FILES + 1;
-        SNPRINTF(filePath, MAX_PATH_LEN, "./h264SampleFrames/frame-%03d.h264", fileIndex);
-        CHK_STATUS(readFrameFromDisk(NULL, &frameSize, filePath));
+        snprintf(filePath, MAX_PATH_LEN, "./h264SampleFrames/frame-%03d.h264", fileIndex);
+
+        retStatus = readFrameFromDisk(NULL, &frameSize, filePath);
+        if(retStatus != STATUS_SUCCESS) {
+            printf("[KVS Master] readFrameFromDisk(): operation returned status code: 0x%08x \n", retStatus);
+            goto CleanUp;
+        }
 
         // Re-alloc if needed
         if (frameSize > pSampleConfiguration->videoBufferSize) {
-            CHK(NULL != (pSampleConfiguration->pVideoFrameBuffer = (PBYTE) MEMREALLOC(pSampleConfiguration->pVideoFrameBuffer, frameSize)), STATUS_NOT_ENOUGH_MEMORY);
+            pSampleConfiguration->pVideoFrameBuffer = (PBYTE) realloc(pSampleConfiguration->pVideoFrameBuffer, frameSize);
+            if(pSampleConfiguration->pVideoFrameBuffer == NULL)
+            {
+                printf("[KVS Master] Video frame Buffer reallocation failed...%s (code %d)\n", strerror(errno), errno);
+                printf("[KVS Master] realloc(): operation returned status code: 0x%08x \n", STATUS_NOT_ENOUGH_MEMORY);
+                goto CleanUp;
+            }
+
             pSampleConfiguration->videoBufferSize = frameSize;
         }
 
         frame.frameData = pSampleConfiguration->pVideoFrameBuffer;
         frame.size = frameSize;
 
-        CHK_STATUS(readFrameFromDisk(frame.frameData, &frameSize, filePath));
+        retStatus = readFrameFromDisk(frame.frameData, &frameSize, filePath);
+        if(retStatus != STATUS_SUCCESS) {
+            printf("[KVS Master] readFrameFromDisk(): operation returned status code: 0x%08x \n", retStatus);
+            goto CleanUp;
+        }
 
         frame.presentationTs += SAMPLE_VIDEO_FRAME_DURATION;
 
@@ -152,19 +217,19 @@ PVOID sendVideoPackets(PVOID args)
             ATOMIC_INCREMENT(&pSampleConfiguration->streamingSessionListReadingThreadCount);
             for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
                 status = writeFrame(pSampleConfiguration->sampleStreamingSessionList[i]->pVideoRtcRtpTransceiver, &frame);
-                if (STATUS_FAILED(status)) {
-                    DLOGD("writeFrame failed with 0x%08x", status);
+                if (status != STATUS_SUCCESS) {
+                    #ifdef VERBOSE
+                        printf("writeFrame() failed with 0x%08x", status);
+                    #endif
                 }
             }
             ATOMIC_DECREMENT(&pSampleConfiguration->streamingSessionListReadingThreadCount);
         }
-
         THREAD_SLEEP(SAMPLE_VIDEO_FRAME_DURATION);
     }
 
 CleanUp:
 
-    CHK_LOG_ERR_NV(retStatus);
     return (PVOID) (ULONG_PTR) retStatus;
 }
 
@@ -178,25 +243,41 @@ PVOID sendAudioPackets(PVOID args)
     UINT32 i;
     STATUS status;
 
-    CHK(pSampleConfiguration != NULL, STATUS_NULL_ARG);
+    if(pSampleConfiguration == NULL) {
+        printf("[KVS Master] sendAudioPackets(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+        goto CleanUp;
+    }
 
     frame.presentationTs = 0;
 
     while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->appTerminateFlag)) {
         fileIndex = fileIndex % NUMBER_OF_OPUS_FRAME_FILES + 1;
-        SNPRINTF(filePath, MAX_PATH_LEN, "./opusSampleFrames/sample-%03d.opus", fileIndex);
-        CHK_STATUS(readFrameFromDisk(NULL, &frameSize, filePath));
+        snprintf(filePath, MAX_PATH_LEN, "./opusSampleFrames/sample-%03d.opus", fileIndex);
+
+        retStatus = readFrameFromDisk(NULL, &frameSize, filePath);
+        if(retStatus != STATUS_SUCCESS) {
+            printf("[KVS Master] readFrameFromDisk(): operation returned status code: 0x%08x \n", retStatus);
+            goto CleanUp;
+        }
 
         // Re-alloc if needed
         if (frameSize > pSampleConfiguration->audioBufferSize) {
-            CHK(NULL != (pSampleConfiguration->pAudioFrameBuffer = (PBYTE) MEMREALLOC(pSampleConfiguration->pAudioFrameBuffer, frameSize)), STATUS_NOT_ENOUGH_MEMORY);
-            pSampleConfiguration->audioBufferSize = frameSize;
+            pSampleConfiguration->pAudioFrameBuffer = (uint8_t*) realloc(pSampleConfiguration->pAudioFrameBuffer, frameSize);
+            if(pSampleConfiguration->pAudioFrameBuffer == NULL) {
+                printf("[KVS Master] Audio frame Buffer reallocation failed...%s (code %d)\n", strerror(errno), errno);
+                printf("[KVS Master] realloc(): operation returned status code: 0x%08x \n", STATUS_NOT_ENOUGH_MEMORY);
+                goto CleanUp;
+            }
         }
 
         frame.frameData = pSampleConfiguration->pAudioFrameBuffer;
         frame.size = frameSize;
 
-        CHK_STATUS(readFrameFromDisk(frame.frameData, &frameSize, filePath));
+        retStatus = readFrameFromDisk(frame.frameData, &frameSize, filePath);
+        if(retStatus != STATUS_SUCCESS) {
+            printf("[KVS Master] readFrameFromDisk(): operation returned status code: 0x%08x \n", retStatus);
+            goto CleanUp;
+        }
 
         frame.presentationTs += SAMPLE_AUDIO_FRAME_DURATION;
 
@@ -204,19 +285,17 @@ PVOID sendAudioPackets(PVOID args)
             ATOMIC_INCREMENT(&pSampleConfiguration->streamingSessionListReadingThreadCount);
             for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
                 status = writeFrame(pSampleConfiguration->sampleStreamingSessionList[i]->pAudioRtcRtpTransceiver, &frame);
-                if (STATUS_FAILED(status)) {
-                    DLOGD("writeFrame failed with 0x%08x", status);
+                if (status != STATUS_SUCCESS) {
+                    printf("writeFrame failed with 0x%08x", status);
                 }
             }
             ATOMIC_DECREMENT(&pSampleConfiguration->streamingSessionListReadingThreadCount);
         }
-
         THREAD_SLEEP(SAMPLE_AUDIO_FRAME_DURATION);
     }
 
 CleanUp:
 
-    CHK_LOG_ERR_NV(retStatus);
     return (PVOID) (ULONG_PTR) retStatus;
 }
 
@@ -224,13 +303,21 @@ PVOID sampleReceiveAudioFrame(PVOID args)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PSampleStreamingSession pSampleStreamingSession = (PSampleStreamingSession) args;
-    CHK(pSampleStreamingSession != NULL, STATUS_NULL_ARG);
+    if(pSampleStreamingSession == NULL) {
+        printf("[KVS Master] sampleReceiveAudioFrame(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+        goto CleanUp;
+    }
 
-    CHK_STATUS(transceiverOnFrame(pSampleStreamingSession->pAudioRtcRtpTransceiver,
-                       (UINT64) pSampleStreamingSession,
-                       sampleFrameHandler));
+    retStatus = transceiverOnFrame(pSampleStreamingSession->pAudioRtcRtpTransceiver,
+                                   (UINT64) pSampleStreamingSession,
+                                   sampleFrameHandler);
+    if(retStatus != STATUS_SUCCESS)
+    {
+        printf("[KVS Master] transceiverOnFrame(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+        goto CleanUp;
+    }
+
 CleanUp:
 
-    CHK_LOG_ERR_NV(retStatus);
     return (PVOID) (ULONG_PTR) retStatus;
 }


### PR DESCRIPTION
*Issue #, if available: #124 *

*Description of changes:*

- Replaced use of PIC Functions such as CHK_STATUS, CHK and CHK_ERROR with standard C calls from sample
- Removed used of other PiC functions wherever applicable and replaced with standard C functions.
- Removed use of DLOG functions. 

Resolves #124 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
