### PR TITLE
Fix broken mbedtls build when using old gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,6 +185,10 @@ matrix:
       before_install:
         # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
         - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        - sudo apt-get -q update
+        - sudo apt-get -y install gcc-4.4
+        - sudo apt-get -y install gdb
       before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
 
     - name: "Windows MSVC"

--- a/CMake/Dependencies/libmbedtls-CMakeLists.txt
+++ b/CMake/Dependencies/libmbedtls-CMakeLists.txt
@@ -22,7 +22,7 @@ ExternalProject_Add(
   #       when they add DTLS-SRTP extension support.
   # Reference: https://github.com/ARMmbed/mbedtls/pull/3235
   GIT_REPOSITORY  https://github.com/lherman-cs/mbedtls.git
-  GIT_TAG         pr1813
+  GIT_TAG         a2c1a8f75f0478bad0479bbc9eb9ec2a4376c5e6
   PREFIX          ${CMAKE_CURRENT_BINARY_DIR}/build
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}


### PR DESCRIPTION
Fix broken mbedtls build when using old gcc.

Resolves https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/651#issuecomment-663076228


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
