### PR TITLE
move ice local candidate reporting from user thread to timer thread

### DIFF
--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -34,6 +34,7 @@ extern "C" {
 
 #define KVS_ICE_MAX_ICE_SERVERS                                         3
 #define KVS_ICE_TURN_CONECTION_TRACKERS                                 4
+#define KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE              10
 
 // https://tools.ietf.org/html/rfc5245#section-4.1.2.1
 #define ICE_PRIORITY_HOST_CANDIDATE_TYPE_PREFERENCE                     126
@@ -104,6 +105,9 @@ typedef struct {
      * TurnConnectionTracker this candidate is associated to */
     PTurnConnectionTracker pTurnConnectionTracker;
 
+    /* If candidate is local. Indicate whether candidate
+     * has been reported through IceNewLocalCandidateFunc */
+    BOOL reported;
     CHAR id[ICE_CANDIDATE_ID_LEN + 1];
 } IceCandidate, *PIceCandidate;
 

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -93,7 +93,7 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersForcedTURN)
     deinitializeSignalingClient();
 }
 
-TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundBeforeTurnEstablished)
+TEST_F(PeerConnectionFunctionalityTest, shutdownTurnDueToP2PFoundBeforeTurnEstablished)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -118,12 +118,12 @@ TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundBeforeTurnEstablish
 
     pIceAgent = ((PKvsPeerConnection)offerPc)->pIceAgent;
     for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
-        EXPECT_TRUE(turnConnectionIsShutdownComplete(pIceAgent->turnConnectionTrackers[i].pTurnConnection));
+        EXPECT_TRUE(ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
     }
 
     pIceAgent = ((PKvsPeerConnection)answerPc)->pIceAgent;
     for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
-        EXPECT_TRUE(turnConnectionIsShutdownComplete(pIceAgent->turnConnectionTrackers[i].pTurnConnection));
+        EXPECT_TRUE(ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
     }
 
     freePeerConnection(&offerPc);
@@ -132,7 +132,7 @@ TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundBeforeTurnEstablish
     deinitializeSignalingClient();
 }
 
-TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundAfterTurnEstablished)
+TEST_F(PeerConnectionFunctionalityTest, shutdownTurnDueToP2PFoundAfterTurnEstablished)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -204,12 +204,12 @@ TEST_F(PeerConnectionFunctionalityTest, freeTurnDueToP2PFoundAfterTurnEstablishe
 
     pIceAgent = ((PKvsPeerConnection)offerPc)->pIceAgent;
     for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
-        EXPECT_TRUE(turnConnectionIsShutdownComplete(pIceAgent->turnConnectionTrackers[i].pTurnConnection));
+        EXPECT_TRUE(ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
     }
 
     pIceAgent = ((PKvsPeerConnection)answerPc)->pIceAgent;
     for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
-        EXPECT_TRUE(turnConnectionIsShutdownComplete(pIceAgent->turnConnectionTrackers[i].pTurnConnection));
+        EXPECT_TRUE(ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
     }
 
     freePeerConnection(&offerPc);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
by moving ice local candidate reporting to timer thread, user can call ice api inside new local candidate callback.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
