### PR TITLE
potential IceAgent deadlock

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -490,6 +490,7 @@ STATUS iceAgentSendPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen)
     // can be invoking incomingDataHandler and cause deadlock.
     // pIceAgent->lock has to be non-reentrant !!
     MUTEX_UNLOCK(pIceAgent->lock);
+    locked = FALSE;
 
     retStatus = iceUtilsSendData(pBuffer,
                                  bufferLen,

--- a/src/source/Ice/IceAgentStateMachine.c
+++ b/src/source/Ice/IceAgentStateMachine.c
@@ -200,15 +200,16 @@ STATUS executeNewIceAgentState(UINT64 customData, UINT64 time)
     UNUSED_PARAM(time);
     STATUS retStatus = STATUS_SUCCESS;
     PIceAgent pIceAgent = (PIceAgent) customData;
+    BOOL locked = FALSE;
 
     CHK(pIceAgent != NULL, STATUS_NULL_ARG);
     // return early if we are already in ICE_AGENT_STATE_GATHERING
     CHK(pIceAgent->iceAgentState != ICE_AGENT_STATE_NEW, retStatus);
 
-    pIceAgent->iceAgentState = ICE_AGENT_STATE_NEW;
-
     //assumes this is called while holding pIceAgent->lock
-    BOOL locked = TRUE;
+    locked = TRUE;
+
+    pIceAgent->iceAgentState = ICE_AGENT_STATE_NEW;
 
     //unlocking here to make thread sanitizer happy
 

--- a/src/source/Ice/IceAgentStateMachine.c
+++ b/src/source/Ice/IceAgentStateMachine.c
@@ -200,14 +200,12 @@ STATUS executeNewIceAgentState(UINT64 customData, UINT64 time)
     UNUSED_PARAM(time);
     STATUS retStatus = STATUS_SUCCESS;
     PIceAgent pIceAgent = (PIceAgent) customData;
-    BOOL locked = FALSE;
+    //assumes this is called while holding pIceAgent->lock
+    BOOL locked = TRUE;
 
     CHK(pIceAgent != NULL, STATUS_NULL_ARG);
     // return early if we are already in ICE_AGENT_STATE_GATHERING
     CHK(pIceAgent->iceAgentState != ICE_AGENT_STATE_NEW, retStatus);
-
-    //assumes this is called while holding pIceAgent->lock
-    locked = TRUE;
 
     pIceAgent->iceAgentState = ICE_AGENT_STATE_NEW;
 


### PR DESCRIPTION
*Issue #, if available:*
Thread sanitizer is unhappy about timer queue executor lock
*Description of changes:*
unlock `iceagent.lock` while submitting `iceAgentStateTransitionTimerCallback` to timer queue

WARNING: i don't really know what i'm doing, so please scrutinize this PR   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
