### PR TITLE
Add SDP logging support through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ configuration.certificates[0].pCertificate = pSampleConfiguration->rtcConfig.cer
 configuration.certificates[0].pPrivateKey = pSampleConfiguration->rtcConfig.certificates[0].pPrivateKey;
 ```
 
+## Getting the SDPs
+If you would like to print out the SDPs, run this command:
+`export DEBUG_LOG_SDP=TRUE`
+
 ## Documentation
 All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -844,6 +844,10 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     CHK_STATUS(setTransceiverPayloadTypes(pKvsPeerConnection->pCodecTable, pKvsPeerConnection->pRtxTable, pKvsPeerConnection->pTransceievers));
     CHK_STATUS(setReceiversSsrc(pSessionDescription, pKvsPeerConnection->pTransceievers));
 
+    if (NULL != getenv(DEBUG_LOG_SDP)) {
+        DLOGD("REMOTE_SDP:%s\n", pSessionDescriptionInit->sdp);
+    }
+
 CleanUp:
 
     LEAVES();
@@ -904,12 +908,16 @@ STATUS setLocalDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescri
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
+
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
 
     CHK(pKvsPeerConnection != NULL && pSessionDescriptionInit != NULL, STATUS_NULL_ARG);
 
     CHK_STATUS(iceAgentStartGathering(pKvsPeerConnection->pIceAgent));
 
+    if (NULL != getenv(DEBUG_LOG_SDP)) {
+        DLOGD("LOCAL_SDP:%s", pSessionDescriptionInit->sdp);
+    }
 CleanUp:
 
     LEAVES();

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -33,6 +33,9 @@ extern "C" {
 #define DATA_CHANNEL_HASH_TABLE_BUCKET_COUNT            200
 #define DATA_CHANNEL_HASH_TABLE_BUCKET_LENGTH           2
 
+// Environment variable to display SDPs
+#define DEBUG_LOG_SDP                                                     ((PCHAR) "DEBUG_LOG_SDP")
+
 typedef enum {
     RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE = 1,
     RTC_RTX_CODEC_VP8 = 2,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added an env `DEBUG_LOG_SDP` option to get SDPs displayed
- This will useful when customers want to view the SDPs on the local machine without the need to add debug lines on their own
- Will also be useful for us to debug SDP related issues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
