### PR TITLE
fix edge case when turnConnection shutdown happen before an allocatio…

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1231,10 +1231,11 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
     UINT64 data;
     PIceCandidate pIceCandidate = NULL;
     UINT32 pendingSrflxCandidateCount = 0, pendingCandidateCount = 0, i;
-    PKvsIpAddress pRelayAddress = NULL;
+    KvsIpAddress relayAddress;
 
     CHK(pIceAgent != NULL, STATUS_NULL_ARG);
     MEMSET(newLocalCandidates, 0x00, SIZEOF(newLocalCandidates));
+    MEMSET(&relayAddress, 0x00, SIZEOF(KvsIpAddress));
 
     MUTEX_LOCK(pIceAgent->lock);
     locked = TRUE;
@@ -1251,9 +1252,9 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
                 pendingSrflxCandidateCount++;
             } else if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_RELAYED &&
                        pIceCandidate->pTurnConnectionTracker != NULL &&
-                       (pRelayAddress = turnConnectionGetRelayAddress(pIceCandidate->pTurnConnectionTracker->pTurnConnection)) != NULL) {
+                       turnConnectionGetRelayAddress(pIceCandidate->pTurnConnectionTracker->pTurnConnection, &relayAddress)) {
                 /* Check if any relay address has been obtained. */
-                CHK_STATUS(updateCandidateAddress(pIceCandidate, pRelayAddress));
+                CHK_STATUS(updateCandidateAddress(pIceCandidate, &relayAddress));
                 CHK_STATUS(createIceCandidatePairs(pIceAgent, pIceCandidate, FALSE));
             }
         }

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -17,7 +17,7 @@ extern "C" {
 #define KVS_ICE_CONNECTIVITY_CHECK_TIMEOUT                              10 * HUNDREDS_OF_NANOS_IN_A_SECOND
 #define KVS_ICE_CANDIDATE_NOMINATION_TIMEOUT                            10 * HUNDREDS_OF_NANOS_IN_A_SECOND
 #define KVS_ICE_SEND_KEEP_ALIVE_INTERVAL                                15 * HUNDREDS_OF_NANOS_IN_A_SECOND
-#define KVS_ICE_TURN_CONNECTION_SHUTDOWN_TIMEOUT                        5 * HUNDREDS_OF_NANOS_IN_A_SECOND
+#define KVS_ICE_TURN_CONNECTION_SHUTDOWN_TIMEOUT                        1 * HUNDREDS_OF_NANOS_IN_A_SECOND
 #define KVS_ICE_DEFAULT_TIMER_START_DELAY                               3 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND
 
 // Ta in https://tools.ietf.org/html/rfc8445

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -115,8 +115,7 @@ typedef struct {
 typedef struct __TurnConnection TurnConnection;
 struct __TurnConnection {
     volatile ATOMIC_BOOL stopTurnConnection;
-    volatile ATOMIC_BOOL allocationFreed;
-    volatile ATOMIC_BOOL relayAddressReceived;
+    volatile ATOMIC_BOOL hasAllocation;
     volatile SIZE_T timerCallbackId;
 
     // realm attribute in Allocation response
@@ -186,7 +185,7 @@ STATUS turnConnectionSendData(PTurnConnection, PBYTE, UINT32, PKvsIpAddress);
 STATUS turnConnectionStart(PTurnConnection);
 STATUS turnConnectionShutdown(PTurnConnection, UINT64);
 BOOL turnConnectionIsShutdownComplete(PTurnConnection);
-PKvsIpAddress turnConnectionGetRelayAddress(PTurnConnection);
+BOOL turnConnectionGetRelayAddress(PTurnConnection, PKvsIpAddress);
 STATUS turnConnectionRefreshAllocation(PTurnConnection);
 STATUS turnConnectionRefreshPermission(PTurnConnection, PBOOL);
 STATUS turnConnectionFreePreAllocatedPackets(PTurnConnection);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -118,12 +118,14 @@ TEST_F(PeerConnectionFunctionalityTest, shutdownTurnDueToP2PFoundBeforeTurnEstab
 
     pIceAgent = ((PKvsPeerConnection)offerPc)->pIceAgent;
     for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
-        EXPECT_TRUE(ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
+        EXPECT_TRUE(!ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->hasAllocation) ||
+                    ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
     }
 
     pIceAgent = ((PKvsPeerConnection)answerPc)->pIceAgent;
     for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
-        EXPECT_TRUE(ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
+        EXPECT_TRUE(!ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->hasAllocation) ||
+                    ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
     }
 
     freePeerConnection(&offerPc);
@@ -204,12 +206,14 @@ TEST_F(PeerConnectionFunctionalityTest, shutdownTurnDueToP2PFoundAfterTurnEstabl
 
     pIceAgent = ((PKvsPeerConnection)offerPc)->pIceAgent;
     for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
-        EXPECT_TRUE(ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
+        EXPECT_TRUE(!ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->hasAllocation) ||
+                    ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
     }
 
     pIceAgent = ((PKvsPeerConnection)answerPc)->pIceAgent;
     for(i = 0; i < pIceAgent->turnConnectionTrackerCount; ++i) {
-        EXPECT_TRUE(ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
+        EXPECT_TRUE(!ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->hasAllocation) ||
+                    ATOMIC_LOAD_BOOL(&pIceAgent->turnConnectionTrackers[i].pTurnConnection->stopTurnConnection));
     }
 
     freePeerConnection(&offerPc);


### PR DESCRIPTION
…n is obtained cause STATUS_NULL_ARG in turn timer task.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
