### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 
 set(KINESIS_VIDEO_PIC_SRC "${CMAKE_CURRENT_SOURCE_DIR}/open-source/amazon-kinesis-video-streams-pic/")
 set(KINESIS_VIDEO_PRODUCER_C_SRC "${CMAKE_CURRENT_SOURCE_DIR}/open-source/amazon-kinesis-video-streams-producer-c/")
-set(KINESIS_VIDEO_WEBRTC_CLIENT_SRC "${CMAKE_SOURCE_DIR}")
+set(KINESIS_VIDEO_WEBRTC_CLIENT_SRC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # expecting libjsmn, libwebsockets and gtest to be in
 # ${KINESIS_VIDEO_OPEN_SOURCE_SRC}/lib and their headers in


### PR DESCRIPTION
Resolves #389

Issue #389
Description of changes
In addition to the earlier PR #391 (closed) there was one more location where CMAKE_SOURCE_DIR was used.