### PR TITLE
Add G.711 PCM A-law and µ-law to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
   - VP8
   - H264
   - Opus
+  - G.711 PCM (A-law)
+  - G.711 PCM (µ-law)
 * Developer Controlled Media Pipeline
   - Raw Media for Input/Output
   - Callbacks for [Congestion Control](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/201), FIR and PLI (set on RtcRtpTransceiver)


### PR DESCRIPTION
We currently support A-law and µ-law as it's shown here, https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/910a67c822a2bd9e14e3271a81cb57516add2b6e/src/source/PeerConnection/Rtp.c#L225-L229. But, the support is missing from our README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
