### PR TITLE
add flag for turn shutdown complete. At turnConnectionShutdown, run c…

### DIFF
--- a/src/source/Ice/ConnectionListener.c
+++ b/src/source/Ice/ConnectionListener.c
@@ -136,9 +136,7 @@ STATUS connectionListenerRemoveConnection(PConnectionListener pConnectionListene
     while (!hasConnection && pCurNode != NULL) {
         pCurrSocketConnection = (PSocketConnection) pCurNode->data;
         pCurNode = pCurNode->pNext;
-        if (pCurrSocketConnection == pSocketConnection) {
-            hasConnection = TRUE;
-        }
+        hasConnection = pCurrSocketConnection == pSocketConnection;
     }
 
     /* If connection is not found then return early */
@@ -302,8 +300,12 @@ PVOID connectionListenerReceiveDataRoutine(PVOID arg)
 
         for (i = 0; i < socketCount; ++i) {
             pSocketConnection = socketList[i];
-            FD_SET(pSocketConnection->localSocket, &rfds);
-            nfds = MAX(nfds, pSocketConnection->localSocket);
+            if (socketConnectionIsClosed(pSocketConnection)) {
+                updateSocketList = TRUE;
+            } else {
+                FD_SET(pSocketConnection->localSocket, &rfds);
+                nfds = MAX(nfds, pSocketConnection->localSocket);
+            }
         }
 
         nfds++;

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -43,6 +43,7 @@ STATUS createTurnConnection(PIceServer pTurnServer, TIMER_QUEUE_HANDLE timerQueu
 
     ATOMIC_STORE_BOOL(&pTurnConnection->stopTurnConnection, FALSE);
     ATOMIC_STORE_BOOL(&pTurnConnection->hasAllocation, FALSE);
+    ATOMIC_STORE_BOOL(&pTurnConnection->shutdownComplete, FALSE);
 
     if (pTurnConnectionCallbacks != NULL) {
         pTurnConnection->turnConnectionCallbacks = *pTurnConnectionCallbacks;
@@ -107,10 +108,16 @@ STATUS freeTurnConnection(PTurnConnection* ppTurnConnection)
     }
 
     if (IS_VALID_MUTEX_VALUE(pTurnConnection->lock)) {
+        /* in case some thread is in the middle of a turn api call. */
+        MUTEX_LOCK(pTurnConnection->lock);
+        MUTEX_UNLOCK(pTurnConnection->lock);
         MUTEX_FREE(pTurnConnection->lock);
     }
 
     if (IS_VALID_MUTEX_VALUE(pTurnConnection->sendLock)) {
+        /* in case some thread is in the middle of a turn api call. */
+        MUTEX_LOCK(pTurnConnection->sendLock);
+        MUTEX_UNLOCK(pTurnConnection->sendLock);
         MUTEX_FREE(pTurnConnection->sendLock);
     }
 
@@ -211,6 +218,8 @@ STATUS turnConnectionHandleStun(PTurnConnection pTurnConnection, PBYTE pBuffer, 
 
     switch (stunPacketType) {
         case STUN_PACKET_TYPE_ALLOCATE_SUCCESS_RESPONSE:
+            /* If shutdown has been initiated, ignore the alloaction response */
+            CHK(!ATOMIC_LOAD(&pTurnConnection->stopTurnConnection), retStatus);
             CHK_STATUS(deserializeStunPacket(pBuffer, bufferLen, pTurnConnection->longTermKey, KVS_MD5_DIGEST_LENGTH, &pStunPacket));
             CHK_STATUS(getStunAttribute(pStunPacket, STUN_ATTRIBUTE_TYPE_XOR_RELAYED_ADDRESS, &pStunAttr));
             CHK_WARN(pStunAttr != NULL, retStatus, "No relay address attribute found in TURN allocate response. Dropping Packet");
@@ -1048,10 +1057,9 @@ STATUS turnConnectionStepState(PTurnConnection pTurnConnection)
                 }
 
                 CHK_STATUS(turnConnectionFreePreAllocatedPackets(pTurnConnection));
-
+                CHK_STATUS(socketConnectionClosed(pTurnConnection->pControlChannel));
                 pTurnConnection->state = TURN_STATE_NEW;
-
-                CHK_STATUS(connectionListenerRemoveConnection(pTurnConnection->pConnectionListener, pTurnConnection->pControlChannel));
+                ATOMIC_STORE_BOOL(&pTurnConnection->shutdownComplete, TRUE);
             }
 
             break;
@@ -1067,19 +1075,15 @@ STATUS turnConnectionStepState(PTurnConnection pTurnConnection)
             break;
     }
 
-    if (ATOMIC_LOAD_BOOL(&pTurnConnection->stopTurnConnection) && pTurnConnection->state != TURN_STATE_CLEAN_UP &&
-        pTurnConnection->state != TURN_STATE_NEW) {
-        if (ATOMIC_LOAD_BOOL(&pTurnConnection->hasAllocation)) {
-            pTurnConnection->state = TURN_STATE_CLEAN_UP;
-            pTurnConnection->stateTimeoutTime = currentTime + DEFAULT_TURN_CLEAN_UP_TIMEOUT;
-        } else {
-            pTurnConnection->state = TURN_STATE_NEW;
-        }
-    }
-
 CleanUp:
 
     CHK_LOG_ERR(retStatus);
+
+    if (STATUS_SUCCEEDED(retStatus) && ATOMIC_LOAD_BOOL(&pTurnConnection->stopTurnConnection) && pTurnConnection->state != TURN_STATE_CLEAN_UP &&
+        pTurnConnection->state != TURN_STATE_NEW) {
+        pTurnConnection->state = TURN_STATE_CLEAN_UP;
+        pTurnConnection->stateTimeoutTime = currentTime + DEFAULT_TURN_CLEAN_UP_TIMEOUT;
+    }
 
     /* move to failed state if retStatus is failed status and state is not yet TURN_STATE_FAILED */
     if (STATUS_FAILED(retStatus) && pTurnConnection->state != TURN_STATE_FAILED) {
@@ -1172,7 +1176,7 @@ BOOL turnConnectionIsShutdownComplete(PTurnConnection pTurnConnection)
     if (pTurnConnection == NULL) {
         return TRUE;
     } else {
-        return !ATOMIC_LOAD_BOOL(&pTurnConnection->hasAllocation);
+        return ATOMIC_LOAD_BOOL(&pTurnConnection->shutdownComplete);
     }
 }
 

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -110,6 +110,8 @@ typedef struct {
 typedef struct __TurnConnection TurnConnection;
 struct __TurnConnection {
     volatile ATOMIC_BOOL stopTurnConnection;
+    /* shutdown is complete when turn socket is closed */
+    volatile ATOMIC_BOOL shutdownComplete;
     volatile ATOMIC_BOOL hasAllocation;
     volatile SIZE_T timerCallbackId;
 
@@ -134,7 +136,7 @@ struct __TurnConnection {
     MUTEX sendLock;
     CVAR freeAllocationCvar;
 
-    volatile TURN_CONNECTION_STATE state;
+    TURN_CONNECTION_STATE state;
 
     UINT64 stateTimeoutTime;
 


### PR DESCRIPTION
…leanup regardless of having allocation or not to clean up the socket. Add unit test covering turn socket clean up

*Issue #, if available:*
fix #649 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
