### PR TITLE
Add IPv6 support for reflexive candidates

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1326,6 +1326,7 @@ STATUS iceAgentInitSrflxCandidate(PIceAgent pIceAgent)
     STATUS retStatus = STATUS_SUCCESS;
     PDoubleListNode pCurNode = NULL;
     UINT64 data;
+    PIceServer pIceServer = NULL;
     PIceCandidate pCandidate = NULL, pNewCandidate = NULL;
     UINT32 j;
     BOOL locked = FALSE;
@@ -1339,11 +1340,10 @@ STATUS iceAgentInitSrflxCandidate(PIceAgent pIceAgent)
         pCurNode = pCurNode->pNext;
         pCandidate = (PIceCandidate) data;
 
-        // TODO: Stop skipping IPv6. Stun serialization and deserialization needs to be implemented properly first.
-        if (pCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_HOST &&
-              IS_IPV4_ADDR(&pCandidate->ipAddress)) {
+        if (pCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_HOST) {
             for (j = 0; j < pIceAgent->iceServersCount; j++) {
-                if (!pIceAgent->iceServers[j].isTurn) {
+                pIceServer = &pIceAgent->iceServers[j];
+                if (!pIceServer->isTurn && pIceServer->ipAddress.family == pCandidate->ipAddress.family) {
                     CHK((pNewCandidate = (PIceCandidate) MEMCALLOC(1, SIZEOF(IceCandidate))) != NULL,
                         STATUS_NOT_ENOUGH_MEMORY);
                     generateJSONSafeString(pNewCandidate->id, ARRAY_SIZE(pNewCandidate->id));

--- a/src/source/Stun/Stun.c
+++ b/src/source/Stun/Stun.c
@@ -801,18 +801,12 @@ STATUS deserializeStunPacket(PBYTE pStunBuffer, UINT32 bufferSize, PBYTE passwor
                     pStunAttributeAddress->address.port ^= (UINT16) stunMagicCookie;
 
                     // Perform the XOR-ing
-                    if (IS_IPV4_ADDR(&pStunAttributeAddress->address)) {
-                        data = *(PUINT32) pStunAttributeAddress->address.address;
-                        data ^= stunMagicCookie;
-                        *(PUINT32) pStunAttributeAddress->address.address = data;
-                    } else {
-                        // TODO Ensure we interpret the RFC properly with the host byte order thing
-                        // Process the first 4 bytes exactly the same way as the ipV4
-                        data = (UINT32) getInt32(*(PINT32) pStunAttributeAddress->address.address);
-                        data ^= STUN_HEADER_MAGIC_COOKIE;
-                        *(PUINT32) pStunAttributeAddress->address.address = data;
+                    data = *(PUINT32) pStunAttributeAddress->address.address;
+                    data ^= stunMagicCookie;
+                    *(PUINT32) pStunAttributeAddress->address.address = data;
 
-                        // Process the rest of 12 bytes
+                    if (pStunAttributeAddress->address.family == KVS_IP_FAMILY_TYPE_IPV6) {
+                        // Process the rest of 12 bytes for IPv6
                         pData = &pStunAttributeAddress->address.address[SIZEOF(UINT32)];
                         pTransaction = pStunPacket->header.transactionId;
                         for (j = 0; j < STUN_TRANSACTION_ID_LEN; j++) {
@@ -1235,8 +1229,6 @@ STATUS xorIpAddress(PKvsIpAddress pAddress, PBYTE pTransactionId)
     putInt32((PINT32) pAddress->address, data);
 
     if (pAddress->family == KVS_IP_FAMILY_TYPE_IPV6) {
-        // TODO Ensure we interpret the RFC properly with the host byte order thing
-
         // Process the rest of 12 bytes
         pData = &pAddress->address[SIZEOF(UINT32)];
         for (i = 0; i < STUN_TRANSACTION_ID_LEN; i++) {


### PR DESCRIPTION
*Issue #394 and #115*

*Description of changes:*
* Fixed a minor bug in deserializing XOR addresses
* Verified the serialization/deserialization of XOR addresses
  * Tested end-to-end with IPv6 stun server (stun:numb.viagenie.ca:3478) and observed it from chrome webrtc internal tool and tcpdump
  * Added some unit tests to verify it further
* Enable gathering IPv6 reflexive candidates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
