### PR TITLE
Measure start up latency from offer to first frame

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -512,7 +512,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
 
     CHK_STATUS(transceiverOnBandwidthEstimation(pSampleStreamingSession->pAudioRtcRtpTransceiver, (UINT64) pSampleStreamingSession,
                                                 sampleBandwidthEstimationHandler));
-
+    pSampleStreamingSession->firstFrame = TRUE;
+    pSampleStreamingSession->startUpLatency = 0;
 CleanUp:
 
     if (STATUS_FAILED(retStatus) && pSampleStreamingSession != NULL) {

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -92,7 +92,8 @@ struct __SampleStreamingSession {
     CHAR peerId[MAX_SIGNALING_CLIENT_ID_LEN + 1];
     TID receiveAudioVideoSenderTid;
     UINT64 firstSdpMsgReceiveTime;
-
+    UINT64 startUpLatency;
+    BOOL firstFrame;
     // this is called when the SampleStreamingSession is being freed
     StreamSessionShutdownCallback shutdownCallback;
     UINT64 shutdownCallbackCustomData;
@@ -127,6 +128,7 @@ STATUS sessionCleanupWait(PSampleConfiguration);
 STATUS awaitGetIceConfigInfoCount(SIGNALING_CLIENT_HANDLE, PUINT32);
 STATUS logSignalingClientStats(PSignalingClientMetrics);
 STATUS logSelectedIceCandidatesInformation(PSampleStreamingSession);
+STATUS logStartUpLatency(PSampleConfiguration);
 
 #ifdef __cplusplus
 }

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -202,6 +202,7 @@ extern "C" {
 #define STATUS_SRTP_TRANSMIT_SESSION_CREATION_FAILED STATUS_SRTP_BASE + 0x00000003
 #define STATUS_SRTP_RECEIVE_SESSION_CREATION_FAILED  STATUS_SRTP_BASE + 0x00000004
 #define STATUS_SRTP_INIT_FAILED                      STATUS_SRTP_BASE + 0x00000005
+#define STATUS_SRTP_NOT_READY_YET                    STATUS_SRTP_BASE + 0x00000006
 /*!@} */
 
 /*===========================================================================================*/

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -226,8 +226,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
     locked = TRUE;
-    CHK(pKvsPeerConnection->pSrtpSession != NULL, STATUS_SUCCESS); // Discard packets till SRTP is ready
-
+    CHK(pKvsPeerConnection->pSrtpSession != NULL, STATUS_SRTP_NOT_READY_YET); // Discard packets till SRTP is ready
     switch (pKvsRtpTransceiver->sender.track.codec) {
         case RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE:
             rtpPayloadFunc = createPayloadForH264;
@@ -305,7 +304,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             continue;
         }
         CHK_STATUS(sendStatus);
-
         if (bufferAfterEncrypt) {
             pRtpPacket->pRawPacket = rawPacket;
             pRtpPacket->rawPacketLength = packetLen;
@@ -368,8 +366,9 @@ CleanUp:
 
     SAFE_MEMFREE(rawPacket);
     SAFE_MEMFREE(pPacketList);
-
-    CHK_LOG_ERR(retStatus);
+    if (retStatus != STATUS_SRTP_NOT_READY_YET) {
+        CHK_LOG_ERR(retStatus);
+    }
 
     return retStatus;
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Measures start up latency from offer to first frame for every streaming session
- Changed status code from `STATUS_SUCCESS` to `STATUS_SRTP_NOT_READY_YET` to clearly indicate packets are discarded because SRTP is not set up.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
