### PR TITLE
Merge free rtp packet

### DIFF
--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -98,7 +98,7 @@ STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
         || pRtpPacket->header.timestamp >= pJitterBuffer->lastPushTimestamp - pJitterBuffer->maxLatency) {
         pCurPacket = pJitterBuffer->pktBuffer[pRtpPacket->header.sequenceNumber];
         if (pCurPacket != NULL) {
-            freeRtpPacketAndRawPacket(&pCurPacket);
+            freeRtpPacket(&pCurPacket);
             pJitterBuffer->pktBuffer[pRtpPacket->header.sequenceNumber] = NULL;
         }
         pJitterBuffer->pktBuffer[pRtpPacket->header.sequenceNumber] = pRtpPacket;
@@ -106,7 +106,7 @@ STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
         DLOGS("jitterBufferPush get packet timestamp %lu seqNum %lu", pRtpPacket->header.timestamp, pRtpPacket->header.sequenceNumber);
     } else {
         // Free the packet if it is out of range, jitter buffer need to own the packet and do free
-        freeRtpPacketAndRawPacket(&pRtpPacket);
+        freeRtpPacket(&pRtpPacket);
     }
 
     CHK_STATUS(jitterBufferPop(pJitterBuffer, FALSE));
@@ -235,7 +235,7 @@ STATUS jitterBufferDropBufferData(PJitterBuffer pJitterBuffer, UINT16 startIndex
     for (; UINT16_DEC(index) != endIndex; index++) {
         pCurPacket = pJitterBuffer->pktBuffer[index];
         if (pCurPacket != NULL) {
-            freeRtpPacketAndRawPacket(&pCurPacket);
+            freeRtpPacket(&pCurPacket);
             pJitterBuffer->pktBuffer[index] = NULL;
         }
     }

--- a/src/source/PeerConnection/Retransimitter.c
+++ b/src/source/PeerConnection/Retransimitter.c
@@ -118,7 +118,7 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
                 DLOGS("Retransmit add back to rolling %lu", pRtpPacket->header.sequenceNumber);
             }
 
-            freeRtpPacketAndRawPacket(&pRtxRtpPacket);
+            freeRtpPacket(&pRtxRtpPacket);
             pRtpPacket = NULL;
         }
     }
@@ -129,7 +129,7 @@ CleanUp:
         freeRtpPacket(&pRtpPacket);
         pRtpPacket = NULL;
     }
-    freeRtpPacketAndRawPacket(&pRtpPacket);
+    freeRtpPacket(&pRtpPacket);
 
     LEAVES();
     return retStatus;

--- a/src/source/Rtcp/RtpRollingBuffer.c
+++ b/src/source/Rtcp/RtpRollingBuffer.c
@@ -45,7 +45,7 @@ STATUS freeRtpRollingBufferData(PUINT64 pData)
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     CHK(pData != NULL, STATUS_NULL_ARG);
-    CHK_STATUS(freeRtpPacketAndRawPacket((PRtpPacket*) pData));
+    CHK_STATUS(freeRtpPacket((PRtpPacket*) pData));
 CleanUp:
     LEAVES();
     return retStatus;

--- a/src/source/Rtp/RtpPacket.c
+++ b/src/source/Rtp/RtpPacket.c
@@ -208,8 +208,6 @@ STATUS setRtpPacketFromBytes(PBYTE rawPacket, UINT32 packetLength, PRtpPacket pR
             payloadType, sequenceNumber, timestamp, ssrc, csrcArray, extensionProfile,
             extensionLength, extensionPayload, rawPacket + currOffset,
             packetLength - currOffset, pRtpPacket));
-    pRtpPacket->pRawPacket = rawPacket;
-    pRtpPacket->rawPacketLength = packetLength;
 
 CleanUp:
     LEAVES();

--- a/src/source/Rtp/RtpPacket.c
+++ b/src/source/Rtp/RtpPacket.c
@@ -73,24 +73,6 @@ STATUS freeRtpPacket(PRtpPacket * ppRtpPacket)
 
     CHK(ppRtpPacket != NULL, STATUS_NULL_ARG);
 
-    SAFE_MEMFREE(*ppRtpPacket);
-
-CleanUp:
-
-    CHK_LOG_ERR(retStatus);
-
-    LEAVES();
-    return retStatus;
-}
-
-STATUS freeRtpPacketAndRawPacket(PRtpPacket * ppRtpPacket)
-{
-    ENTERS();
-
-    STATUS retStatus = STATUS_SUCCESS;
-
-    CHK(ppRtpPacket != NULL, STATUS_NULL_ARG);
-
     if (*ppRtpPacket != NULL) {
         SAFE_MEMFREE((*ppRtpPacket)->pRawPacket);
     }

--- a/src/source/Rtp/RtpPacket.h
+++ b/src/source/Rtp/RtpPacket.h
@@ -92,7 +92,6 @@ typedef RtpPacket* PRtpPacket;
 STATUS createRtpPacket(UINT8, BOOL, BOOL, UINT8, BOOL, UINT8, UINT16, UINT32, UINT32, PUINT32, UINT16, UINT32, PBYTE, PBYTE, UINT32, PRtpPacket*);
 STATUS setRtpPacket(UINT8, BOOL, BOOL, UINT8, BOOL, UINT8, UINT16, UINT32, UINT32, PUINT32, UINT16, UINT32, PBYTE, PBYTE, UINT32, PRtpPacket);
 STATUS freeRtpPacket(PRtpPacket*);
-STATUS freeRtpPacketAndRawPacket(PRtpPacket*);
 STATUS createRtpPacketFromBytes(PBYTE, UINT32, PRtpPacket*);
 STATUS constructRetransmitRtpPacketFromBytes(PBYTE, UINT32, UINT16, UINT8, UINT32, PRtpPacket*);
 STATUS setRtpPacketFromBytes(PBYTE, UINT32, PRtpPacket);

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -74,8 +74,6 @@ TEST_F(RtpFunctionalityTest, marshallUnmarshallGettingSameData)
         EXPECT_TRUE(MEMCMP(pRtpPacket->payload, pNewRtpPacket->payload, pRtpPacket->payloadLength) == 0);
 
         EXPECT_EQ(STATUS_SUCCESS, freeRtpPacket(&pNewRtpPacket));
-        MEMFREE(rawPacket);
-        rawPacket = NULL;
     }
 
     MEMFREE(packetList);

--- a/tst/RtpRollingBufferFunctionalityTest.cpp
+++ b/tst/RtpRollingBufferFunctionalityTest.cpp
@@ -64,7 +64,7 @@ TEST_F(RtpRollingBufferFunctionalityTest, appendDataToBufferAndVerify)
     EXPECT_EQ(STATUS_SUCCESS, rtpRollingBufferAddRtpPacket(pRtpRollingBuffer, pRtpPacket));
     EXPECT_EQ(3, pRtpRollingBuffer->lastIndex);
     EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
-    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacket(&pRtpPacket));
 }
 
 TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnEmptyList)
@@ -83,7 +83,7 @@ TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnEmptyList)
     EXPECT_EQ(0, filledIndexListLen);
     EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
     SAFE_MEMFREE(indexList);
-    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacket(&pRtpPacket));
 }
 
 TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnCorrectIndexs)
@@ -104,7 +104,7 @@ TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnCorrectIndexs)
     EXPECT_EQ(5, indexList[1]);
     EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
     SAFE_MEMFREE(indexList);
-    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacket(&pRtpPacket));
 }
 
 TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnIndexsFitIntoSmallBuffer)
@@ -125,7 +125,7 @@ TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnIndexsFitIntoS
     EXPECT_EQ(4, indexList[1]);
     EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
     SAFE_MEMFREE(indexList);
-    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacket(&pRtpPacket));
 }
 
 TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnCorrectIndexsWhenSeqNumGetOver65535)
@@ -149,7 +149,7 @@ TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnCorrectIndexsW
     EXPECT_EQ(65535, indexList[4]);
     EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
     SAFE_MEMFREE(indexList);
-    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacket(&pRtpPacket));
 
     indexList = (PUINT64) MEMALLOC(SIZEOF(UINT64) * 5);
     // add 0 - 131074(65538 + 65536), capacity is 5, 65534(131070) 65335(131071) 0(131072) 1(131073) 2(131074) are in rolling buffer
@@ -164,7 +164,7 @@ TEST_F(RtpRollingBufferFunctionalityTest, getIndexForSeqListReturnCorrectIndexsW
     EXPECT_EQ(131071, indexList[4]);
     EXPECT_EQ(STATUS_SUCCESS, freeRtpRollingBuffer(&pRtpRollingBuffer));
     SAFE_MEMFREE(indexList);
-    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacketAndRawPacket(&pRtpPacket));
+    EXPECT_EQ(STATUS_SUCCESS, freeRtpPacket(&pRtpPacket));
 }
 
 


### PR DESCRIPTION
*Issue #, if available:*
fix #518 
*Description of changes:*
RtpPacket should take ownership of its pRawPacket. pRawPacket is set in the following places:
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/source/PeerConnection/Rtp.c#L207
  - rawPacket is a copy and allocated at line https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/source/PeerConnection/Rtp.c#L203
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/source/PeerConnection/Rtp.c#L216
  - rawPacket is a copy and allocated at line https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/source/PeerConnection/Rtp.c#L203
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/source/Rtp/RtpPacket.c#L113
  - createRtpPacketFromBytes is called in https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/6f741f4c6830fcad7eb2ccb9f07f38367ee7fb40/src/source/Rtcp/RtpRollingBuffer.c#L66 and https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/b2d1600c62ac14f1a7c4557f914086d195caccd6/src/source/PeerConnection/PeerConnection.c#L187, in both places the rawPacket is a copy
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/93dbd03699b9eaaa9c173de888da7e0dd2f5daec/src/source/Rtp/RtpPacket.c#L158. pRawPacket is allocated and copied

Since pRawPacket is always a copy owned by pRtpPacket, it should be safe to free pRawPacket also when free pRtpPacket.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
