### PR TITLE
Setting the global instrumented memory allocator size to 0 for each r…

### DIFF
--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -36,6 +36,13 @@ void WebRtcClientTestBase::SetUp()
     mExpectedFrameCount = 0;
     mExpectedDroppedFrameCount = 0;
 
+    // We need to reset the current for every run of the test.
+    // This is done so a failed test that leaked will not cause
+    // failures for every other test that follows as the accounting
+    // is done in a global that has a lifespan tied with the process
+    // rather than the particular test run
+    gInstrumentedAllocatorsTotalAllocationSize = 0;
+    
     SET_INSTRUMENTED_ALLOCATORS();
 
     SET_LOGGER_LOG_LEVEL(LOG_LEVEL_DEBUG);


### PR DESCRIPTION
…un of the tests so a single leak will not "contaminate" all of the consequent tests

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
