### PR TITLE
Add kvsCommonLws to target_link_libraries for kvsWebRTCClientMasterGs…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,22 +437,23 @@ target_link_libraries(
 add_library(kvsWebrtcSignalingClient ${LINKAGE}
             ${WEBRTC_SIGNALING_CLIENT_SOURCE_FILES})
 
-target_link_libraries(kvsWebrtcSignalingClient PRIVATE kvspicUtils kvspicState
-                      kvspicClient kvsCommonLws)
+target_link_libraries(kvsWebrtcSignalingClient
+        PRIVATE kvspicUtils kvspicState kvspicClient
+        PUBLIC kvsCommonLws)
 
 add_executable(
   kvsWebrtcClientMaster
   ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}/samples/Common.c
   ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}/samples/kvsWebRTCClientMaster.c)
 target_link_libraries(kvsWebrtcClientMaster kvsWebrtcClient
-                      kvsWebrtcSignalingClient kvsCommonLws)
+                      kvsWebrtcSignalingClient)
 
 add_executable(
   kvsWebrtcClientViewer
   ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}/samples/Common.c
   ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}/samples/kvsWebRTCClientViewer.c)
 target_link_libraries(kvsWebrtcClientViewer kvsWebrtcClient
-                      kvsWebrtcSignalingClient kvsCommonLws)
+                      kvsWebrtcSignalingClient)
 
 if(COMPILER_WARNINGS)
   target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)


### PR DESCRIPTION
…treamerSample

Fixes
```
/usr/bin/ld: CMakeFiles/kvsWebrtcClientMasterGstSample.dir/samples/Common.c.o: in function `createSampleConfiguration':
Common.c:(.text+0x1f0e): undefined reference to `createStaticCredentialProvider'
/usr/bin/ld: CMakeFiles/kvsWebrtcClientMasterGstSample.dir/samples/Common.c.o: in function `freeSampleConfiguration':
Common.c:(.text+0x22a0): undefined reference to `freeStaticCredentialProvider'
collect2: error: ld returned 1 exit status
```
