### PR TITLE
Add IPv6 support for host candidates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,9 @@ matrix:
     - name: "Linux GCC Code Coverage"
       os: linux
       compiler: gcc
+      before_install:
+        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script:
         - mkdir build && cd build && cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
       after_success:
@@ -71,6 +74,9 @@ matrix:
       env:
         - ASAN_OPTIONS=detect_odr_violation=0:detect_leaks=1
         - LSAN_OPTIONS=suppressions=../tst/suppressions/LSAN.supp
+      before_install:
+        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
 
     # UndefinedBehaviorSanitizer
@@ -78,11 +84,17 @@ matrix:
       os: linux
       compiler: clang
       env: UBSAN_OPTIONS=halt_on_error=1
+      before_install:
+        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
 
     # MemorySanitizer
     - name: "Linux Clang MemorySanitizer"
       before_install:
+        # TODO: Remove the following 2 lines. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
         - mkdir build
         - docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -w /src/build -dit --name msan-tester -v $(pwd):/src seaduboi/kvs-msan-tester
         - msan-tester() { docker exec -it msan-tester "$@"; }
@@ -97,12 +109,17 @@ matrix:
       os: linux
       compiler: clang
       env: TSAN_OPTIONS=halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
+      before_install:
+        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
 
     # Old Version GCC 4.4
     - name: "Linux GCC 4.4 Build"
       os: linux
       before_install:
+        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
         - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
         - sudo apt-get -q update
         - sudo apt-get -y install gcc-4.4
@@ -113,6 +130,9 @@ matrix:
     # Static Build
     - name: "Static Build"
       before_install:
+        # TODO: Remove the following 2 lines. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+        - sudo service docker restart
         - mkdir build
         - docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -w /src/build -dit --name alpine -v $(pwd):/src alpine
         - alpine() { docker exec -it alpine "$@"; }
@@ -135,6 +155,9 @@ matrix:
             - g++-arm-linux-gnueabi
             - binutils-arm-linux-gnueabi
       compiler: gcc
+      before_install:
+        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script:
         - export CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++
         - mkdir build && cd build

--- a/src/source/Ice/IceUtils.c
+++ b/src/source/Ice/IceUtils.c
@@ -185,45 +185,6 @@ CleanUp:
     return retStatus;
 }
 
-// only work with ipv4 right now
-STATUS populateIpFromString(PKvsIpAddress pKvsIpAddress, PCHAR pBuff)
-{
-    ENTERS();
-    STATUS retStatus = STATUS_SUCCESS;
-    PCHAR curr, tail, next;
-    UINT8 octet = 0;
-    UINT32 ipValue;
-
-    CHK(pKvsIpAddress != NULL && pBuff != NULL, STATUS_NULL_ARG);
-    CHK(STRNLEN(pBuff, KVS_MAX_IPV4_ADDRESS_STRING_LEN) > 0, STATUS_INVALID_ARG);
-
-    curr = pBuff;
-    tail = pBuff + STRLEN(pBuff);
-    // first 3 octet should always end with a '.', the last octet may end with ' ' or '\0'
-    while ((next = STRNCHR(curr, tail - curr, '.')) != NULL && octet < 3) {
-        CHK_STATUS(STRTOUI32(curr, curr + (next - curr), 10, &ipValue));
-        pKvsIpAddress->address[octet] = (UINT8) ipValue;
-        octet++;
-
-        curr = next + 1;
-    }
-
-    // work with string containing just ip address and string that has ip address as substring
-    if ((next = STRNCHR(curr, tail - curr, ' ')) != NULL || (next = STRNCHR(curr, tail - curr, '\0')) != NULL) {
-        CHK_STATUS(STRTOUI32(curr, curr + (next - curr), 10, &ipValue));
-        pKvsIpAddress->address[octet] = (UINT8) ipValue;
-        octet++;
-    }
-
-    CHK(octet == 4, STATUS_ICE_CANDIDATE_STRING_INVALID_IP); // IPv4 MUST have 4 octets
-CleanUp:
-
-    CHK_LOG_ERR(retStatus);
-
-    LEAVES();
-    return retStatus;
-}
-
 STATUS parseIceServer(PIceServer pIceServer, PCHAR url, PCHAR username, PCHAR credential)
 {
     ENTERS();

--- a/src/source/Ice/IceUtils.h
+++ b/src/source/Ice/IceUtils.h
@@ -37,8 +37,6 @@ STATUS iceUtilsPackageStunPacket(PStunPacket, PBYTE, UINT32, PBYTE, PUINT32);
 STATUS iceUtilsSendStunPacket(PStunPacket, PBYTE, UINT32, PKvsIpAddress, PSocketConnection, struct __TurnConnection*, BOOL);
 STATUS iceUtilsSendData(PBYTE, UINT32, PKvsIpAddress, PSocketConnection, struct __TurnConnection*, BOOL);
 
-STATUS populateIpFromString(PKvsIpAddress, PCHAR);
-
 typedef struct {
     BOOL isTurn;
     CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -51,6 +51,12 @@ STATUS getLocalhostIpAddresses(PKvsIpAddress destIpList, PUINT32 pDestIpListLen,
                     destIpList[ipCount].family = KVS_IP_FAMILY_TYPE_IPV6;
                     destIpList[ipCount].port = 0;
                     pIpv6Addr = (struct sockaddr_in6 *) ifa->ifa_addr;
+                    // Ignore link local: not very useful and will add work unnecessarily
+                    // Ignore site local: https://tools.ietf.org/html/rfc8445#section-5.1.1.1
+                    if (IN6_IS_ADDR_LINKLOCAL(&pIpv6Addr->sin6_addr) ||
+                        IN6_IS_ADDR_SITELOCAL(&pIpv6Addr->sin6_addr)) {
+                      continue;
+                    }
                     MEMCPY(destIpList[ipCount].address, &pIpv6Addr->sin6_addr, IPV6_ADDRESS_LENGTH);
                 }
 

--- a/tst/IceApiTest.cpp
+++ b/tst/IceApiTest.cpp
@@ -91,33 +91,6 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
         EXPECT_EQ(STATUS_SUCCESS, freeStunPacket(&pStunPacket));
         EXPECT_EQ(STATUS_SUCCESS, freeTransactionIdStore(&pTransactionIdStore));
     }
-
-    TEST_F(IceApiTest, IceUtilPopulateIpFromStringTest)
-    {
-        KvsIpAddress kvsIpAddress;
-        PCHAR ipString = (PCHAR) "16.213.65.123";
-        BYTE expectIpAddr[IPV4_ADDRESS_LENGTH] = {0x10, 0xD5, 0x41, 0x7B};
-        PCHAR ipString2 = (PCHAR) "255.255.255.255";
-        PCHAR ipString2Longer = (PCHAR) "255.255.255.255 34388 222.222.222.222";
-        BYTE expectIpAddr2[IPV4_ADDRESS_LENGTH] = {0xFF, 0xFF, 0xFF, 0xFF};
-
-        MEMSET(&kvsIpAddress, 0x0, SIZEOF(KvsIpAddress));
-
-        EXPECT_NE(STATUS_SUCCESS, populateIpFromString(NULL, NULL));
-        EXPECT_NE(STATUS_SUCCESS, populateIpFromString(&kvsIpAddress, NULL));
-        EXPECT_NE(STATUS_SUCCESS, populateIpFromString(&kvsIpAddress, (PCHAR) ""));
-        EXPECT_NE(STATUS_SUCCESS, populateIpFromString(NULL, ipString));
-
-        EXPECT_EQ(STATUS_SUCCESS, populateIpFromString(&kvsIpAddress, ipString));
-        EXPECT_EQ(0, MEMCMP(expectIpAddr, kvsIpAddress.address, IPV4_ADDRESS_LENGTH));
-
-        EXPECT_EQ(STATUS_SUCCESS, populateIpFromString(&kvsIpAddress, ipString2));
-        EXPECT_EQ(0, MEMCMP(expectIpAddr2, kvsIpAddress.address, IPV4_ADDRESS_LENGTH));
-
-        EXPECT_EQ(STATUS_SUCCESS, populateIpFromString(&kvsIpAddress, ipString2Longer));
-        EXPECT_EQ(0, MEMCMP(expectIpAddr2, kvsIpAddress.address, IPV4_ADDRESS_LENGTH));
-    }
-
 }
 }
 }

--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -366,7 +366,7 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
         EXPECT_NE(STATUS_SUCCESS, findCandidateWithIp(&ipAddress, NULL, NULL));
         EXPECT_NE(STATUS_SUCCESS, findCandidateWithIp(&ipAddress, &candidateList, NULL));
 
-        EXPECT_EQ(STATUS_SUCCESS, populateIpFromString(&ipAddress, (PCHAR) "127.0.0.1"));
+        EXPECT_EQ(1, inet_pton(AF_INET, (PCHAR) "127.0.0.1", &ipAddress.address));
         ipAddress.port = 123;
         ipAddress.family = KVS_IP_FAMILY_TYPE_IPV4;
         EXPECT_EQ(STATUS_SUCCESS, findCandidateWithIp(&ipAddress, &candidateList, &pIceCandidate));
@@ -382,12 +382,12 @@ namespace com { namespace amazonaws { namespace kinesis { namespace video { name
         EXPECT_EQ(NULL, pIceCandidate);
 
         ipAddress.family = KVS_IP_FAMILY_TYPE_IPV4;
-        EXPECT_EQ(STATUS_SUCCESS, populateIpFromString(&ipAddress, (PCHAR) "127.0.0.2"));
+        EXPECT_EQ(1, inet_pton(AF_INET, (PCHAR) "127.0.0.2", &ipAddress.address));
         EXPECT_EQ(STATUS_SUCCESS, findCandidateWithIp(&ipAddress, &candidateList, &pIceCandidate));
         // address not match
         EXPECT_EQ(NULL, pIceCandidate);
 
-        EXPECT_EQ(STATUS_SUCCESS, populateIpFromString(&ipAddress, (PCHAR) "127.0.0.1"));
+        EXPECT_EQ(1, inet_pton(AF_INET, (PCHAR) "127.0.0.1", &ipAddress.address));
         ipAddress.port = 124;
         EXPECT_EQ(STATUS_SUCCESS, findCandidateWithIp(&ipAddress, &candidateList, &pIceCandidate));
         // port not match


### PR DESCRIPTION
* Issue #115 

* Description of changes:
  * Add IPv6 support for host candidates
  * Refractor `iceAgentAddRemoteCandidate`

* Todo:
  * Add IPv6 support for reflexive candidates
    * Verify the XOR mapped address for IPv6 implementation follows STUN RFC, https://tools.ietf.org/html/rfc5389#section-15.2 (https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/394)
  * Add IPv6 support for TURN, https://tools.ietf.org/html/rfc6156
  * Update `getIpWithHostName` to use `getaddrinfo` instead of `gethostbyname` since `gethostbyname` doesn't support IPv6 (https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/395)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
