### PR TITLE
Log errno if getaddrinfo returns EAI_SYSTEM

### DIFF
--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -291,6 +291,7 @@ STATUS getIpWithHostName(PCHAR hostname, PKvsIpAddress destIp)
 {
     STATUS retStatus = STATUS_SUCCESS;
     INT32 errCode;
+    PCHAR errStr;
     struct addrinfo *res, *rp;
     BOOL resolved = FALSE;
     struct sockaddr_in *ipv4Addr;
@@ -298,7 +299,11 @@ STATUS getIpWithHostName(PCHAR hostname, PKvsIpAddress destIp)
 
     CHK(hostname != NULL, STATUS_NULL_ARG);
 
-    CHK_ERR((errCode = getaddrinfo(hostname, NULL, NULL, &res)) == 0, STATUS_RESOLVE_HOSTNAME_FAILED, "getaddrinfo() with errno %s", gai_strerror(errCode));
+    errCode = getaddrinfo(hostname, NULL, NULL, &res);
+    if (errCode != 0) {
+        errStr = errCode == EAI_SYSTEM ? strerror(errno) : (PCHAR) gai_strerror(errCode);
+        CHK_ERR(FALSE, STATUS_RESOLVE_HOSTNAME_FAILED, "getaddrinfo() with errno %s", errStr);
+    }
 
     for (rp = res; rp != NULL && !resolved; rp = rp->ai_next) {
         if (rp->ai_family == AF_INET) {

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -28,6 +28,11 @@ extern "C" {
 #    define NO_SIGNAL MSG_NOSIGNAL
 #endif
 
+// Some systems such as Windows doesn't have this value
+#ifndef EAI_SYSTEM
+#define EAI_SYSTEM -11
+#endif
+
 typedef enum {
     KVS_SOCKET_PROTOCOL_NONE,
     KVS_SOCKET_PROTOCOL_TCP,


### PR DESCRIPTION
Issue #580 

It's possible that `getaddrinfo` returns a system error, in which case we'll lose the context of what caused the error. This PR will fix this by printing out the error cause from errno.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
