### PR TITLE
free dtleSession before ice shutdown so dtlsSession's timer wont sent…

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -493,8 +493,6 @@ STATUS iceAgentSendPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen)
     STATUS retStatus = STATUS_SUCCESS;
     BOOL locked = FALSE;
 
-    SocketConnection socketConnection;
-    KvsIpAddress destAddr;
     BOOL isRelay = FALSE;
     PTurnConnection pTurnConnection = NULL;
 
@@ -507,10 +505,6 @@ STATUS iceAgentSendPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen)
     CHK_WARN(pIceAgent->pDataSendingIceCandidatePair != NULL, retStatus, "No valid ice candidate pair available to send data");
 
     pIceAgent->pDataSendingIceCandidatePair->lastDataSentTime = GETTIME();
-
-    // Construct context
-    socketConnection = *pIceAgent->pDataSendingIceCandidatePair->local->pSocketConnection;
-    destAddr = pIceAgent->pDataSendingIceCandidatePair->remote->ipAddress;
     isRelay = IS_CANN_PAIR_SENDING_FROM_RELAYED(pIceAgent->pDataSendingIceCandidatePair);
 
     if (isRelay) {
@@ -521,8 +515,8 @@ STATUS iceAgentSendPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen)
 
     retStatus = iceUtilsSendData(pBuffer,
                                  bufferLen,
-                                 &destAddr,
-                                 &socketConnection,
+                                 &pIceAgent->pDataSendingIceCandidatePair->remote->ipAddress,
+                                 pIceAgent->pDataSendingIceCandidatePair->local->pSocketConnection,
                                  pTurnConnection,
                                  isRelay);
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -535,6 +535,8 @@ STATUS freePeerConnection(PRtcPeerConnection *ppPeerConnection)
 
     CHK(pKvsPeerConnection != NULL, retStatus);
 
+    /* Free dtlsSession before ice to stop dtlsSession's timer from sending anymore data. */
+    CHK_LOG_ERR(freeDtlsSession(&pKvsPeerConnection->pDtlsSession));
     CHK_LOG_ERR(iceAgentShutdown(pKvsPeerConnection->pIceAgent));
 
     // free timer queue first to remove liveness provided by timer
@@ -563,7 +565,6 @@ STATUS freePeerConnection(PRtcPeerConnection *ppPeerConnection)
 
     // free rest of structs
     CHK_LOG_ERR(freeSrtpSession(&pKvsPeerConnection->pSrtpSession));
-    CHK_LOG_ERR(freeDtlsSession(&pKvsPeerConnection->pDtlsSession));
     CHK_LOG_ERR(doubleListFree(pKvsPeerConnection->pTransceievers));
     CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pCodecTable));
     CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pRtxTable));


### PR DESCRIPTION
… anymore data through ice while ice is shutting down.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
