### PR TITLE
Signaling metrics work

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           11d0d4a5e906b26376b2cd816954d00af13503f9
+    GIT_TAG           7705175dcf687477e68d36857bae3683259182e3
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -274,6 +274,7 @@ extern "C" {
 #define STATUS_SIGNALING_ICE_CONFIG_REFRESH_FAILED                                  STATUS_SIGNALING_BASE + 0x0000002F
 #define STATUS_SIGNALING_RECONNECT_FAILED                                           STATUS_SIGNALING_BASE + 0x00000030
 #define STATUS_SIGNALING_DELETE_CALL_FAILED                                         STATUS_SIGNALING_BASE + 0x00000031
+#define STATUS_SIGNALING_INVALID_METRICS_VERSION                                    STATUS_SIGNALING_BASE + 0x00000032
 
 /*!@} */
 /*===========================================================================================*/

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -296,17 +296,17 @@ typedef struct {
     UINT64 dpApiCallLatency; //!< Latency (in 100 ns) incurred per backend API call for the data plane APIs
     UINT64 signalingClientUptime; //!< Client uptime (in 100 ns). Timestamp will be recorded at every SIGNALING_CLIENT_STATE_CONNECTED
     UINT64 connectionDuration; //!< Duration of connection (in 100 ns)
-    UINT64 numberOfMessagesSent; //!< Number of messages sent by the signaling client
-    UINT64 numberOfMessagesReceived; //!< Number of messages received by the signaling client
-    UINT64 iceRefreshCount; //!< Number of times the ICE is refreshed
-    UINT64 numberOfDynamicErrors; //!< Number of indirect errors. These are errors that are not returned as part of
+    UINT32 numberOfMessagesSent; //!< Number of messages sent by the signaling client
+    UINT32 numberOfMessagesReceived; //!< Number of messages received by the signaling client
+    UINT32 iceRefreshCount; //!< Number of times the ICE is refreshed
+    UINT32 numberOfDynamicErrors; //!< Number of indirect errors. These are errors that are not returned as part of
                                   //!< public API calls but rather when an error occurs on background threads
                                   //!< for example:
                                   //!< * When received message on the background thread is "bad"
                                   //!< * When re-connect logic fails after pre-configured retries/times out
                                   //!< * When refreshing ICE server configuration fails after pre-configured retries
                                   //!< In all of these cases the error callback (if specified) will be called.
-    UINT64 numberOfReconnects; //!< Number of reconnects in the session
+    UINT32 numberOfReconnects; //!< Number of reconnects in the session
 } SignalingClientStats, PSignalingClientStats;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -299,7 +299,8 @@ typedef struct {
     UINT32 numberOfMessagesSent; //!< Number of messages sent by the signaling client
     UINT32 numberOfMessagesReceived; //!< Number of messages received by the signaling client
     UINT32 iceRefreshCount; //!< Number of times the ICE is refreshed
-    UINT32 numberOfDynamicErrors; //!< Number of indirect errors. These are errors that are not returned as part of
+    UINT32 numberOfRuntimeErrors; //!< Number of indirect or runtime errors.
+                                  //!< These are errors that are not returned as part of
                                   //!< public API calls but rather when an error occurs on background threads
                                   //!< for example:
                                   //!< * When received message on the background thread is "bad"

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -299,6 +299,11 @@ typedef struct {
     UINT32 numberOfMessagesSent; //!< Number of messages sent by the signaling client
     UINT32 numberOfMessagesReceived; //!< Number of messages received by the signaling client
     UINT32 iceRefreshCount; //!< Number of times the ICE is refreshed
+    UINT32 numberOfErrors; //!< Number of signaling client API call failures.
+                           //!< These errors are the result of non STATUS_SUCCESS returns from all of the public
+                           //!< APIs defined for the signaling client with the exception of
+                           //!< createSignalingClientSync and freeSignalingClient invocation
+                           //!< and errors where the signaling client handle is invalid
     UINT32 numberOfRuntimeErrors; //!< Number of indirect or runtime errors.
                                   //!< These are errors that are not returned as part of
                                   //!< public API calls but rather when an error occurs on background threads

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -292,13 +292,20 @@ typedef struct {
  * @brief SignalingClientMetrics Represent the stats related to the KVS WebRTC SDK signaling client
  */
 typedef struct {
-    UINT64 apiCallLatency; //!< Latency (milliseconds) incurred per backend API call
-    UINT64 signalingClientUptime; //!< Client uptime (milliseconds). Timestamp will be recorded at every SIGNALING_CLIENT_STATE_CONNECTED
-    UINT64 connectionDuration; //!< Duration of connection (milliseconds)
+    UINT64 cpApiCallLatency; //!< Latency (in 100 ns) incurred per backend API call for the control plane APIs
+    UINT64 dpApiCallLatency; //!< Latency (in 100 ns) incurred per backend API call for the data plane APIs
+    UINT64 signalingClientUptime; //!< Client uptime (in 100 ns). Timestamp will be recorded at every SIGNALING_CLIENT_STATE_CONNECTED
+    UINT64 connectionDuration; //!< Duration of connection (in 100 ns)
     UINT64 numberOfMessagesSent; //!< Number of messages sent by the signaling client
     UINT64 numberOfMessagesReceived; //!< Number of messages received by the signaling client
     UINT64 iceRefreshCount; //!< Number of times the ICE is refreshed
-    UINT64 numberOfRecoverableErrors; //!< Number of recoverable errors. Will be a static count returned when requested
+    UINT64 numberOfDynamicErrors; //!< Number of indirect errors. These are errors that are not returned as part of
+                                  //!< public API calls but rather when an error occurs on background threads
+                                  //!< for example:
+                                  //!< * When received message on the background thread is "bad"
+                                  //!< * When re-connect logic fails after pre-configured retries/times out
+                                  //!< * When refreshing ICE server configuration fails after pre-configured retries
+                                  //!< In all of these cases the error callback (if specified) will be called.
     UINT64 numberOfReconnects; //!< Number of reconnects in the session
 } SignalingClientStats, PSignalingClientStats;
 

--- a/src/source/Signaling/Client.c
+++ b/src/source/Signaling/Client.c
@@ -68,6 +68,7 @@ STATUS signalingClientSendMessageSync(SIGNALING_CLIENT_HANDLE signalingClientHan
 
 CleanUp:
 
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
     LEAVES();
     return retStatus;
 }
@@ -84,6 +85,7 @@ STATUS signalingClientConnectSync(SIGNALING_CLIENT_HANDLE signalingClientHandle)
 
 CleanUp:
 
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
     LEAVES();
     return retStatus;
 }
@@ -100,6 +102,7 @@ STATUS signalingClientDisconnectSync(SIGNALING_CLIENT_HANDLE signalingClientHand
 
 CleanUp:
 
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
     LEAVES();
     return retStatus;
 }
@@ -116,6 +119,7 @@ STATUS signalingClientDeleteSync(SIGNALING_CLIENT_HANDLE signalingClientHandle)
 
 CleanUp:
 
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
     LEAVES();
     return retStatus;
 }
@@ -132,6 +136,7 @@ STATUS signalingClientGetIceConfigInfoCount(SIGNALING_CLIENT_HANDLE signalingCli
 
 CleanUp:
 
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
     LEAVES();
     return retStatus;
 }
@@ -148,6 +153,7 @@ STATUS signalingClientGetIceConfigInfo(SIGNALING_CLIENT_HANDLE signalingClientHa
 
 CleanUp:
 
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
     LEAVES();
     return retStatus;
 }
@@ -173,6 +179,7 @@ CleanUp:
         *pState = state;
     }
 
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
     LEAVES();
     return retStatus;
 }
@@ -250,14 +257,15 @@ STATUS signalingClientGetMetrics(SIGNALING_CLIENT_HANDLE signalingClientHandle, 
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
+    PSignalingClient pSignalingClient = FROM_SIGNALING_CLIENT_HANDLE(signalingClientHandle);
 
     DLOGV("Signaling Client Get Metrics");
 
-    CHK_STATUS(signalingGetMetrics(FROM_SIGNALING_CLIENT_HANDLE(signalingClientHandle),
-            pSignalingClientMetrics));
+    CHK_STATUS(signalingGetMetrics(pSignalingClient, pSignalingClientMetrics));
 
 CleanUp:
 
+    SIGNALING_UPDATE_ERROR_COUNT(pSignalingClient, retStatus);
     LEAVES();
     return retStatus;
 }

--- a/src/source/Signaling/Client.c
+++ b/src/source/Signaling/Client.c
@@ -245,3 +245,19 @@ CleanUp:
     LEAVES();
     return retStatus;
 }
+
+STATUS signalingClientGetMetrics(SIGNALING_CLIENT_HANDLE signalingClientHandle, PSignalingClientMetrics pSignalingClientMetrics)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    DLOGV("Signaling Client Get Metrics");
+
+    CHK_STATUS(signalingGetMetrics(FROM_SIGNALING_CLIENT_HANDLE(signalingClientHandle),
+            pSignalingClientMetrics));
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1396,7 +1396,7 @@ CleanUp:
         // Call the error handler in case of an error
         if (STATUS_FAILED(retStatus)) {
             // Update the diagnostics before calling the error callback
-            ATOMIC_INCREMENT(&pSignalingClient->diagnostics.numberOfDynamicErrors);
+            ATOMIC_INCREMENT(&pSignalingClient->diagnostics.numberOfRuntimeErrors);
             if (pSignalingClient->signalingClientCallbacks.errorReportFn != NULL) {
                 reconnectErrLen = SNPRINTF(reconnectErrMsg, SIGNALING_MAX_ERROR_MESSAGE_LEN,
                                            SIGNALING_RECONNECT_ERROR_MSG, retStatus);
@@ -1755,7 +1755,7 @@ CleanUp:
     CHK_LOG_ERR(retStatus);
 
     if (pSignalingClient != NULL && STATUS_FAILED(retStatus)) {
-        ATOMIC_INCREMENT(&pSignalingClient->diagnostics.numberOfDynamicErrors);
+        ATOMIC_INCREMENT(&pSignalingClient->diagnostics.numberOfRuntimeErrors);
         if (pSignalingClient->signalingClientCallbacks.errorReportFn != NULL) {
             retStatus = pSignalingClient->signalingClientCallbacks.errorReportFn(
                     pSignalingClient->signalingClientCallbacks.customData,

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -154,9 +154,6 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
 
     // Initializing the diagnostics mostly is taken care of by zero-mem in MEMCALLOC
     pSignalingClient->diagnostics.createTime = GETTIME();
-    pSignalingClient->diagnostics.connectTime = 0;
-    pSignalingClient->diagnostics.cpApiLatency = 0;
-    pSignalingClient->diagnostics.dpApiLatency = 0;
 
     // At this point we have constructed the main object and we can assign to the returned pointer
     *ppSignalingClient = pSignalingClient;
@@ -1226,6 +1223,7 @@ STATUS signalingGetMetrics(PSignalingClient pSignalingClient, PSignalingClientMe
     pSignalingClientMetrics->signalingClientStats.numberOfMessagesSent = (UINT32) pSignalingClient->diagnostics.numberOfMessagesSent;
     pSignalingClientMetrics->signalingClientStats.numberOfMessagesReceived = (UINT32) pSignalingClient->diagnostics.numberOfMessagesReceived;
     pSignalingClientMetrics->signalingClientStats.iceRefreshCount = (UINT32) pSignalingClient->diagnostics.iceRefreshCount;
+    pSignalingClientMetrics->signalingClientStats.numberOfErrors = (UINT32) pSignalingClient->diagnostics.numberOfErrors;
     pSignalingClientMetrics->signalingClientStats.numberOfRuntimeErrors = (UINT32) pSignalingClient->diagnostics.numberOfRuntimeErrors;
     pSignalingClientMetrics->signalingClientStats.numberOfReconnects = (UINT32) pSignalingClient->diagnostics.numberOfReconnects;
     pSignalingClientMetrics->signalingClientStats.cpApiCallLatency = pSignalingClient->diagnostics.cpApiLatency;

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -50,6 +50,10 @@ extern "C" {
 // Async ICE config refresh delay in case if the signaling is not yet in READY state
 #define SIGNALING_ASYNC_ICE_CONFIG_REFRESH_DELAY                            (50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
+
+// API call latency calculation
+#define SIGNALING_API_LATENCY_CALCULATION(t)                                (GETTIME() - (t))
+
 // Forward declaration
 typedef struct __LwsCallInfo *PLwsCallInfo;
 
@@ -100,6 +104,21 @@ typedef struct {
     MUTEX lock;
     CVAR await;
 } ThreadTracker, *PThreadTracker;
+
+/**
+ * Internal structure tracking various parameters for diagnostics and metrics/stats
+ */
+typedef struct {
+    UINT64 createTime;
+    UINT64 connectTime;
+    UINT64 numberOfMessagesSent;
+    UINT64 numberOfMessagesReceived;
+    UINT64 iceRefreshCount;
+    UINT64 numberOfDynamicErrors;
+    UINT64 numberOfReconnects;
+    UINT64 cpApiLatency;
+    UINT64 dpApiLatency;
+} SignalingDiagnostics, PSignalingDiagnostics;
 
 /**
  * Internal representation of the Signaling client.
@@ -236,6 +255,9 @@ typedef struct {
     // Timer queue to handle stale ICE configuration
     TIMER_QUEUE_HANDLE timerQueueHandle;
 
+    // Internal diagnostics object
+    SignalingDiagnostics diagnostics;
+
     // Tracking when was the Last time the APIs were called
     UINT64 describeTime;
     UINT64 createTime;
@@ -283,6 +305,7 @@ STATUS getChannelEndpoint(PSignalingClient, UINT64);
 STATUS getIceConfig(PSignalingClient, UINT64);
 STATUS connectSignalingChannel(PSignalingClient, UINT64);
 STATUS deleteChannel(PSignalingClient, UINT64);
+STATUS signalingGetMetrics(PSignalingClient, PSignalingClientMetrics);
 
 #ifdef  __cplusplus
 }

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -55,9 +55,9 @@ extern "C" {
 #define SIGNALING_API_LATENCY_CALCULATION(pClient, time, isCpApi) \
         MUTEX_LOCK((pClient)->diagnosticsLock); \
         if (isCpApi) { \
-            (pClient)->diagnostics.cpApiLatency = (GETTIME() - (time)); \
+            (pClient)->diagnostics.cpApiLatency = EMA_ACCUMULATOR_GET_NEXT((pClient)->diagnostics.cpApiLatency, GETTIME() - (time)); \
         } else { \
-            (pClient)->diagnostics.dpApiLatency = (GETTIME() - (time)); \
+            (pClient)->diagnostics.dpApiLatency = EMA_ACCUMULATOR_GET_NEXT((pClient)->diagnostics.dpApiLatency, GETTIME() - (time)); \
         } \
         MUTEX_UNLOCK((pClient)->diagnosticsLock); \
 
@@ -119,7 +119,7 @@ typedef struct {
     volatile SIZE_T numberOfMessagesSent;
     volatile SIZE_T numberOfMessagesReceived;
     volatile SIZE_T iceRefreshCount;
-    volatile SIZE_T numberOfDynamicErrors;
+    volatile SIZE_T numberOfRuntimeErrors;
     volatile SIZE_T numberOfReconnects;
     UINT64 createTime;
     UINT64 connectTime;

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -50,7 +50,6 @@ extern "C" {
 // Async ICE config refresh delay in case if the signaling is not yet in READY state
 #define SIGNALING_ASYNC_ICE_CONFIG_REFRESH_DELAY                            (50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
-
 // API call latency calculation
 #define SIGNALING_API_LATENCY_CALCULATION(pClient, time, isCpApi) \
         MUTEX_LOCK((pClient)->diagnosticsLock); \
@@ -60,6 +59,11 @@ extern "C" {
             (pClient)->diagnostics.dpApiLatency = EMA_ACCUMULATOR_GET_NEXT((pClient)->diagnostics.dpApiLatency, GETTIME() - (time)); \
         } \
         MUTEX_UNLOCK((pClient)->diagnosticsLock); \
+
+#define SIGNALING_UPDATE_ERROR_COUNT(pClient, status) \
+        if((pClient) != NULL && STATUS_FAILED(status)) { \
+            ATOMIC_INCREMENT(&(pClient)->diagnostics.numberOfErrors); \
+        } \
 
 // Forward declaration
 typedef struct __LwsCallInfo *PLwsCallInfo;
@@ -119,6 +123,7 @@ typedef struct {
     volatile SIZE_T numberOfMessagesSent;
     volatile SIZE_T numberOfMessagesReceived;
     volatile SIZE_T iceRefreshCount;
+    volatile SIZE_T numberOfErrors;
     volatile SIZE_T numberOfRuntimeErrors;
     volatile SIZE_T numberOfReconnects;
     UINT64 createTime;

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -257,6 +257,7 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfReconnects);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesSent);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesReceived);
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfErrors);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfRuntimeErrors);
     EXPECT_EQ(1, metrics.signalingClientStats.iceRefreshCount);
     EXPECT_NE(0, metrics.signalingClientStats.signalingClientUptime);
@@ -270,6 +271,7 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfReconnects);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesSent);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesReceived);
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfErrors);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfRuntimeErrors);
     EXPECT_EQ(1, metrics.signalingClientStats.iceRefreshCount);
     EXPECT_NE(0, metrics.signalingClientStats.signalingClientUptime);
@@ -291,6 +293,26 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfReconnects);
     EXPECT_EQ(1, metrics.signalingClientStats.numberOfMessagesSent);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesReceived);
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfErrors);
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfRuntimeErrors);
+    EXPECT_EQ(1, metrics.signalingClientStats.iceRefreshCount);
+    EXPECT_NE(0, metrics.signalingClientStats.signalingClientUptime);
+    EXPECT_NE(0, metrics.signalingClientStats.connectionDuration);
+    EXPECT_NE(0, metrics.signalingClientStats.cpApiCallLatency);
+    EXPECT_NE(0, metrics.signalingClientStats.dpApiCallLatency);
+
+    // Make a couple of bad API invocations
+    EXPECT_NE(STATUS_SUCCESS, signalingClientGetIceConfigInfoCount(mSignalingClientHandle, NULL));
+    EXPECT_NE(STATUS_SUCCESS, signalingClientGetIceConfigInfo(mSignalingClientHandle, 0, NULL));
+    EXPECT_NE(STATUS_SUCCESS, signalingClientGetCurrentState(mSignalingClientHandle, NULL));
+    EXPECT_NE(STATUS_SUCCESS, signalingClientGetMetrics(mSignalingClientHandle, NULL));
+    EXPECT_NE(STATUS_SUCCESS, signalingClientSendMessageSync(mSignalingClientHandle, NULL));
+
+    EXPECT_EQ(STATUS_SUCCESS, signalingClientGetMetrics(mSignalingClientHandle, &metrics));
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfReconnects);
+    EXPECT_EQ(1, metrics.signalingClientStats.numberOfMessagesSent);
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesReceived);
+    EXPECT_EQ(5, metrics.signalingClientStats.numberOfErrors);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfRuntimeErrors);
     EXPECT_EQ(1, metrics.signalingClientStats.iceRefreshCount);
     EXPECT_NE(0, metrics.signalingClientStats.signalingClientUptime);

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -257,10 +257,10 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfReconnects);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesSent);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesReceived);
-    EXPECT_EQ(0, metrics.signalingClientStats.numberOfDynamicErrors);
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfRuntimeErrors);
     EXPECT_EQ(1, metrics.signalingClientStats.iceRefreshCount);
     EXPECT_NE(0, metrics.signalingClientStats.signalingClientUptime);
-    EXPECT_EQ(INVALID_TIMESTAMP_VALUE, metrics.signalingClientStats.connectionDuration);
+    EXPECT_EQ(0, metrics.signalingClientStats.connectionDuration);
     EXPECT_NE(0, metrics.signalingClientStats.cpApiCallLatency);
     EXPECT_NE(0, metrics.signalingClientStats.dpApiCallLatency);
 
@@ -270,10 +270,10 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfReconnects);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesSent);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesReceived);
-    EXPECT_EQ(0, metrics.signalingClientStats.numberOfDynamicErrors);
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfRuntimeErrors);
     EXPECT_EQ(1, metrics.signalingClientStats.iceRefreshCount);
     EXPECT_NE(0, metrics.signalingClientStats.signalingClientUptime);
-    EXPECT_NE(INVALID_TIMESTAMP_VALUE, metrics.signalingClientStats.connectionDuration);
+    EXPECT_NE(0, metrics.signalingClientStats.connectionDuration);
     EXPECT_NE(0, metrics.signalingClientStats.cpApiCallLatency);
     EXPECT_NE(0, metrics.signalingClientStats.dpApiCallLatency);
 
@@ -291,10 +291,10 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfReconnects);
     EXPECT_EQ(1, metrics.signalingClientStats.numberOfMessagesSent);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesReceived);
-    EXPECT_EQ(0, metrics.signalingClientStats.numberOfDynamicErrors);
+    EXPECT_EQ(0, metrics.signalingClientStats.numberOfRuntimeErrors);
     EXPECT_EQ(1, metrics.signalingClientStats.iceRefreshCount);
     EXPECT_NE(0, metrics.signalingClientStats.signalingClientUptime);
-    EXPECT_NE(INVALID_TIMESTAMP_VALUE, metrics.signalingClientStats.connectionDuration);
+    EXPECT_NE(0, metrics.signalingClientStats.connectionDuration);
     EXPECT_NE(0, metrics.signalingClientStats.cpApiCallLatency);
     EXPECT_NE(0, metrics.signalingClientStats.dpApiCallLatency);
 

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -267,6 +267,10 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
 
     // Connect and get metrics
     EXPECT_EQ(STATUS_SUCCESS, signalingClientConnectSync(mSignalingClientHandle));
+
+    // Await for a little to ensure we get some metrics for the connection duration
+    THREAD_SLEEP(200 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+
     EXPECT_EQ(STATUS_SUCCESS, signalingClientGetMetrics(mSignalingClientHandle, &metrics));
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfReconnects);
     EXPECT_EQ(0, metrics.signalingClientStats.numberOfMessagesSent);

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -13,6 +13,7 @@ UINT64 gTotalWebRtcClientMemoryUsage = 0;
 MUTEX gTotalWebRtcClientMemoryMutex;
 
 WebRtcClientTestBase::WebRtcClientTestBase() :
+        mSignalingClientHandle(INVALID_SIGNALING_CLIENT_HANDLE_VALUE),
         mAccessKey(NULL),
         mSecretKey(NULL),
         mSessionToken(NULL),


### PR DESCRIPTION
*Issue #, if available:*

This is the first cut for the signaling metrics work. Not yet finished. 

Need to

* Add EMA (Exponential Mean Averaging) for the durations once this is exposed from PIC which is ongoing
* Look for ways to not use interlocking (for performance and complexity reasons) as the metrics operations could soft-lock with reading them/updating.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
