### PR TITLE
When constructing a RTP packet SeqNum must be big endian

### DIFF
--- a/src/source/Rtp/RtpPacket.c
+++ b/src/source/Rtp/RtpPacket.c
@@ -135,7 +135,7 @@ STATUS constructRetransmitRtpPacketFromBytes(PBYTE rawPacket, UINT32 packetLengt
     pPayload = (PBYTE) MEMALLOC(pRtpPacket->payloadLength + SIZEOF(UINT16));
     CHK(pPayload != NULL, STATUS_NOT_ENOUGH_MEMORY);
     // Retransmission payload header is OSN original sequence number
-    putInt16((PINT16) pPayload, pRtpPacket->header.sequenceNumber);
+    putUnalignedInt16BigEndian((PINT16) pPayload, pRtpPacket->header.sequenceNumber);
     MEMCPY(pPayload + SIZEOF(UINT16), pRtpPacket->payload, pRtpPacket->payloadLength);
     pRtpPacket->payloadLength += SIZEOF(UINT16);
     pRtpPacket->payload = pPayload;


### PR DESCRIPTION
Don't use putInt16, we don't want host aware operations.

Co-authored-by: Alex Zhukov <alex.zhukov@uber.com>
