### PR TITLE
generateJSONSafeString randBuffer msan

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -429,7 +429,7 @@ STATUS generateJSONSafeString(PCHAR pDst, UINT32 len)
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     UINT32 i = 0;
-    BYTE randBuffer[MAX_RAND_BUFFER_SIZE_FOR_NAME];
+    BYTE randBuffer[MAX_RAND_BUFFER_SIZE_FOR_NAME] = {0};
 
     CHK(pDst != NULL, STATUS_NULL_ARG);
     CHK(RAND_bytes(randBuffer, MIN(len, MAX_RAND_BUFFER_SIZE_FOR_NAME)), STATUS_INTERNAL_ERROR );

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -702,10 +702,11 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     PCHAR remoteIceUfrag = NULL, remoteIcePwd = NULL;
     UINT32 i, j;
 
+    CHK(pPeerConnection != NULL, STATUS_NULL_ARG);
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
     PSessionDescription pSessionDescription = &(pKvsPeerConnection->remoteSessionDescription);
 
-    CHK(pPeerConnection != NULL && pSessionDescriptionInit != NULL, STATUS_NULL_ARG);
+    CHK(pSessionDescriptionInit != NULL, STATUS_NULL_ARG);
 
     MEMSET(pSessionDescription, 0x00, SIZEOF(SessionDescription));
     pKvsPeerConnection->dtlsIsServer = FALSE;


### PR DESCRIPTION
our memory sanitizer complains about the use of uninitialized memory here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
