### PR TITLE
configure libwebsocket to fallback to gethostbyname if getaddrinfo fails

### DIFF
--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -33,6 +33,7 @@ ExternalProject_Add(project_libwebsockets
         -DLWS_WITH_SHARED=${LWS_WITH_SHARED}
         -DLWS_STATIC_PIC=1
         -DLWS_WITH_ZLIB=0
+        -DLWS_FALLBACK_GETHOSTBYNAME=ON
 # enable for debug output        -DCMAKE_BUILD_TYPE=DEBUG
         -DOPENSSL_ROOT_DIR=${OPENSSL_DIR}
         BUILD_ALWAYS      TRUE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
