### PR TITLE
in connection listener, when removing socket connection, check if the…

### DIFF
--- a/src/source/Ice/ConnectionListener.h
+++ b/src/source/Ice/ConnectionListener.h
@@ -23,6 +23,7 @@ typedef struct {
     TID receiveDataRoutine;
     PBYTE pBuffer;
     UINT64 bufferLen;
+    PHashTable activeSocketConnections;
 } ConnectionListener, *PConnectionListener;
 
 /**


### PR DESCRIPTION
… connection has already been freed or not. This can happen because up stream can have a reference of PSocketConnection thats already freed.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
