### PR TITLE
Switch to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -40,7 +40,7 @@ function(build_dependency lib_name)
 
   # build library
   configure_file(
-    ${CMAKE_SOURCE_DIR}/CMake/Dependencies/lib${lib_name}-CMakeLists.txt
+    ${CMAKE_CURRENT_SOURCE_DIR}/Dependencies/lib${lib_name}-CMakeLists.txt
     ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/lib${lib_name}/CMakeLists.txt COPYONLY)
   execute_process(
     COMMAND ${CMAKE_COMMAND} ${build_args}

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -40,7 +40,7 @@ function(build_dependency lib_name)
 
   # build library
   configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/Dependencies/lib${lib_name}-CMakeLists.txt
+    ./CMake/Dependencies/lib${lib_name}-CMakeLists.txt
     ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/lib${lib_name}/CMakeLists.txt COPYONLY)
   execute_process(
     COMMAND ${CMAKE_COMMAND} ${build_args}


### PR DESCRIPTION
Resolves #389

*Issue #389
*Description of changes: Replace CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
