### PR TITLE
Add support for test source in GStreamer sample

### DIFF
--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -40,6 +40,7 @@ typedef struct {
     volatile ATOMIC_BOOL updatingSampleStreamingSessionList;
     volatile ATOMIC_BOOL recreateSignalingClient;
     volatile SIZE_T streamingSessionListReadingThreadCount;
+    BOOL useTestSrc;
     ChannelInfo channelInfo;
     PCHAR pCaCertPath;
     PAwsCredentialProvider pCredentialProvider;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a command line option to select test source for GStreamer pipeline. It would be useful for testing basic sample functionality on systems with no camera attached to get the frame

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
