### PR TITLE
start dtlsSession when Ice is connected. Make sure dtleSessionStart d…

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -273,10 +273,12 @@ VOID onIceConnectionStateChange(UINT64 customData, UINT64 connectionState)
             break;
 
         case ICE_AGENT_STATE_CONNECTED:
-            // explicit fall-through
+            /* explicit fall-through */
         case ICE_AGENT_STATE_NOMINATING:
-            // explicit fall-through
+            /* explicit fall-through */
         case ICE_AGENT_STATE_READY:
+            /* start dtlsSession as soon as ice is connected */
+            CHK_STATUS(dtlsSessionStart(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->dtlsIsServer));
             newConnectionState = RTC_PEER_CONNECTION_STATE_CONNECTED;
             break;
 
@@ -740,7 +742,6 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     CHK(remoteIceUfrag != NULL && remoteIcePwd != NULL, STATUS_SESSION_DESCRIPTION_MISSING_ICE_VALUES);
     CHK(pKvsPeerConnection->remoteCertificateFingerprint[0] != '\0', STATUS_SESSION_DESCRIPTION_MISSING_CERTIFICATE_FINGERPRINT);
 
-    CHK_STATUS(dtlsSessionStart(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->dtlsIsServer));
     CHK_STATUS(iceAgentStartAgent(pKvsPeerConnection->pIceAgent, remoteIceUfrag, remoteIcePwd, pKvsPeerConnection->isOffer));
     if (!pKvsPeerConnection->isOffer) {
         CHK_STATUS(setPayloadTypesFromOffer(pKvsPeerConnection->pCodecTable, pKvsPeerConnection->pRtxTable, pSessionDescription));


### PR DESCRIPTION
…ont get executed again once started.
*Issue #, if available:*

*Description of changes:*
Previously we call dtlsSessionStart along with IceAgentStartAgent, at that time ice is not connected yet, so if dtls need to initiate a handshake, the packet it sends will be lost. Only until dtls handshake timeout is hit will it retransmit handshake again. On my laptop there was noticeable reduction in time it took for picture to show up in JS viewer when running the master sample using relay only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
