### PR TITLE
Fix incorrect rtp raw packet size

### DIFF
--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -199,7 +199,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         CHK_STATUS(createBytesFromRtpPacket(pRtpPacket, NULL, &packetLen));
 
         // Account for SRTP authentication tag
-        allocSize = bufferAfterEncrypt ? packetLen + SRTP_AUTH_TAG_OVERHEAD : packetLen;
+        allocSize = packetLen + SRTP_AUTH_TAG_OVERHEAD;
         CHK(NULL != (rawPacket = (PBYTE) MEMALLOC(allocSize)), STATUS_NOT_ENOUGH_MEMORY);
         CHK_STATUS(createBytesFromRtpPacket(pRtpPacket, rawPacket, &packetLen));
 


### PR DESCRIPTION
* Issue #380 

* Description of changes:
Update raw rtp packet size to be big enough to include SRTP_AUTH_TAG_OVERHEAD


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
