### PR TITLE
Fix deserializeRtcIceCandidateInit

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -785,7 +785,7 @@ STATUS deserializeRtcIceCandidateInit(PCHAR pJson, UINT32 jsonLen, PRtcIceCandid
     CHK(tokenCount > 1, STATUS_INVALID_API_CALL_RETURN_JSON);
     CHK(tokens[0].type == JSMN_OBJECT, STATUS_ICE_CANDIDATE_INIT_MALFORMED);
 
-    for (i = 1; i < (tokenCount - 1); i++) {
+    for (i = 1; i < (tokenCount - 1); i += 2) {
         if (STRNCMP(CANDIDATE_KEY, pJson + tokens[i].start, ARRAY_SIZE(CANDIDATE_KEY) - 1) == 0) {
             STRNCPY(pRtcIceCandidateInit->candidate, pJson + tokens[i + 1].start, (tokens[i + 1].end - tokens[i + 1].start));
         }

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -26,6 +26,10 @@ TEST_F(PeerConnectionApiTest, deserializeRtcIceCandidateInit)
     auto validCandidate = "{candidate: \"foobar\"}";
     EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) validCandidate, STRLEN(validCandidate), &rtcIceCandidateInit), STATUS_SUCCESS);
     EXPECT_STREQ(rtcIceCandidateInit.candidate, "foobar");
+
+    auto validCandidate2 = "{candidate: \"candidate: 1 2 3\", \"sdpMid\": 0}";
+    EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) validCandidate2, STRLEN(validCandidate2), &rtcIceCandidateInit), STATUS_SUCCESS);
+    EXPECT_STREQ(rtcIceCandidateInit.candidate, "candidate: 1 2 3");
 }
 
 TEST_F(PeerConnectionApiTest, serializeSessionDescriptionInit)


### PR DESCRIPTION
When looking for the `candidate` key we would improperly inspect values
also. If a value began with `candidate` we would assume it was a key and
would take the next value.

Instead properly iterate only through keys.

Resolves #268
