### PR TITLE
Introduce peerConnectionGetLocalDescription() with other bug fixes

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1297,7 +1297,17 @@ PUBLIC_API STATUS peerConnectionOnDataChannel(PRtcPeerConnection, UINT64, RtcOnD
 PUBLIC_API STATUS peerConnectionOnConnectionStateChange(PRtcPeerConnection, UINT64, RtcOnConnectionStateChange);
 
 /**
- * Load the sdp field of PRtcSessionDescriptionInit with latest local session description
+ * Load the sdp field of PRtcSessionDescriptionInit with pending or current local session description
+ *
+ * @param[in] PRtcPeerConnection Initialized RtcPeerConnection
+ * @param[in,out] PRtcSessionDescriptionInit IN/PRtcSessionDescriptionInit whose sdp field will be modified.
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS peerConnectionGetLocalDescription(PRtcPeerConnection, PRtcSessionDescriptionInit);
+
+/**
+ * Load the sdp field of PRtcSessionDescriptionInit with current local session description
  *
  * @param[in] PRtcPeerConnection Initialized RtcPeerConnection
  * @param[in,out] PRtcSessionDescriptionInit IN/PRtcSessionDescriptionInit whose sdp field will be modified.

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -665,6 +665,36 @@ CleanUp:
     return retStatus;
 }
 
+STATUS peerConnectionGetLocalDescription(PRtcPeerConnection pRtcPeerConnection, PRtcSessionDescriptionInit pRtcSessionDescriptionInit)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    SessionDescription sessionDescription;
+    UINT32 deserializeLen = 0;
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pRtcPeerConnection;
+
+    CHK(pRtcPeerConnection != NULL && pRtcSessionDescriptionInit != NULL, STATUS_NULL_ARG);
+
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+
+    if (pKvsPeerConnection->isOffer) {
+        pRtcSessionDescriptionInit->type = SDP_TYPE_OFFER;
+    } else {
+        pRtcSessionDescriptionInit->type = SDP_TYPE_ANSWER;
+    }
+
+    CHK_STATUS(populateSessionDescription(pKvsPeerConnection, &(pKvsPeerConnection->remoteSessionDescription), &sessionDescription));
+    CHK_STATUS(deserializeSessionDescription(&sessionDescription, NULL, &deserializeLen));
+    CHK(deserializeLen <= MAX_SESSION_DESCRIPTION_INIT_SDP_LEN, STATUS_NOT_ENOUGH_MEMORY);
+
+    CHK_STATUS(deserializeSessionDescription(&sessionDescription, pRtcSessionDescriptionInit->sdp, &deserializeLen));
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS peerConnectionGetCurrentLocalDescription(PRtcPeerConnection pRtcPeerConnection, PRtcSessionDescriptionInit pRtcSessionDescriptionInit)
 {
     ENTERS();


### PR DESCRIPTION
Issue #368
Description of changes:
* Introduce peerConnectionGetLocalDescription() to return pending local description.
    - peerConnectionGetCurrentLocalDescription() should be for description that has already offered to the peer. There needs to be another method that can return the "pending" description. (which aligns with W3C WebRTC API)
* Fix deadlock when calling peerConnectionGetLocalDescription() from within the onIceCandidate callback.
* Fix incorrect endianness of the candidate port on the SDP.

With the above fixes, I was able to establish a peer connection in non-trickle-ice procedure.
