### PR TITLE
in socketConnection, also store socket's ip address. Reduce ssl error…

### DIFF
--- a/src/source/Ice/SocketConnection.h
+++ b/src/source/Ice/SocketConnection.h
@@ -21,6 +21,7 @@ struct __SocketConnection {
     INT32 localSocket;
     KVS_SOCKET_PROTOCOL protocol;
     KvsIpAddress peerIpAddr;
+    KvsIpAddress hostIpAddr;
 
     BOOL secureConnection;
     SSL_CTX *pSslCtx;


### PR DESCRIPTION
in socketConnection, also store socket's ip address. Reduce ssl error log from socketConnectionReadData

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
