### PR TITLE
Improve SDP conformation with RFC

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           7705175dcf687477e68d36857bae3683259182e3
+    GIT_TAG           6d4f72f2b063ed65ca530b64ed88c002ad051546
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/src/source/PeerConnection/SessionDescription.h
+++ b/src/source/PeerConnection/SessionDescription.h
@@ -10,7 +10,8 @@ SessionDescription internal include file
 extern "C" {
 #endif
 
-#define SESSION_DESCRIPTION_INIT_LINE_ENDING "\\r\\n"
+#define SESSION_DESCRIPTION_INIT_LINE_ENDING            "\\r\\n"
+#define SESSION_DESCRIPTION_INIT_LINE_ENDING_WITHOUT_CR "\\n"
 
 #define SESSION_DESCRIPTION_INIT_TEMPLATE_HEAD "{\"type\": \"%s\", \"sdp\": \""
 #define SESSION_DESCRIPTION_INIT_TEMPLATE_TAIL "\"}"

--- a/src/source/Sdp/Deserialize.c
+++ b/src/source/Sdp/Deserialize.c
@@ -93,6 +93,10 @@ STATUS deserializeSessionDescription(PSessionDescription pSessionDescription, PC
     while ((next = STRNCHR(curr, tail - curr, '\n')) != NULL) {
         lineLen = (UINT32) (next - curr);
 
+        if (lineLen > 0 && curr[lineLen - 1] == '\r') {
+            lineLen--;
+        }
+
         if (0 == STRNCMP(curr, SDP_MEDIA_NAME_MARKER, (ARRAY_SIZE(SDP_MEDIA_NAME_MARKER) - 1))) {
             CHK_STATUS(parseMediaName(pSessionDescription, curr, lineLen));
         }

--- a/src/source/Sdp/Sdp.h
+++ b/src/source/Sdp/Sdp.h
@@ -29,6 +29,12 @@ extern "C" {
 #define    SDP_URI_MARKER                      "u="
 #define    SDP_VERSION_MARKER                  "v="
 
+// The sequence CRLF (0x0d0a) is used to end a record, although parsers SHOULD be
+// tolerant and also accept records terminated with a single newline
+// character.
+// Reference: https://tools.ietf.org/html/rfc4566#section-5
+#define    SDP_LINE_SEPARATOR                  "\r\n"
+
 #define    SDP_CANDIDATE_TYPE_HOST             "host"
 #define    SDP_CANDIDATE_TYPE_SERFLX           "srflx"
 #define    SDP_CANDIDATE_TYPE_PRFLX            "prflx"

--- a/src/source/Sdp/Serialize.c
+++ b/src/source/Sdp/Serialize.c
@@ -9,7 +9,7 @@ STATUS serializeVersion(UINT64 version, PCHAR *ppOutputData, PUINT32 pTotalWritt
 
     currentWriteSize = SNPRINTF(*ppOutputData,
                            (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                           SDP_VERSION_MARKER"%" PRIu64 "\n",
+                           SDP_VERSION_MARKER"%" PRIu64 SDP_LINE_SEPARATOR,
                            version);
 
     CHK(*ppOutputData == NULL || ((*pBufferSize - *pTotalWritten) >= currentWriteSize), STATUS_BUFFER_TOO_SMALL);
@@ -40,7 +40,7 @@ STATUS serializeOrigin(PSdpOrigin pSDPOrigin, PCHAR *ppOutputData, PUINT32 pTota
 
         currentWriteSize = SNPRINTF(*ppOutputData,
                                (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                               SDP_ORIGIN_MARKER"%s %" PRIu64 " %" PRIu64 " %s %s %s\n",
+                               SDP_ORIGIN_MARKER"%s %" PRIu64 " %" PRIu64 " %s %s %s" SDP_LINE_SEPARATOR,
                                pSDPOrigin->userName,
                                pSDPOrigin->sessionId,
                                pSDPOrigin->sessionVersion,
@@ -70,7 +70,7 @@ STATUS serializeSessionName(PCHAR sessionName, PCHAR *ppOutputData, PUINT32 pTot
     if (sessionName[0] != '\0') {
         currentWriteSize = SNPRINTF(*ppOutputData,
                                (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                               SDP_SESSION_NAME_MARKER"%s\n",
+                               SDP_SESSION_NAME_MARKER"%s" SDP_LINE_SEPARATOR,
                                sessionName);
 
         CHK(*ppOutputData == NULL || ((*pBufferSize - *pTotalWritten) >= currentWriteSize), STATUS_BUFFER_TOO_SMALL);
@@ -94,7 +94,7 @@ STATUS serializeTimeDescription(PSdpTimeDescription pSDPTimeDescription, PCHAR *
 
     currentWriteSize = SNPRINTF(*ppOutputData,
                            (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                           SDP_TIME_DESCRIPTION_MARKER"%" PRIu64 " %" PRIu64 "\n",
+                           SDP_TIME_DESCRIPTION_MARKER"%" PRIu64 " %" PRIu64 SDP_LINE_SEPARATOR,
                            pSDPTimeDescription->startTime,
                            pSDPTimeDescription->stopTime);
 
@@ -116,12 +116,12 @@ STATUS serializeAttribute(PSdpAttributes pSDPAttributes, PCHAR *ppOutputData, PU
     if (pSDPAttributes->attributeValue[0] == '\0') {
         currentWriteSize = SNPRINTF(*ppOutputData,
                                (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                               SDP_ATTRIBUTE_MARKER"%s\n",
+                               SDP_ATTRIBUTE_MARKER"%s" SDP_LINE_SEPARATOR,
                                pSDPAttributes->attributeName);
     } else {
         currentWriteSize = snprintf(*ppOutputData,
                                (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                               SDP_ATTRIBUTE_MARKER"%s:%s\n",
+                               SDP_ATTRIBUTE_MARKER"%s:%s" SDP_LINE_SEPARATOR,
                                pSDPAttributes->attributeName,
                                pSDPAttributes->attributeValue);
     }
@@ -144,7 +144,7 @@ STATUS serializeMediaName(PCHAR pMediaName, PCHAR *ppOutputData, PUINT32 pTotalW
     if (pMediaName[0] != '\0') {
         currentWriteSize = snprintf(*ppOutputData,
                                (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                               SDP_MEDIA_NAME_MARKER"%s\n",
+                               SDP_MEDIA_NAME_MARKER"%s" SDP_LINE_SEPARATOR,
                                pMediaName);
 
         CHK(*ppOutputData == NULL || ((*pBufferSize - *pTotalWritten) >= currentWriteSize), STATUS_BUFFER_TOO_SMALL);
@@ -169,7 +169,7 @@ STATUS serializeMediaConnectionInformation(PSdpConnectionInformation pSdpConnect
     if (pSdpConnectionInformation->networkType[0] != '\0') {
         currentWriteSize = SNPRINTF(*ppOutputData,
                                (*ppOutputData) == NULL ? 0 : *pBufferSize - *pTotalWritten,
-                               SDP_CONNECTION_INFORMATION_MARKER"%s %s %s\n",
+                               SDP_CONNECTION_INFORMATION_MARKER"%s %s %s" SDP_LINE_SEPARATOR,
                                pSdpConnectionInformation->networkType,
                                pSdpConnectionInformation->addressType,
                                pSdpConnectionInformation->connectionAddress);

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -115,7 +115,7 @@ TEST_F(PeerConnectionApiTest, deserializeSessionDescriptionInit)
 
     auto validSessionDescriptionInit = "{sdp: \"KVS\\r\\nWebRTC\\r\\nSDP\\r\\nValue\\r\\n\", type: \"offer\"}";
     EXPECT_EQ(deserializeSessionDescriptionInit((PCHAR) validSessionDescriptionInit, STRLEN(validSessionDescriptionInit), &rtcSessionDescriptionInit), STATUS_SUCCESS);
-    EXPECT_STREQ(rtcSessionDescriptionInit.sdp, "KVS\nWebRTC\nSDP\nValue\n");
+    EXPECT_STREQ(rtcSessionDescriptionInit.sdp, "KVS\r\nWebRTC\r\nSDP\r\nValue\r\n");
     EXPECT_EQ(rtcSessionDescriptionInit.type, SDP_TYPE_OFFER);
 }
 


### PR DESCRIPTION
Improve SDP conformation with RFC

Resolves https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/587

Changes:
 * SDP parser now works with CRLF and LF
* SDP line separator is now using CRLF to conform with RFC, https://tools.ietf.org/html/rfc4566#section-5
* Add unit tests for CRLF cases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
