### PR TITLE
Fix some potential memory leak in peer connection and jitterbuffer

### DIFF
--- a/src/source/Rtp/RtpPacket.c
+++ b/src/source/Rtp/RtpPacket.c
@@ -108,7 +108,6 @@ STATUS createRtpPacketFromBytes(PBYTE rawPacket, UINT32 packetLength, PRtpPacket
     CHK(pRtpPacket != NULL, STATUS_NOT_ENOUGH_MEMORY);
     pRtpPacket->pRawPacket = rawPacket;
     pRtpPacket->rawPacketLength = packetLength;
-    CHK(pRtpPacket != NULL, STATUS_NOT_ENOUGH_MEMORY);
     CHK_STATUS(setRtpPacketFromBytes(rawPacket, packetLength, pRtpPacket));
 
 CleanUp:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Travis reported some leaks in createRtpPacket, as the ownership was handed over to jitter buffer, it need to clean up the rtp packets.
https://travis-ci.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/jobs/296211416

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
