### PR TITLE
Enabling instrumented allocators

### DIFF
--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -36,9 +36,7 @@ void WebRtcClientTestBase::SetUp()
     mExpectedFrameCount = 0;
     mExpectedDroppedFrameCount = 0;
 
-    /* Disable instrumented allocator for now due to inconsistent behavior.
-     * Sometimes it report leaks but running the same test again it doesnt report leak again. */
-    /* SET_INSTRUMENTED_ALLOCATORS(); */
+    SET_INSTRUMENTED_ALLOCATORS();
 
     SET_LOGGER_LOG_LEVEL(LOG_LEVEL_DEBUG);
 
@@ -91,9 +89,7 @@ void WebRtcClientTestBase::TearDown()
 
     freeStaticCredentialProvider(&mTestCredentialProvider);
 
-    /* Disable instrumented allocator for now due to inconsistent behavior.
-     * Sometimes it report leaks but running the same test again it doesnt report leak again. */
-    /* EXPECT_EQ(STATUS_SUCCESS, RESET_INSTRUMENTED_ALLOCATORS()); */
+    EXPECT_EQ(STATUS_SUCCESS, RESET_INSTRUMENTED_ALLOCATORS());
 }
 
 VOID WebRtcClientTestBase::initializeJitterBuffer(UINT32 expectedFrameCount, UINT32 expectedDroppedFrameCount, UINT32 rtpPacketCount)


### PR DESCRIPTION
*Issue #, if available:*

Enabling the instrumented allocators. As it turns out we are doing the right thing here and we don't end up with two global symbols because they are not marked as statics in their TUs.

The issues I was facing were caused by my incorrect interpretation of the readelf -Ws output from Linux with GCC. The duplicate entires were entries in .dynsym and .symtab tables which are OK and as they point to the exact same export.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
