### PR TITLE
Fixing view sample with async ICE config retrieval.

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -342,7 +342,7 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
 
     if (pSampleConfiguration->useTurn) {
         // Set the URIs from the configuration
-        CHK_STATUS(signalingClientGetIceConfigInfoCount(pSampleConfiguration->signalingClientHandle, &iceConfigCount));
+        CHK_STATUS(awaitGetIceConfigInfoCount(pSampleConfiguration->signalingClientHandle, &iceConfigCount));
 
         /* signalingClientGetIceConfigInfoCount can return more than one turn server. Use only one to optimize
          * candidate gathering latency. But user can also choose to use more than 1 turn server. */
@@ -360,6 +360,32 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
     }
 
     CHK_STATUS(createPeerConnection(&configuration, ppRtcPeerConnection));
+
+CleanUp:
+
+    return retStatus;
+}
+
+STATUS awaitGetIceConfigInfoCount(SIGNALING_CLIENT_HANDLE signalingClientHandle, PUINT32 pIceConfigInfoCount)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 elapsed = 0;
+
+    CHK(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingClientHandle) && pIceConfigInfoCount != NULL, STATUS_NULL_ARG);
+
+    while (TRUE) {
+        // Get the configuration count
+        CHK_STATUS(signalingClientGetIceConfigInfoCount(signalingClientHandle, pIceConfigInfoCount));
+
+        // Return OK if we have some ice configs
+        CHK(*pIceConfigInfoCount == 0, retStatus);
+
+        // Check for timeout
+        CHK_ERR(elapsed <= ASYNC_ICE_CONFIG_INFO_WAIT_TIMEOUT, STATUS_OPERATION_TIMED_OUT, "Couldn't retrieve ICE configurations in alotted time.");
+
+        THREAD_SLEEP(ICE_CONFIG_INFO_POLL_PERIOD);
+        elapsed += ICE_CONFIG_INFO_POLL_PERIOD;
+    }
 
 CleanUp:
 

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -24,6 +24,9 @@ extern "C" {
 #define SAMPLE_AUDIO_FRAME_DURATION                                             (20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 #define SAMPLE_VIDEO_FRAME_DURATION                                             (HUNDREDS_OF_NANOS_IN_A_SECOND / DEFAULT_FPS_VALUE)
 
+#define ASYNC_ICE_CONFIG_INFO_WAIT_TIMEOUT                                      (3 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+#define ICE_CONFIG_INFO_POLL_PERIOD                                             (20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+
 #define CA_CERT_PEM_FILE_EXTENSION                                              ".pem"
 typedef enum {
     SAMPLE_STREAMING_VIDEO_ONLY,
@@ -118,6 +121,7 @@ VOID sampleBandwidthEstimationHandler(UINT64, DOUBLE);
 VOID onDataChannel(UINT64, PRtcDataChannel);
 VOID onConnectionStateChange(UINT64, RTC_PEER_CONNECTION_STATE);
 STATUS sessionCleanupWait(PSampleConfiguration);
+STATUS awaitGetIceConfigInfoCount(SIGNALING_CLIENT_HANDLE, PUINT32);
 
 #ifdef  __cplusplus
 }

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -53,6 +53,15 @@ INT32 main(INT32 argc, CHAR *argv[])
 
     printf("[KVS Viewer] Signaling client created successfully\n");
 
+    // Enable the processing of the messages
+    retStatus = signalingClientConnectSync(pSampleConfiguration->signalingClientHandle);
+    if(retStatus != STATUS_SUCCESS) {
+        printf("[KVS Viewer] signalingClientConnectSync(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
+
+    printf("[KVS Viewer] Signaling client connection to socket established\n");
+
     // Initialize streaming session
     MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
     locked = TRUE;
@@ -68,15 +77,6 @@ INT32 main(INT32 argc, CHAR *argv[])
 
     MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
     locked = FALSE;
-
-    // Enable the processing of the messages
-    retStatus = signalingClientConnectSync(pSampleConfiguration->signalingClientHandle);
-    if(retStatus != STATUS_SUCCESS) {
-        printf("[KVS Viewer] signalingClientConnectSync(): operation returned status code: 0x%08x \n", retStatus);
-        goto CleanUp;
-    }
-
-    printf("[KVS Viewer] Signaling client connection to socket established\n");
 
     memset(&offerSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
 

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -137,6 +137,9 @@ typedef struct {
     // if it comes first forcing the state machine to loop back to connected state.
     volatile ATOMIC_BOOL refreshIceConfig;
 
+    // Indicate whether the ICE configuration has been retrieved at least once
+    volatile ATOMIC_BOOL iceConfigRetrieved;
+
     // Current version of the structure
     UINT32 version;
 


### PR DESCRIPTION
Issue #414 

Samples are using async get ICE config mode. The viewer application was creating the signaling client and immediately moving on to retrieving the ICE configs which returns 0. The sample assumes that there will be at least 1 turn server config avilable.

The fix is 

* In Viewer sample move the connect right after the create client before the initialization of the peer connection. This way, we will benefit from latency gains in async
* In Viewer sample, add a polling to await for the ice configs to resolve or timeuot.
* In Signaling client, in async mode to not check for known state machine states as async ICE retrieval might fail and run through other states.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
