### PR TITLE
log ice candidate protocol type. change sample to handle upcoming get…

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -356,14 +356,17 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
             CHK_STATUS(signalingClientGetIceConfigInfo(pSampleConfiguration->signalingClientHandle, i, &pIceConfigInfo));
             for (j = 0; j < pIceConfigInfo->uriCount; j++) {
                 CHECK(uriCount < MAX_ICE_SERVERS_COUNT);
-                /* - change url to "turn:ip:port?transport=udp" to do turn through UDP
-                 * - change url to "turn:ip:port?transport=tcp" will do turn through TCP/TLS currently,
-                 *   but later will be changed to plain tcp
-                 * - change url to "turns:ip:port?transport=tcp" to do turn through TCP/TLS
-                 * - "turns:ip:port?transport=udp" will just do UDP.
-                 * Currently if "transport=" is missing, ICE will try both UDP and TCP/TLS
-                 * By default use UDP since it's fastest. */
-                SNPRINTF(configuration.iceServers[uriCount + 1].urls, MAX_ICE_CONFIG_URI_LEN, "%s?transport=udp", pIceConfigInfo->uris[j]);
+                /*
+                 * if configuration.iceServers[uriCount + 1].urls is "turn:ip:port?transport=udp" then ICE will try TURN over UDP
+                 * if configuration.iceServers[uriCount + 1].urls is "turn:ip:port?transport=tcp" then ICE will try TURN over TCP/TLS
+                 * if configuration.iceServers[uriCount + 1].urls is "turns:ip:port?transport=udp", it's currently ignored because sdk dont do TURN over DTLS yet.
+                 * if configuration.iceServers[uriCount + 1].urls is "turns:ip:port?transport=tcp" then ICE will try TURN over TCP/TLS
+                 * if configuration.iceServers[uriCount + 1].urls is "turn:ip:port" then ICE will try both TURN over UPD and TCP/TLS
+                 *
+                 * It's recommended to not pass too many TURN iceServers to configuration because it will slow down ice gathering in non-trickle mode.
+                 */
+
+                STRNCPY(configuration.iceServers[uriCount + 1].urls, pIceConfigInfo->uris[j], MAX_ICE_CONFIG_URI_LEN);
                 STRNCPY(configuration.iceServers[uriCount + 1].credential, pIceConfigInfo->password, MAX_ICE_CONFIG_CREDENTIAL_LEN);
                 STRNCPY(configuration.iceServers[uriCount + 1].username, pIceConfigInfo->userName, MAX_ICE_CONFIG_USER_NAME_LEN);
 

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -32,7 +32,6 @@ extern "C" {
 
 #define STUN_HEADER_MAGIC_BYTE_OFFSET                                   4
 
-#define KVS_ICE_MAX_ICE_SERVERS                                         3
 #define KVS_ICE_MAX_RELAY_CANDIDATE_COUNT                               4
 #define KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE              10
 
@@ -168,7 +167,7 @@ struct __IceAgent {
 
     IceAgentCallbacks iceAgentCallbacks;
 
-    IceServer iceServers[KVS_ICE_MAX_ICE_SERVERS];
+    IceServer iceServers[MAX_ICE_SERVERS_COUNT];
     UINT32 iceServersCount;
 
     KvsIpAddress localNetworkInterfaces[MAX_LOCAL_NETWORK_INTERFACE_COUNT];

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -262,7 +262,7 @@ CleanUp:
 STATUS getIpWithHostName(PCHAR hostname, PKvsIpAddress destIp)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    UINT32 errCode;
+    INT32 errCode;
     struct addrinfo *res, *rp;
     BOOL resolved = FALSE;
     struct sockaddr_in *ipv4Addr;

--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -260,6 +260,7 @@ STATUS socketConnectionReadData(PSocketConnection pSocketConnection, PBYTE pBuf,
                     continueRead = FALSE;
                     break;
                 case SSL_ERROR_WANT_READ:
+                case SSL_ERROR_ZERO_RETURN:
                     break;
                 default:
                     sslErrorRet = ERR_get_error();

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -28,11 +28,6 @@ extern "C" {
 #define DEFAULT_TURN_BIND_CHANNEL_TIMEOUT                               (3 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 #define DEFAULT_TURN_CLEAN_UP_TIMEOUT                                   (10 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
-/*
- * if no application data is sent through turn for this much time then we assume that a better connection is found
- * and initiate turn clean up.
- */
-#define DEFAULT_TURN_START_CLEAN_UP_TIMEOUT                             (10 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 #define DEFAULT_TURN_ALLOCATION_REFRESH_GRACE_PERIOD                    (30 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 #define DEFAULT_TURN_PERMISSION_REFRESH_GRACE_PERIOD                    (30 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
@@ -40,7 +35,7 @@ extern "C" {
 #define DEFAULT_TURN_MESSAGE_SEND_CHANNEL_DATA_BUFFER_LEN               MAX_TURN_CHANNEL_DATA_MESSAGE_SIZE
 #define DEFAULT_TURN_MESSAGE_RECV_CHANNEL_DATA_BUFFER_LEN               MAX_TURN_CHANNEL_DATA_MESSAGE_SIZE
 #define DEFAULT_TURN_CHANNEL_DATA_BUFFER_SIZE                           512
-#define DEFAULT_TURN_MAX_PEER_COUNT                                     16
+#define DEFAULT_TURN_MAX_PEER_COUNT                                     32
 
 // all turn channel numbers must be greater than 0x4000 and less than 0x7FFF
 #define TURN_CHANNEL_BIND_CHANNEL_NUMBER_BASE                           (UINT16) 0x4000


### PR DESCRIPTION
…IceServerConfigChange. Other minor fixs.

getIceServerConfig will soon return urls in follow forms:
  - turn:ip:port?transport=udp
  - turns:ip:port?transport=udp
  - turns:ip:port?transport=tcp

Originally in Common.c we are manually appending the query param. It's removed in this commit. After this commit and before the getIceServerConfig change, ICE will try both TURN over UDP and TURN over TCP/TLS.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
