### PR TITLE
Adapt public stats interface to align with spec

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -380,7 +380,7 @@ STATUS gatherIceServerStats(PSampleStreamingSession pSampleStreamingSession)
     rtcmetrics.requestedTypeOfStats = RTC_STATS_TYPE_ICE_SERVER;
     for (; j < pSampleStreamingSession->pSampleConfiguration->iceUriCount; j++) {
         rtcmetrics.rtcStatsObject.iceServerStats.iceServerIndex = j;
-        CHK_STATUS(rtcPeerConnectionGetMetrics(pSampleStreamingSession->pPeerConnection, &rtcmetrics));
+        CHK_STATUS(rtcPeerConnectionGetMetrics(pSampleStreamingSession->pPeerConnection, NULL, &rtcmetrics));
         DLOGD("ICE Server URL: %s", rtcmetrics.rtcStatsObject.iceServerStats.url);
         DLOGD("ICE Server port: %d", rtcmetrics.rtcStatsObject.iceServerStats.port);
         DLOGD("ICE Server protocol: %s", rtcmetrics.rtcStatsObject.iceServerStats.protocol);

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1869,9 +1869,13 @@ PUBLIC_API STATUS signalingClientGetMetrics(SIGNALING_CLIENT_HANDLE, PSignalingC
  * is expected to pass in the specific iceServerIndex for which the stats are desired
 
  * @param [in] PRtcPeerConnection Peer connection for which the stats need to be collected
+ * @param [in] PRtcRtpTransceiver set to desired transceiver for RTP stats, NULL otherwise
+ * If set to NULL for RTP stats, the stats for the first transceiver are returned.
  * @param [in/out] PRtcStats The stats object with the RTCStatsType field populated
+ *
+ * Reference: https://www.w3.org/TR/webrtc/#rtcpeerconnection-interface-extensions-1
  */
-PUBLIC_API STATUS rtcPeerConnectionGetMetrics(PRtcPeerConnection, PRtcStats);
+PUBLIC_API STATUS rtcPeerConnectionGetMetrics(PRtcPeerConnection, PRtcRtpTransceiver, PRtcStats);
 
 #ifdef __cplusplus
 }

--- a/src/source/Metrics/Metrics.c
+++ b/src/source/Metrics/Metrics.c
@@ -116,17 +116,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS logWebRTCMetrics(PRtcPeerConnection pRtcPeerConnection, RTC_STATS_TYPE statsType)
-{
-    UNUSED_PARAM(statsType);
-    STATUS retStatus = STATUS_SUCCESS;
-    CHK(pRtcPeerConnection != NULL, STATUS_NULL_ARG);
-    DLOGW("logWebRTCMetrics not supported currently");
-CleanUp:
-    return retStatus;
-}
-
-STATUS rtcPeerConnectionGetMetrics(PRtcPeerConnection pRtcPeerConnection, PRtcStats pRtcMetrics)
+STATUS rtcPeerConnectionGetMetrics(PRtcPeerConnection pRtcPeerConnection, PRtcRtpTransceiver pRtcRtpTransceiver, PRtcStats pRtcMetrics)
 {
     STATUS retStatus = STATUS_SUCCESS;
     CHK(pRtcPeerConnection != NULL && pRtcMetrics != NULL, STATUS_NULL_ARG);
@@ -144,10 +134,10 @@ STATUS rtcPeerConnectionGetMetrics(PRtcPeerConnection pRtcPeerConnection, PRtcSt
             getTransportStats(pRtcPeerConnection, &pRtcMetrics->rtcStatsObject.transportStats);
             break;
         case RTC_STATS_TYPE_REMOTE_INBOUND_RTP:
-            getRtpRemoteInboundStats(pRtcPeerConnection, NULL, &pRtcMetrics->rtcStatsObject.remoteInboundRtpStreamStats);
+            getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &pRtcMetrics->rtcStatsObject.remoteInboundRtpStreamStats);
             break;
         case RTC_STATS_TYPE_OUTBOUND_RTP:
-            getRtpOutboundStats(pRtcPeerConnection, NULL, &pRtcMetrics->rtcStatsObject.outboundRtpStreamStats);
+            getRtpOutboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &pRtcMetrics->rtcStatsObject.outboundRtpStreamStats);
             break;
         case RTC_STATS_TYPE_ICE_SERVER:
             pRtcMetrics->timestamp = GETTIME();

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -484,12 +484,13 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
     pKvsPeerConnection = pKvsRtpTransceiver->pKvsPeerConnection;
 
     ssrc = pKvsRtpTransceiver->sender.ssrc;
-    DLOGD("rtcpReportsCallback %" PRIu64 " ssrc: %u rtxssrc: %u", currentTime, ssrc, pKvsRtpTransceiver->sender.rtxSsrc);
+    DLOGV("rtcpReportsCallback %" PRIu64 " ssrc: %u rtxssrc: %u", currentTime, ssrc, pKvsRtpTransceiver->sender.rtxSsrc);
+
     // check if ice agent is connected, reschedule in 200msec if not
     ready = pKvsPeerConnection->pSrtpSession != NULL &&
         currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime >= 2500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     if (!ready) {
-        DLOGD("sender report no frames sent %u", ssrc);
+        DLOGV("sender report no frames sent %u", ssrc);
     } else {
         // create rtcp sender report packet
         // https://tools.ietf.org/html/rfc3550#section-6.4.1
@@ -500,7 +501,7 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         packetCount = pKvsRtpTransceiver->sender.outboundStats.sent.packetsSent;
         octetCount = pKvsRtpTransceiver->sender.outboundStats.sent.bytesSent;
         MUTEX_UNLOCK(pKvsRtpTransceiver->sender.statsLock);
-        DLOGD("sender report %u %" PRIu64 " %" PRIu64 " : %u packets %u bytes", ssrc, ntpTime, rtpTime, packetCount, octetCount);
+        DLOGV("sender report %u %" PRIu64 " %" PRIu64 " : %u packets %u bytes", ssrc, ntpTime, rtpTime, packetCount, octetCount);
         packetLen = RTCP_PACKET_HEADER_LEN + 24;
 
         // srtp_protect_rtcp() in encryptRtcpPacket() assumes memory availability to write 10 bytes of authentication tag and

--- a/tst/MetricsApiTest.cpp
+++ b/tst/MetricsApiTest.cpp
@@ -15,17 +15,17 @@ TEST_F(MetricsApiTest, webRtcGetMetrics)
     PRtcPeerConnection pRtcPeerConnection;
     RtcStats rtcMetrics;
 
-    EXPECT_EQ(STATUS_NULL_ARG, rtcPeerConnectionGetMetrics(NULL, NULL));
-    EXPECT_EQ(STATUS_NULL_ARG, rtcPeerConnectionGetMetrics(NULL, &rtcMetrics));
+    EXPECT_EQ(STATUS_NULL_ARG, rtcPeerConnectionGetMetrics(NULL, NULL, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, rtcPeerConnectionGetMetrics(NULL, NULL, &rtcMetrics));
 
     MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
 
     EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
 
-    EXPECT_EQ(STATUS_NULL_ARG, rtcPeerConnectionGetMetrics(pRtcPeerConnection, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, rtcPeerConnectionGetMetrics(pRtcPeerConnection, NULL, NULL));
 
     rtcMetrics.requestedTypeOfStats = (RTC_STATS_TYPE) 20; // Supplying a type that is unavailable
-    EXPECT_EQ(STATUS_NOT_IMPLEMENTED, rtcPeerConnectionGetMetrics(pRtcPeerConnection, &rtcMetrics));
+    EXPECT_EQ(STATUS_NOT_IMPLEMENTED, rtcPeerConnectionGetMetrics(pRtcPeerConnection, NULL, &rtcMetrics));
 
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
@@ -49,17 +49,17 @@ TEST_F(MetricsApiTest, webRtcIceGetMetrics)
 
     EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
 
-    EXPECT_EQ(STATUS_ICE_SERVER_INDEX_INVALID, rtcPeerConnectionGetMetrics(pRtcPeerConnection, &rtcIceMetrics));
+    EXPECT_EQ(STATUS_ICE_SERVER_INDEX_INVALID, rtcPeerConnectionGetMetrics(pRtcPeerConnection, NULL, &rtcIceMetrics));
 
     rtcIceMetrics.rtcStatsObject.iceServerStats.iceServerIndex = 0;
-    EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(pRtcPeerConnection, &rtcIceMetrics));
+    EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(pRtcPeerConnection, NULL, &rtcIceMetrics));
 
     EXPECT_EQ(443, rtcIceMetrics.rtcStatsObject.iceServerStats.port);
     EXPECT_PRED_FORMAT2(testing::IsSubstring, configuration.iceServers[0].urls, rtcIceMetrics.rtcStatsObject.iceServerStats.url);
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "", rtcIceMetrics.rtcStatsObject.iceServerStats.protocol);
 
     rtcIceMetrics.rtcStatsObject.iceServerStats.iceServerIndex = 1;
-    EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(pRtcPeerConnection, &rtcIceMetrics));
+    EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(pRtcPeerConnection, NULL, &rtcIceMetrics));
     EXPECT_EQ(443, rtcIceMetrics.rtcStatsObject.iceServerStats.port);
     EXPECT_PRED_FORMAT2(testing::IsSubstring, configuration.iceServers[1].urls, rtcIceMetrics.rtcStatsObject.iceServerStats.url);
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "transport=tcp", rtcIceMetrics.rtcStatsObject.iceServerStats.protocol);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The public API needs to take an option mediaTrack argument (In our case PRtcRtpTransceiver) to allow pulling RTP stats for a specific transceiver. 
https://www.w3.org/TR/webrtc/#rtcpeerconnection-interface-extensions-1

To Do:

Update #615 and #634 once this is merged.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
