### PR TITLE
Nullable data types

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -17,6 +17,8 @@ extern "C" {
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #include <com/amazonaws/kinesis/video/client/Include.h>
 #include <com/amazonaws/kinesis/video/common/Include.h>
+#include <com/amazonaws/kinesis/video/webrtcclient/NullableDefs.h>
+
 #pragma clang diagnostic pop
 
 /*===========================================================================================*/

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/NullableDefs.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/NullableDefs.h
@@ -1,0 +1,97 @@
+/*
+ * Header file to define nullable values for common data types
+ */
+
+#ifndef __KINESIS_VIDEO_WEBRTC_CLIENT_NULLABLEDEFS__
+#define __KINESIS_VIDEO_WEBRTC_CLIENT_NULLABLEDEFS__
+
+#pragma once
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+////////////////////////////////////////////////////
+// Public headers
+////////////////////////////////////////////////////
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#pragma clang diagnostic pop
+
+#define NULLABLE_SET_EMPTY(a) \
+    do { \
+        (a).isNull = TRUE; \
+    } while(FALSE)
+
+#define NULLABLE_CHECK_EMPTY(a) ((a).isNull == TRUE)
+
+#define NULLABLE_SET_VALUE(a, val) \
+    do { \
+        (a).isNull = FALSE; \
+        (a).value = val; \
+    } while(FALSE)
+
+typedef struct {
+    BOOL isNull;
+    BOOL value;
+} NullableBool;
+
+typedef struct {
+    BOOL isNull;
+    UINT8 value;
+} NullableUint8;
+
+typedef struct {
+    BOOL isNull;
+    INT8 value;
+} NullableInt8;
+
+typedef struct {
+    BOOL isNull;
+    UINT16 value;
+} NullableUint16;
+
+typedef struct {
+    BOOL isNull;
+    INT16 value;
+} NullableInt16;
+
+typedef struct {
+    BOOL isNull;
+    UINT32 value;
+} NullableUint32;
+
+typedef struct {
+    BOOL isNull;
+    INT32 value;
+} NullableInt32;
+
+typedef struct {
+    BOOL isNull;
+    UINT64 value;
+} NullableUint64;
+
+typedef struct {
+    BOOL isNull;
+    INT64 value;
+} NullableInt64;
+
+typedef struct {
+    BOOL isNull;
+    FLOAT value;
+} NullableFloat;
+
+typedef struct {
+    BOOL isNull;
+    DOUBLE value;
+} NullableDouble;
+
+typedef struct {
+    BOOL isNull;
+    LDOUBLE value;
+} NullableLongDouble;
+
+#ifdef  __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_WEBRTC_CLIENT_NULLABLEDEFS__ */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

RTC spec has a few attributes that have a default of NULL value/undefined. Since C does not allow us to define types such as UINTx and BOOL to a NULL value, a new data type has to be created to allow such values. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
