### PR TITLE
Add missing documentation about how to set session token

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ export AWS_ACCESS_KEY_ID= <AWS account access key>
 export AWS_SECRET_ACCESS_KEY= <AWS account secret key>
 ```
 
+* Optionally, set AWS_SESSION_TOKEN if integrating with temporary token
+
+```
+export AWS_SESSION_TOKEN=<session token>
+```
+
 * Region is optional, if not being set, then us-west-2 will be used as default region.
 
 ```


### PR DESCRIPTION
Add missing documentation about how to set session token.

Resolves https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/641


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
