### PR TITLE
fix leaking TurnConnection obj when there are more than one turn server.

### DIFF
--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -17,7 +17,7 @@ extern "C" {
 #define KVS_ICE_CONNECTIVITY_CHECK_TIMEOUT                              10 * HUNDREDS_OF_NANOS_IN_A_SECOND
 #define KVS_ICE_CANDIDATE_NOMINATION_TIMEOUT                            10 * HUNDREDS_OF_NANOS_IN_A_SECOND
 #define KVS_ICE_SEND_KEEP_ALIVE_INTERVAL                                15 * HUNDREDS_OF_NANOS_IN_A_SECOND
-#define KVS_ICE_TURN_CONNECTION_SHUTDOWN_TIMEOUT                        3 * HUNDREDS_OF_NANOS_IN_A_SECOND
+#define KVS_ICE_TURN_CONNECTION_SHUTDOWN_TIMEOUT                        5 * HUNDREDS_OF_NANOS_IN_A_SECOND
 #define KVS_ICE_DEFAULT_TIMER_START_DELAY                               3 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND
 
 // Ta in https://tools.ietf.org/html/rfc8445
@@ -142,6 +142,7 @@ struct __IceAgent {
     volatile ATOMIC_BOOL agentStartGathering;
     volatile ATOMIC_BOOL remoteCredentialReceived;
     volatile ATOMIC_BOOL candidateGatheringFinished;
+    volatile ATOMIC_BOOL shutdown;
 
     CHAR localUsername[MAX_ICE_CONFIG_USER_NAME_LEN + 1];
     CHAR localPassword[MAX_ICE_CONFIG_CREDENTIAL_LEN + 1];

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -205,6 +205,7 @@ STATUS turnConnectionHandleStun(PTurnConnection, PBYTE, UINT32);
 STATUS turnConnectionHandleStunError(PTurnConnection, PBYTE, UINT32);
 STATUS turnConnectionHandleChannelData(PTurnConnection, PBYTE, UINT32, PTurnChannelData, PUINT32);
 STATUS turnConnectionHandleChannelDataTcpMode(PTurnConnection, PBYTE, UINT32, PTurnChannelData, PUINT32);
+VOID turnConnectionFatalError(PTurnConnection, STATUS);
 
 PTurnPeer turnConnectionGetPeerWithChannelNumber(PTurnConnection, UINT16);
 PTurnPeer turnConnectionGetPeerWithIp(PTurnConnection, PKvsIpAddress);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -99,8 +99,10 @@ TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundBeforeTurnEstablish
         return;
     }
 
+    UINT32 i;
     RtcConfiguration configuration;
     PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    PIceAgent pIceAgent = NULL;
 
     MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
 
@@ -114,8 +116,15 @@ TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundBeforeTurnEstablish
 
     THREAD_SLEEP(5 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
-    EXPECT_TRUE(((PKvsPeerConnection)offerPc)->pIceAgent->turnConnectionTrackerCount == 0);
-    EXPECT_TRUE(((PKvsPeerConnection)answerPc)->pIceAgent->turnConnectionTrackerCount == 0);
+    pIceAgent = ((PKvsPeerConnection)offerPc)->pIceAgent;
+    for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
+        EXPECT_TRUE(turnConnectionIsShutdownComplete(pIceAgent->turnConnectionTrackers[i].pTurnConnection));
+    }
+
+    pIceAgent = ((PKvsPeerConnection)answerPc)->pIceAgent;
+    for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
+        EXPECT_TRUE(turnConnectionIsShutdownComplete(pIceAgent->turnConnectionTrackers[i].pTurnConnection));
+    }
 
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);
@@ -134,6 +143,8 @@ TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundAfterTurnEstablishe
     RtcSessionDescriptionInit sdp;
     SIZE_T offerPcDoneGatherCandidate = 0, answerPcDoneGatherCandidate = 0;
     UINT64 candidateGatherTimeout;
+    PIceAgent pIceAgent = NULL;
+    UINT32 i;
 
     MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
 
@@ -191,8 +202,15 @@ TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundAfterTurnEstablishe
     // give time for turn allocated to be freed
     THREAD_SLEEP(5 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
-    EXPECT_TRUE(((PKvsPeerConnection)offerPc)->pIceAgent->turnConnectionTrackerCount == 0);
-    EXPECT_TRUE(((PKvsPeerConnection)answerPc)->pIceAgent->turnConnectionTrackerCount == 0);
+    pIceAgent = ((PKvsPeerConnection)offerPc)->pIceAgent;
+    for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
+        EXPECT_TRUE(turnConnectionIsShutdownComplete(pIceAgent->turnConnectionTrackers[i].pTurnConnection));
+    }
+
+    pIceAgent = ((PKvsPeerConnection)answerPc)->pIceAgent;
+    for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
+        EXPECT_TRUE(turnConnectionIsShutdownComplete(pIceAgent->turnConnectionTrackers[i].pTurnConnection));
+    }
 
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
