### PR TITLE
Update certificate expiration to be 1 year

### DIFF
--- a/src/source/Dtls/Dtls.c
+++ b/src/source/Dtls/Dtls.c
@@ -123,8 +123,8 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     CHK((*ppCert = X509_new()) != NULL, STATUS_CERTIFICATE_GENERATION_FAILED);
     X509_set_version(*ppCert, 2);
     ASN1_INTEGER_set(X509_get_serialNumber(*ppCert), GENERATED_CERTIFICATE_SERIAL);
-    X509_gmtime_adj(X509_get_notBefore(*ppCert), -1 * GENERATED_CERTIFICATE_DAYS);
-    X509_gmtime_adj(X509_get_notAfter(*ppCert), GENERATED_CERTIFICATE_DAYS);
+    X509_gmtime_adj(X509_get_notBefore(*ppCert), -1 * GENERATED_CERTIFICATE_DAYS * SECONDS_IN_A_DAY);
+    X509_gmtime_adj(X509_get_notAfter(*ppCert), GENERATED_CERTIFICATE_DAYS * SECONDS_IN_A_DAY);
     CHK(X509_set_pubkey(*ppCert, *ppPkey) != 0, STATUS_CERTIFICATE_GENERATION_FAILED);
 
     CHK((pX509Name = X509_get_subject_name(*ppCert)) != NULL, STATUS_CERTIFICATE_GENERATION_FAILED);

--- a/src/source/Dtls/Dtls.h
+++ b/src/source/Dtls/Dtls.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define GENERATED_CERTIFICATE_BITS 2048
 #define GENERATED_CERTIFICATE_SERIAL 0
-#define GENERATED_CERTIFICATE_DAYS 36500
+#define GENERATED_CERTIFICATE_DAYS 365
 #define GENERATED_CERTIFICATE_NAME (PUINT8) "KVS-WebRTC-Client"
 #define KEYING_EXTRACTOR_LABEL "EXTRACTOR-dtls_srtp"
 
@@ -26,6 +26,8 @@ extern "C" {
 #define DTLS_TRANSMISSION_INTERVAL          (200 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
 #define DTLS_SESSION_TIMER_START_DELAY      (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+
+#define SECONDS_IN_A_DAY                    (24 * 60 * 60LL)
 
 #define LOG_OPENSSL_ERROR(s)                    while ((sslErr = ERR_get_error()) != 0) { \
                                                     if (sslErr != SSL_ERROR_WANT_WRITE && sslErr != SSL_ERROR_WANT_READ) { \


### PR DESCRIPTION
`X509_gmtime_adj` accepts seconds. So, the PR is a fix for the time conversion between days to seconds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
