### PR TITLE
Update getIpWithHostName to use getaddrinfo

### DIFF
--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -183,20 +183,32 @@ CleanUp:
 STATUS getIpWithHostName(PCHAR hostname, PKvsIpAddress destIp)
 {
     STATUS retStatus = STATUS_SUCCESS;
+    UINT32 errCode;
+    struct addrinfo *res, *rp;
+    BOOL resolved = FALSE;
+    struct sockaddr_in *ipv4Addr;
+    struct sockaddr_in6 *ipv6Addr;
 
     CHK(hostname != NULL, STATUS_NULL_ARG);
 
-    struct hostent *entry = gethostbyname(hostname);
-    CHK_ERR(entry != NULL, STATUS_RESOLVE_HOSTNAME_FAILED, "gethostbyname() with errno %s", strerror(errno));
-    CHK_ERR(entry->h_length != 0, STATUS_HOSTNAME_NOT_FOUND, "could not find network address of %s", hostname);
+    CHK_ERR((errCode = getaddrinfo(hostname, NULL, NULL, &res)) == 0, STATUS_RESOLVE_HOSTNAME_FAILED, "getaddrinfo() with errno %s", gai_strerror(errCode));
 
-    if (entry->h_addrtype == AF_INET) {
-        destIp->family = KVS_IP_FAMILY_TYPE_IPV4;
-        MEMCPY(destIp->address, entry->h_addr_list[0], IPV4_ADDRESS_LENGTH);
-    } else {
-        destIp->family = KVS_IP_FAMILY_TYPE_IPV6;
-        MEMCPY(destIp->address, entry->h_addr_list[0], IPV6_ADDRESS_LENGTH);
+    for (rp = res; rp != NULL && !resolved; rp = rp->ai_next) {
+        if (rp->ai_family == AF_INET) {
+            ipv4Addr = (struct sockaddr_in*)rp->ai_addr;
+            destIp->family = KVS_IP_FAMILY_TYPE_IPV4;
+            MEMCPY(destIp->address, &ipv4Addr->sin_addr, IPV4_ADDRESS_LENGTH);
+            resolved = TRUE;
+        } else if (rp->ai_family == AF_INET6) {
+            ipv6Addr = (struct sockaddr_in6*)rp->ai_addr;
+            destIp->family = KVS_IP_FAMILY_TYPE_IPV6;
+            MEMCPY(destIp->address, &ipv6Addr->sin6_addr, IPV6_ADDRESS_LENGTH);
+            resolved = TRUE;
+        }
     }
+
+    freeaddrinfo(res);
+    CHK_ERR(resolved, STATUS_HOSTNAME_NOT_FOUND, "could not find network address of %s", hostname);
 
 CleanUp:
 


### PR DESCRIPTION
*Issue #395*

*Description of changes:* Replace `gethostbyname` with `getaddrinfo`

IPv6 enabled stun server: **test-stun-dualstack-9fa4df9b63d779eb.elb.us-west-2.amazonaws.com**

Screenshot of a working example in resolving an IPv6 host:
<img width="721" alt="Screen Shot 2020-04-28 at 3 49 29 PM" src="https://user-images.githubusercontent.com/15654932/80531868-462ac180-8969-11ea-810c-c1e07be8ae4e.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
