### PR TITLE
Decouple SocketConnection from OpenSSL

### DIFF
--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -31,10 +31,8 @@ STATUS createSocketConnection(PKvsIpAddress pHostIpAddr, PKvsIpAddress pPeerIpAd
     }
     ATOMIC_STORE_BOOL(&pSocketConnection->connectionClosed, FALSE);
     ATOMIC_STORE_BOOL(&pSocketConnection->receiveData, FALSE);
-    pSocketConnection->freeBios = TRUE;
     pSocketConnection->dataAvailableCallbackCustomData = customData;
     pSocketConnection->dataAvailableCallbackFn = dataAvailableFn;
-    pSocketConnection->tlsHandshakeStartTime = INVALID_TIMESTAMP_VALUE;
 
 CleanUp:
 
@@ -68,20 +66,8 @@ STATUS freeSocketConnection(PSocketConnection* ppSocketConnection)
         MUTEX_FREE(pSocketConnection->lock);
     }
 
-    if (pSocketConnection->pSslCtx != NULL) {
-        SSL_CTX_free(pSocketConnection->pSslCtx);
-    }
-
-    if (pSocketConnection->freeBios && pSocketConnection->pReadBio != NULL) {
-        BIO_free(pSocketConnection->pReadBio);
-    }
-
-    if (pSocketConnection->freeBios && pSocketConnection->pWriteBio != NULL) {
-        BIO_free(pSocketConnection->pWriteBio);
-    }
-
-    if (pSocketConnection->pSsl != NULL) {
-        SSL_free(pSocketConnection->pSsl);
+    if (pSocketConnection->pTlsSession != NULL) {
+        freeTlsSession(&pSocketConnection->pTlsSession);
     }
 
     close(pSocketConnection->localSocket);
@@ -96,54 +82,67 @@ CleanUp:
     return retStatus;
 }
 
+STATUS socketConnectionTlsSessionOutBoundPacket(UINT64 customData, PBYTE pBuffer, UINT32 bufferLen)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PSocketConnection pSocketConnection = NULL;
+    CHK(customData != 0, STATUS_NULL_ARG);
+
+    pSocketConnection = (PSocketConnection) customData;
+    CHK_STATUS(socketSendDataWithRetry(pSocketConnection, pBuffer, bufferLen, NULL, NULL));
+
+CleanUp:
+    return retStatus;
+}
+
+VOID socketConnectionTlsSessionOnStateChange(UINT64 customData, TLS_SESSION_STATE state)
+{
+    PSocketConnection pSocketConnection = NULL;
+    if (customData == 0) {
+        return;
+    }
+
+    pSocketConnection = (PSocketConnection) customData;
+    switch (state) {
+        case TLS_SESSION_STATE_NEW:
+            pSocketConnection->tlsHandshakeStartTime = INVALID_TIMESTAMP_VALUE;
+            break;
+        case TLS_SESSION_STATE_CONNECTING:
+            pSocketConnection->tlsHandshakeStartTime = GETTIME();
+            break;
+        case TLS_SESSION_STATE_CONNECTED:
+            if (IS_VALID_TIMESTAMP(pSocketConnection->tlsHandshakeStartTime)) {
+                DLOGD("TLS handshake done. Time taken %" PRIu64 " ms",
+                      (GETTIME() - pSocketConnection->tlsHandshakeStartTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+                pSocketConnection->tlsHandshakeStartTime = INVALID_TIMESTAMP_VALUE;
+            }
+            break;
+        case TLS_SESSION_STATE_CLOSED:
+            ATOMIC_STORE_BOOL(&pSocketConnection->connectionClosed, TRUE);
+            break;
+    }
+}
+
 STATUS socketConnectionInitSecureConnection(PSocketConnection pSocketConnection, BOOL isServer)
 {
     ENTERS();
+    TlsSessionCallbacks callbacks;
     STATUS retStatus = STATUS_SUCCESS;
-
+    
     CHK(pSocketConnection != NULL, STATUS_NULL_ARG);
+    CHK(pSocketConnection->pTlsSession == NULL, STATUS_INVALID_ARG);
 
-    pSocketConnection->pSslCtx = SSL_CTX_new(SSLv23_method());
+    callbacks.outBoundPacketFnCustomData = callbacks.stateChangeFnCustomData = (UINT64) pSocketConnection;
+    callbacks.outboundPacketFn = socketConnectionTlsSessionOutBoundPacket;
+    callbacks.stateChangeFn = socketConnectionTlsSessionOnStateChange;
 
-    CHK(pSocketConnection->pSslCtx != NULL, STATUS_SSL_CTX_CREATION_FAILED);
-
-    SSL_CTX_set_read_ahead(pSocketConnection->pSslCtx, 1);
-    SSL_CTX_set_verify(pSocketConnection->pSslCtx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, certificateVerifyCallback);
-
-    CHK(SSL_CTX_set_cipher_list(pSocketConnection->pSslCtx, "HIGH:!aNULL:!MD5:!RC4"), STATUS_SSL_CTX_CREATION_FAILED);
-
-    pSocketConnection->pSsl = SSL_new(pSocketConnection->pSslCtx);
-    CHK(pSocketConnection->pSsl != NULL, STATUS_CREATE_SSL_FAILED);
-
-    if (isServer) {
-        SSL_set_accept_state(pSocketConnection->pSsl);
-    } else {
-        SSL_set_connect_state(pSocketConnection->pSsl);
-    }
-
-    SSL_set_mode(pSocketConnection->pSsl, SSL_MODE_AUTO_RETRY);
-    CHK((pSocketConnection->pReadBio = BIO_new(BIO_s_mem())) != NULL, STATUS_SSL_CTX_CREATION_FAILED);
-    CHK((pSocketConnection->pWriteBio = BIO_new(BIO_s_mem())) != NULL, STATUS_SSL_CTX_CREATION_FAILED);
-
-    BIO_set_mem_eof_return(pSocketConnection->pReadBio, -1);
-    BIO_set_mem_eof_return(pSocketConnection->pWriteBio, -1);
-    SSL_set_bio(pSocketConnection->pSsl, pSocketConnection->pReadBio, pSocketConnection->pWriteBio);
-    pSocketConnection->freeBios = FALSE;
-
-    /* init handshake */
-    SSL_do_handshake(pSocketConnection->pSsl);
+    CHK_STATUS(createTlsSession(&callbacks, &pSocketConnection->pTlsSession));
+    CHK_STATUS(tlsSessionStart(pSocketConnection->pTlsSession, isServer));
     pSocketConnection->secureConnection = TRUE;
-    pSocketConnection->tlsHandshakeStartTime = GETTIME();
-
-    /* send handshake */
-    CHK_STATUS(socketConnectionSendData(pSocketConnection, NULL, 0, NULL));
 
 CleanUp:
-
-    CHK_LOG_ERR(retStatus);
-
-    if (STATUS_FAILED(retStatus)) {
-        ERR_print_errors_fp (stderr);
+    if (STATUS_FAILED(retStatus) && pSocketConnection->pTlsSession != NULL) {
+        freeTlsSession(&pSocketConnection->pTlsSession);
     }
 
     LEAVES();
@@ -154,10 +153,6 @@ STATUS socketConnectionSendData(PSocketConnection pSocketConnection, PBYTE pBuf,
 {
     STATUS retStatus = STATUS_SUCCESS;
     BOOL locked = FALSE;
-    INT32 sslRet = 0, sslErr = 0;
-
-    SIZE_T wBioDataLen = 0;
-    PCHAR wBioBuffer = NULL;
 
     CHK(pSocketConnection != NULL, STATUS_NULL_ARG);
     CHK((pSocketConnection->protocol == KVS_SOCKET_PROTOCOL_TCP || pDestIp != NULL), STATUS_INVALID_ARG);
@@ -171,52 +166,13 @@ STATUS socketConnectionSendData(PSocketConnection pSocketConnection, PBYTE pBuf,
     MUTEX_LOCK(pSocketConnection->lock);
     locked = TRUE;
 
+    /* Should have a valid buffer */
+    CHK(pBuf != NULL && bufLen > 0, STATUS_INVALID_ARG);
     if (pSocketConnection->protocol == KVS_SOCKET_PROTOCOL_TCP && pSocketConnection->secureConnection) {
-        if (SSL_is_init_finished(pSocketConnection->pSsl)) {
-            if (IS_VALID_TIMESTAMP(pSocketConnection->tlsHandshakeStartTime)) {
-                DLOGD("TLS handshake done. Time taken %" PRIu64 " ms",
-                      (GETTIME() - pSocketConnection->tlsHandshakeStartTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
-                pSocketConnection->tlsHandshakeStartTime = INVALID_TIMESTAMP_VALUE;
-            }
-            /* Should have a valid buffer */
-            CHK(pBuf != NULL && bufLen > 0, STATUS_INVALID_ARG);
-            sslRet = SSL_write(pSocketConnection->pSsl, pBuf, bufLen);
-            if (sslRet < 0){
-                sslErr = SSL_get_error(pSocketConnection->pSsl, sslRet);
-                switch (sslErr) {
-                    case SSL_ERROR_WANT_READ:
-                        /* explicit fall-through */
-                    case SSL_ERROR_WANT_WRITE:
-                        break;
-                    default:
-                        DLOGD("Warning: SSL_write failed with %s", ERR_error_string(sslErr, NULL));
-                        DLOGD("Close socket %d", pSocketConnection->localSocket);
-                        ATOMIC_STORE_BOOL(&pSocketConnection->connectionClosed, TRUE);
-                        break;
-                }
-
-                CHK(FALSE, STATUS_SEND_DATA_FAILED);
-            }
-        }
-
-        wBioDataLen = (SIZE_T) BIO_get_mem_data(SSL_get_wbio(pSocketConnection->pSsl), &wBioBuffer);
-        CHK_ERR(wBioDataLen >= 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed");
-
-        if (wBioDataLen > 0) {
-            retStatus = socketSendDataWithRetry(pSocketConnection, (PBYTE) wBioBuffer, (UINT32) wBioDataLen, NULL, NULL);
-
-            /* reset bio to clear its content since it's already sent if possible */
-            BIO_reset(SSL_get_wbio(pSocketConnection->pSsl));
-        }
-
+        CHK_STATUS(tlsSessionPutApplicationData(pSocketConnection->pTlsSession, pBuf, bufLen));
     } else if (pSocketConnection->protocol == KVS_SOCKET_PROTOCOL_TCP) {
-        /* Should have a valid buffer */
-        CHK(pBuf != NULL && bufLen > 0, STATUS_INVALID_ARG);
         CHK_STATUS(retStatus = socketSendDataWithRetry(pSocketConnection, pBuf, bufLen, NULL, NULL));
-
     } else if (pSocketConnection->protocol == KVS_SOCKET_PROTOCOL_UDP) {
-        /* Should have a valid buffer */
-        CHK(pBuf != NULL && bufLen > 0, STATUS_INVALID_ARG);
         CHK_STATUS(retStatus = socketSendDataWithRetry(pSocketConnection, pBuf, bufLen, pDestIp, NULL));
     } else {
         CHECK_EXT(FALSE, "socketConnectionSendData should not reach here. Nothing is sent.");
@@ -234,10 +190,7 @@ CleanUp:
 STATUS socketConnectionReadData(PSocketConnection pSocketConnection, PBYTE pBuf, UINT32 bufferLen, PUINT32 pDataLen)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    BOOL locked = FALSE, continueRead = TRUE;
-    INT32 sslReadRet = 0;
-    UINT32 writtenBytes = 0;
-    UINT64 sslErrorRet;
+    BOOL locked = FALSE;
 
     CHK(pSocketConnection != NULL && pBuf != NULL && pDataLen != NULL, STATUS_NULL_ARG);
     CHK(bufferLen != 0, STATUS_INVALID_ARG);
@@ -245,35 +198,10 @@ STATUS socketConnectionReadData(PSocketConnection pSocketConnection, PBYTE pBuf,
     MUTEX_LOCK(pSocketConnection->lock);
     locked = TRUE;
 
-    // return early if connection is not secure or no data
-    CHK(pSocketConnection->secureConnection && *pDataLen > 0, retStatus);
+    // return early if connection is not secure
+    CHK(pSocketConnection->secureConnection, retStatus);
 
-    CHK(BIO_write(pSocketConnection->pReadBio, pBuf, *pDataLen) > 0, STATUS_SECURE_SOCKET_READ_FAILED);
-
-    // read as much as possible
-    while(continueRead && writtenBytes < bufferLen) {
-        sslReadRet = SSL_read(pSocketConnection->pSsl, pBuf + writtenBytes, bufferLen - writtenBytes);
-        if (sslReadRet <= 0) {
-            sslReadRet = SSL_get_error(pSocketConnection->pSsl, sslReadRet);
-            switch (sslReadRet) {
-                case SSL_ERROR_WANT_WRITE:
-                    continueRead = FALSE;
-                    break;
-                case SSL_ERROR_WANT_READ:
-                case SSL_ERROR_ZERO_RETURN:
-                    break;
-                default:
-                    sslErrorRet = ERR_get_error();
-                    DLOGW("SSL_read failed with %s", ERR_error_string(sslErrorRet, NULL));
-                    break;
-            }
-            break;
-        } else {
-            writtenBytes += sslReadRet;
-        }
-    }
-
-    *pDataLen = writtenBytes;
+    CHK_STATUS(tlsSessionProcessPacket(pSocketConnection->pTlsSession, pBuf, bufferLen, pDataLen));
 
 CleanUp:
 
@@ -295,8 +223,13 @@ STATUS socketConnectionClosed(PSocketConnection pSocketConnection)
 
     CHK(pSocketConnection != NULL, STATUS_NULL_ARG);
     CHK(!ATOMIC_LOAD_BOOL(&pSocketConnection->connectionClosed), retStatus);
+    MUTEX_LOCK(pSocketConnection->lock);
     DLOGD("Close socket %d", pSocketConnection->localSocket);
     ATOMIC_STORE_BOOL(&pSocketConnection->connectionClosed, TRUE);
+    if (pSocketConnection->pTlsSession != NULL) {
+        tlsSessionShutdown(pSocketConnection->pTlsSession);
+    }
+    MUTEX_UNLOCK(pSocketConnection->lock);
 
 CleanUp:
 
@@ -351,14 +284,6 @@ BOOL socketConnectionIsConnected(PSocketConnection pSocketConnection)
 
     DLOGW("socket connection check failed with errno %s", strerror(errno));
     return FALSE;
-}
-
-// https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_verify.html
-INT32 certificateVerifyCallback(INT32 preverify_ok, X509_STORE_CTX *ctx)
-{
-    UNUSED_PARAM(preverify_ok);
-    UNUSED_PARAM(ctx);
-    return 1;
 }
 
 STATUS socketSendDataWithRetry(PSocketConnection pSocketConnection, PBYTE buf, UINT32 bufLen, PKvsIpAddress pDestIp, PUINT32 pBytesWritten)

--- a/src/source/Ice/SocketConnection.h
+++ b/src/source/Ice/SocketConnection.h
@@ -37,14 +37,9 @@ struct __SocketConnection {
     KvsIpAddress hostIpAddr;
 
     BOOL secureConnection;
-    SSL_CTX *pSslCtx;
-    BIO *pReadBio;
-    BIO *pWriteBio;
-    SSL *pSsl;
+    PTlsSession pTlsSession;
 
     MUTEX lock;
-
-    BOOL freeBios;
 
     ConnectionDataAvailableFunc dataAvailableCallbackFn;
     UINT64 dataAvailableCallbackCustomData;
@@ -145,9 +140,9 @@ BOOL socketConnectionIsClosed(PSocketConnection);
 BOOL socketConnectionIsConnected(PSocketConnection);
 
 // internal functions
-STATUS createConnectionCertificateAndKey(X509 **, EVP_PKEY **);
-INT32 certificateVerifyCallback(INT32 preverify_ok, X509_STORE_CTX *ctx);
 STATUS socketSendDataWithRetry(PSocketConnection, PBYTE, UINT32, PKvsIpAddress, PUINT32);
+STATUS socketConnectionTlsSessionOutBoundPacket(UINT64, PBYTE, UINT32);
+VOID socketConnectionTlsSessionOnStateChange(UINT64, TLS_SESSION_STATE);
 
 #ifdef  __cplusplus
 }

--- a/src/source/Ice/Tls.c
+++ b/src/source/Ice/Tls.c
@@ -1,0 +1,265 @@
+/**
+ * Kinesis Video Tcp
+ */
+#define LOG_CLASS "Tls"
+#include "../Include_i.h"
+
+STATUS createTlsSession(PTlsSessionCallbacks pCallbacks, PTlsSession *ppTlsSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PTlsSession pTlsSession = NULL;
+
+    CHK(ppTlsSession != NULL && pCallbacks != NULL, STATUS_NULL_ARG);
+    CHK(pCallbacks->outboundPacketFn != NULL, STATUS_INVALID_ARG);
+
+    pTlsSession = MEMCALLOC(1, SIZEOF(TlsSession));
+    CHK(pTlsSession != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    pTlsSession->callbacks = *pCallbacks;
+    pTlsSession->state = TLS_SESSION_STATE_NEW;
+
+CleanUp:
+    if (STATUS_FAILED(retStatus) && pTlsSession != NULL) {
+        freeTlsSession(&pTlsSession);
+    }
+
+    if (ppTlsSession != NULL) {
+        *ppTlsSession = pTlsSession;
+    }
+    
+    LEAVES();
+    return retStatus;
+}
+
+STATUS freeTlsSession(PTlsSession* ppTlsSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PTlsSession pTlsSession = NULL;
+
+    CHK(ppTlsSession != NULL, STATUS_NULL_ARG);
+
+    pTlsSession = *ppTlsSession;
+    CHK(pTlsSession != NULL, retStatus);
+
+    if (pTlsSession->pSslCtx != NULL) {
+        SSL_CTX_free(pTlsSession->pSslCtx);
+    }
+
+    if (pTlsSession->pSsl != NULL) {
+        SSL_free(pTlsSession->pSsl);
+    }
+
+    retStatus = tlsSessionShutdown(pTlsSession);
+    SAFE_MEMFREE(*ppTlsSession);
+
+CleanUp:
+    return retStatus;
+}
+
+// https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_verify.html
+INT32 tlsSessionCertificateVerifyCallback(INT32 preverify_ok, X509_STORE_CTX *ctx)
+{
+    UNUSED_PARAM(preverify_ok);
+    UNUSED_PARAM(ctx);
+    return 1;
+}
+
+STATUS tlsSessionStart(PTlsSession pTlsSession, BOOL isServer)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    BIO *pReadBio = NULL, *pWriteBio = NULL;
+    BOOL freeBios = TRUE;
+
+    CHK(pTlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pTlsSession->state == TLS_SESSION_STATE_NEW, retStatus);
+
+    pTlsSession->pSslCtx = SSL_CTX_new(SSLv23_method());
+    CHK(pTlsSession->pSslCtx != NULL, STATUS_SSL_CTX_CREATION_FAILED);
+
+    SSL_CTX_set_read_ahead(pTlsSession->pSslCtx, 1);
+    SSL_CTX_set_verify(pTlsSession->pSslCtx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, tlsSessionCertificateVerifyCallback);
+    CHK(SSL_CTX_set_cipher_list(pTlsSession->pSslCtx, "HIGH:!aNULL:!MD5:!RC4"), STATUS_SSL_CTX_CREATION_FAILED);
+
+    pTlsSession->pSsl = SSL_new(pTlsSession->pSslCtx);
+    CHK(pTlsSession->pSsl != NULL, STATUS_CREATE_SSL_FAILED);
+
+    if (isServer) {
+        SSL_set_accept_state(pTlsSession->pSsl);
+    } else {
+        SSL_set_connect_state(pTlsSession->pSsl);
+    }
+
+    SSL_set_mode(pTlsSession->pSsl, SSL_MODE_AUTO_RETRY);
+    CHK((pReadBio = BIO_new(BIO_s_mem())) != NULL, STATUS_SSL_CTX_CREATION_FAILED);
+    CHK((pWriteBio = BIO_new(BIO_s_mem())) != NULL, STATUS_SSL_CTX_CREATION_FAILED);
+
+    BIO_set_mem_eof_return(pReadBio, -1);
+    BIO_set_mem_eof_return(pWriteBio, -1);
+    SSL_set_bio(pTlsSession->pSsl, pReadBio, pWriteBio);
+    freeBios = FALSE;
+
+    /* init handshake */
+    tlsSessionChangeState(pTlsSession, TLS_SESSION_STATE_CONNECTING);
+    SSL_do_handshake(pTlsSession->pSsl);
+
+    /* send handshake */
+    CHK_STATUS(tlsSessionPutApplicationData(pTlsSession, NULL, 0));
+
+CleanUp:
+
+    CHK_LOG_ERR(retStatus);
+
+    if (STATUS_FAILED(retStatus)) {
+        if (freeBios) {
+            if (pReadBio != NULL) {
+                BIO_free(pReadBio);
+            }
+
+            if (pWriteBio != NULL) {
+                BIO_free(pWriteBio);
+            }
+        }
+        ERR_print_errors_fp (stderr);
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS tlsSessionProcessPacket(PTlsSession pTlsSession, PBYTE pData, UINT32 bufferLen, PUINT32 pDataLen)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL continueRead = TRUE;
+    INT32 sslReadRet = 0;
+    UINT32 writtenBytes = 0;
+    UINT64 sslErrorRet;
+
+    CHK(pTlsSession != NULL && pData != NULL && pDataLen != NULL, STATUS_NULL_ARG);
+    CHK(pTlsSession->state != TLS_SESSION_STATE_NEW, STATUS_SOCKET_CONNECTION_NOT_READY_TO_SEND);
+    CHK(pTlsSession->state != TLS_SESSION_STATE_CLOSED, STATUS_SOCKET_CONNECTION_CLOSED_ALREADY);
+
+    // return early if there's no data
+    CHK(*pDataLen != 0, retStatus);
+
+    CHK(BIO_write(SSL_get_rbio(pTlsSession->pSsl), pData, *pDataLen) > 0, STATUS_SECURE_SOCKET_READ_FAILED);
+
+    // read as much as possible
+    while(continueRead && writtenBytes < bufferLen) {
+        sslReadRet = SSL_read(pTlsSession->pSsl, pData + writtenBytes, bufferLen - writtenBytes);
+        if (sslReadRet <= 0) {
+            sslReadRet = SSL_get_error(pTlsSession->pSsl, sslReadRet);
+            switch (sslReadRet) {
+                case SSL_ERROR_WANT_WRITE:
+                    continueRead = FALSE;
+                    break;
+                case SSL_ERROR_WANT_READ:
+                case SSL_ERROR_ZERO_RETURN:
+                    break;
+                default:
+                    sslErrorRet = ERR_get_error();
+                    DLOGW("SSL_read failed with %s", ERR_error_string(sslErrorRet, NULL));
+                    break;
+            }
+            continueRead = FALSE;
+        } else {
+            writtenBytes += sslReadRet;
+        }
+    }
+
+    *pDataLen = writtenBytes;
+
+CleanUp:
+
+    // CHK_LOG_ERR might be too verbose
+    if (STATUS_FAILED(retStatus)) {
+        DLOGD("Warning: reading socket data failed with 0x%08x", retStatus);
+    }
+
+    return retStatus;
+}
+
+STATUS tlsSessionPutApplicationData(PTlsSession pTlsSession, PBYTE pData, UINT32 dataLen)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    INT32 sslRet = 0, sslErr = 0;
+
+    SIZE_T wBioDataLen = 0;
+    PCHAR wBioBuffer = NULL;
+
+    CHK(pTlsSession != NULL, STATUS_NULL_ARG);
+
+    if (SSL_is_init_finished(pTlsSession->pSsl)) {
+        tlsSessionChangeState(pTlsSession, TLS_SESSION_STATE_CONNECTED);
+
+        sslRet = SSL_write(pTlsSession->pSsl, pData, dataLen);
+        if (sslRet < 0){
+            sslErr = SSL_get_error(pTlsSession->pSsl, sslRet);
+            switch (sslErr) {
+                case SSL_ERROR_WANT_READ:
+                    /* explicit fall-through */
+                case SSL_ERROR_WANT_WRITE:
+                    break;
+                default:
+                    DLOGD("Warning: SSL_write failed with %s", ERR_error_string(sslErr, NULL));
+                    tlsSessionChangeState(pTlsSession, TLS_SESSION_STATE_CLOSED);
+                    break;
+            }
+
+            CHK(FALSE, STATUS_SEND_DATA_FAILED);
+        }
+    }
+
+    wBioDataLen = (SIZE_T) BIO_get_mem_data(SSL_get_wbio(pTlsSession->pSsl), &wBioBuffer);
+    CHK_ERR(wBioDataLen >= 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed");
+
+    if (wBioDataLen > 0) {
+        retStatus = pTlsSession->callbacks.outboundPacketFn(pTlsSession->callbacks.outBoundPacketFnCustomData, 
+                                                            (PBYTE) wBioBuffer, (UINT32) wBioDataLen);
+
+        /* reset bio to clear its content since it's already sent if possible */
+        BIO_reset(SSL_get_wbio(pTlsSession->pSsl));
+    }
+
+
+CleanUp:
+    return retStatus;
+}
+
+STATUS tlsSessionShutdown(PTlsSession pTlsSession)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pTlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pTlsSession->state != TLS_SESSION_STATE_CLOSED, retStatus);
+    CHK_STATUS(tlsSessionChangeState(pTlsSession, TLS_SESSION_STATE_CLOSED));
+
+CleanUp:
+
+    CHK_LOG_ERR(retStatus);
+
+    return retStatus;
+}
+
+STATUS tlsSessionChangeState(PTlsSession pTlsSession, TLS_SESSION_STATE newState)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pTlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pTlsSession->state != newState, retStatus);
+
+    pTlsSession->state = newState;
+    if (pTlsSession->callbacks.stateChangeFn != NULL) {
+        pTlsSession->callbacks.stateChangeFn(
+                pTlsSession->callbacks.stateChangeFnCustomData,
+                newState);
+    }
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}

--- a/src/source/Ice/Tls.h
+++ b/src/source/Ice/Tls.h
@@ -1,0 +1,101 @@
+#ifndef __KINESIS_VIDEO_WEBRTC_CLIENT_ICE_TLS__
+#define __KINESIS_VIDEO_WEBRTC_CLIENT_ICE_TLS__
+
+#pragma once
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  TLS_SESSION_STATE_NEW,        /* Tls is just created, but the handshake process has not started */
+  TLS_SESSION_STATE_CONNECTING, /* TLS is in the process of negotiating a secure connection and verifying the remote fingerprint. */
+  TLS_SESSION_STATE_CONNECTED,  /* TLS has completed negotiation of a secure connection and verified the remote fingerprint. */
+  TLS_SESSION_STATE_CLOSED,     /* The transport has been closed intentionally as the result of receipt of a close_notify alert */
+} TLS_SESSION_STATE;
+
+/* Callback that is fired when Tls session wishes to send packet */
+typedef STATUS (*TlsSessionOutboundPacketFunc)(UINT64, PBYTE, UINT32);
+
+/*  Callback that is fired when Tls state has changed */
+typedef VOID (*TlsSessionOnStateChange)(UINT64, TLS_SESSION_STATE);
+
+typedef struct {
+    UINT64 outBoundPacketFnCustomData;
+    // outBoundPacketFn is a required callback to tell TlsSession how to send outbound packets
+    TlsSessionOutboundPacketFunc outboundPacketFn;
+    // stateChangeFn is an optional callback to listen to TlsSession state changes
+    UINT64 stateChangeFnCustomData;
+    TlsSessionOnStateChange stateChangeFn;
+} TlsSessionCallbacks, *PTlsSessionCallbacks;
+
+typedef struct __TlsSession TlsSession, *PTlsSession;
+struct __TlsSession {
+    TlsSessionCallbacks callbacks;
+    TLS_SESSION_STATE state;
+  
+    SSL_CTX *pSslCtx;
+    SSL *pSsl;
+};
+
+/**
+ * Create TLS session.
+ * NOT THREAD SAFE.
+ * @param PTlsSessionCallbacks - callbacks
+ * @param PTlsSession* - pointer to created TlsSession object
+ *
+ * @return STATUS - status of operation
+ */
+STATUS createTlsSession(PTlsSessionCallbacks, PTlsSession*);
+
+/**
+ * Free TLS session. Not thread safe.
+ * @param PTlsSession - TlsSession object to free
+ * @return STATUS - status of operation
+ */
+STATUS freeTlsSession(PTlsSession*);
+
+/**
+ * Start TLS handshake. 
+ * NOT THREAD SAFE.
+ * @param PTlsSession - TlsSession object
+ * @param BOOL - is server
+ * @return STATUS - status of operation
+ */
+STATUS tlsSessionStart(PTlsSession, BOOL);
+
+/**
+ * Decrypt application data up to specified bytes. The decrypted data will be copied back to the original buffer.
+ * During handshaking, the return data size should be always 0 since there's no application data yet.
+ * NOT THREAD SAFE.
+ * @param PTlsSession - TlsSession object
+ * @param PBYTE - encrypted data
+ * @param UINT32 - the size of buffer that PBYTE is pointing to
+ * @param PUINT32 - pointer to the size of encrypted data and will be used to store the size of application data
+ */
+STATUS tlsSessionProcessPacket(PTlsSession, PBYTE, UINT32, PUINT32);
+
+/**
+ * Encrypt application data up to specified bytes. The encrypted data will be sent through specified callback during
+ * initialization. If NULL is specified, it'll only check for pending handshake buffer.
+ * NOT THREAD SAFE.
+ * @param PTlsSession - TlsSession object
+ * @param PBYTE - plain data
+ * @param UINT32 - the size of encrypted data
+ */
+STATUS tlsSessionPutApplicationData(PTlsSession, PBYTE, UINT32);
+
+/**
+ * Mark Tls session to be closed
+ * NOT THREAD SAFE.
+ */
+STATUS tlsSessionShutdown(PTlsSession);
+
+/* internal functions */
+STATUS tlsSessionChangeState(PTlsSession, TLS_SESSION_STATE);
+INT32 tlsSessionCertificateVerifyCallback(INT32, X509_STORE_CTX*);
+
+#ifdef  __cplusplus
+}
+#endif
+#endif  //__KINESIS_VIDEO_WEBRTC_CLIENT_ICE_TLS__

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -927,7 +927,7 @@ STATUS turnConnectionStepState(PTurnConnection pTurnConnection)
                 /* We dont support DTLS and TCP, so only options are TCP/TLS and UDP. */
                 /* TODO: add plain TCP once it becomes available. */
                 if (pTurnConnection->protocol == KVS_SOCKET_PROTOCOL_TCP &&
-                    pTurnConnection->pControlChannel->pSsl == NULL) {
+                    pTurnConnection->pControlChannel->pTlsSession == NULL) {
                     CHK_STATUS(socketConnectionInitSecureConnection(pTurnConnection->pControlChannel, FALSE));
                 }
 

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -106,6 +106,7 @@ STATUS generateJSONSafeString(PCHAR, UINT32);
 // Project internal includes
 ////////////////////////////////////////////////////
 #include "Ice/Network.h"
+#include "Ice/Tls.h"
 #include "Ice/SocketConnection.h"
 #include "Ice/ConnectionListener.h"
 #include "Stun/Stun.h"


### PR DESCRIPTION
The goal for this PR is to decouple Ice from OpenSSL so that we can easily swap the TLS implementation with mbedTLS (https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/121).

`TlsSession` is intentionally designed to be similar to our current `DtlsSession`. The idea is that if the interfaces are similar, we can merge these 2 easily in the future, and have a single proxy class that can swap between DTLS and TLS with a single flag.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
