### PR TITLE
Guard PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ addons:
     packages:
       - gdb
 
+before_install:
+  # Guard PRs from forks because they won't be able to get credentials, which will cause the tests to always fail
+  - >
+      [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY ]] && 
+      echo "Creating a PR from a fork is not allowed. Travis doesn't allow sharing secret keys with fork builds." &&
+      travis_terminate 1
+  # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+  - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+
 script:
   - export AWS_KVS_LOG_LEVEL=2
   - make
@@ -58,9 +67,6 @@ matrix:
     - name: "Linux GCC Code Coverage"
       os: linux
       compiler: gcc
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script:
         - mkdir build && cd build && cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
       after_success:
@@ -74,9 +80,6 @@ matrix:
       env:
         - ASAN_OPTIONS=detect_odr_violation=0:detect_leaks=1
         - LSAN_OPTIONS=suppressions=../tst/suppressions/LSAN.supp
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
 
     # UndefinedBehaviorSanitizer
@@ -84,14 +87,16 @@ matrix:
       os: linux
       compiler: clang
       env: UBSAN_OPTIONS=halt_on_error=1
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
 
     # MemorySanitizer
     - name: "Linux Clang MemorySanitizer"
       before_install:
+        # Guard PRs from forks because they won't be able to get credentials, which will cause the tests to always fail
+        - >
+            [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY ]] && 
+            echo "Creating a PR from a fork is not allowed. Travis doesn't allow sharing secret keys with fork builds." &&
+            travis_terminate 1
         # TODO: Remove the following 2 lines. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
         - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
         - sudo service docker restart
@@ -109,15 +114,17 @@ matrix:
       os: linux
       compiler: clang
       env: TSAN_OPTIONS=halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
 
     # Old Version GCC 4.4
     - name: "Linux GCC 4.4 Build"
       os: linux
       before_install:
+        # Guard PRs from forks because they won't be able to get credentials, which will cause the tests to always fail
+        - >
+            [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY ]] && 
+            echo "Creating a PR from a fork is not allowed. Travis doesn't allow sharing secret keys with fork builds." &&
+            travis_terminate 1
         # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
         - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
         - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -130,6 +137,11 @@ matrix:
     # Static Build
     - name: "Static Build"
       before_install:
+        # Guard PRs from forks because they won't be able to get credentials, which will cause the tests to always fail
+        - >
+            [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY ]] && 
+            echo "Creating a PR from a fork is not allowed. Travis doesn't allow sharing secret keys with fork builds." &&
+            travis_terminate 1
         # TODO: Remove the following 2 lines. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
         - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
         - sudo service docker restart
@@ -155,9 +167,6 @@ matrix:
             - g++-arm-linux-gnueabi
             - binutils-arm-linux-gnueabi
       compiler: gcc
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script:
         - export CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++
         - mkdir build && cd build


### PR DESCRIPTION
Travis doesn't allow sharing private keys to PR that are from forks. Since our tests rely on these private keys, there's no need to run tests from forks. 

By exiting early, this will allow more bandwidth to run other tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
