### PR TITLE
Fix unawaited get ice server configs in test fixture

### DIFF
--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -214,13 +214,40 @@ void WebRtcClientTestBase::addTrackToPeerConnection(PRtcPeerConnection pRtcPeerC
     EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, track, NULL, transceiver));
 }
 
+
+STATUS awaitGetIceConfigInfoCount(SIGNALING_CLIENT_HANDLE signalingClientHandle, PUINT32 pIceConfigInfoCount)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 elapsed = 0;
+
+    CHK(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingClientHandle) && pIceConfigInfoCount != NULL, STATUS_NULL_ARG);
+
+    while (TRUE) {
+        // Get the configuration count
+        CHK_STATUS(signalingClientGetIceConfigInfoCount(signalingClientHandle, pIceConfigInfoCount));
+
+        // Return OK if we have some ice configs
+        CHK(*pIceConfigInfoCount == 0, retStatus);
+
+        // Check for timeout
+        CHK_ERR(elapsed <= TEST_ASYNC_ICE_CONFIG_INFO_WAIT_TIMEOUT, STATUS_OPERATION_TIMED_OUT, "Couldn't retrieve ICE configurations in alotted time.");
+
+        THREAD_SLEEP(TEST_ICE_CONFIG_INFO_POLL_PERIOD);
+        elapsed += TEST_ICE_CONFIG_INFO_POLL_PERIOD;
+    }
+
+CleanUp:
+
+    return retStatus;
+}
+
 void WebRtcClientTestBase::getIceServers(PRtcConfiguration pRtcConfiguration)
 {
     UINT32 i, j, iceConfigCount, uriCount;
     PIceConfigInfo pIceConfigInfo;
 
     // Assume signaling client is already created
-    EXPECT_EQ(STATUS_SUCCESS, signalingClientGetIceConfigInfoCount(mSignalingClientHandle, &iceConfigCount));
+    EXPECT_EQ(STATUS_SUCCESS, awaitGetIceConfigInfoCount(mSignalingClientHandle, &iceConfigCount));
 
     // Set the  STUN server
     SNPRINTF(pRtcConfiguration->iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, TEST_DEFAULT_REGION);

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -17,6 +17,8 @@
 #define SIGNAING_TEST_CORRELATION_ID                            (PCHAR) "Test_correlation_id"
 #define TEST_SIGNALING_MESSAGE_TTL                              (120 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 #define TEST_VIDEO_FRAME_SIZE                                   (120 * 1024)
+#define TEST_ICE_CONFIG_INFO_POLL_PERIOD                        (20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define TEST_ASYNC_ICE_CONFIG_INFO_WAIT_TIMEOUT                 (3 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
 namespace com { namespace amazonaws { namespace kinesis { namespace video { namespace webrtcclient {
 


### PR DESCRIPTION
Make sure that we receive the ice client config by asynchronously wait for the response, similar being done in the sample. This will hopefully reduce some test flakiness.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
