### PR TITLE
Handle SDP offers with ice-options set as session attributes.

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -909,6 +909,9 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
         if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "fingerprint") == 0) {
             STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint, pSessionDescription->sdpAttributes[i].attributeValue + 8,
                     CERTIFICATE_FINGERPRINT_LENGTH);
+        } else if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "ice-options") == 0 &&
+                   STRCMP(pSessionDescription->sdpAttributes[i].attributeValue, "trickle") == 0) {
+            NULLABLE_SET_VALUE(pKvsPeerConnection->canTrickleIce, TRUE);
         } else if (pKvsPeerConnection->isOffer && STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "setup") == 0) {
             pKvsPeerConnection->dtlsIsServer = STRCMP(pSessionDescription->sdpAttributes[i].attributeValue, "active") == 0;
         }

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -40,6 +40,7 @@ o=- 1904080082932320671 2 IN IP4 127.0.0.1
 s=-
 t=0 0
 a=group:BUNDLE 0 1
+a=ice-options:trickle
 a=msid-semantic: WMS f327e13b-3518-47fc-8b53-9cf74d22d03e
 )";
 
@@ -48,13 +49,16 @@ a=msid-semantic: WMS f327e13b-3518-47fc-8b53-9cf74d22d03e
         MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
         EXPECT_EQ(deserializeSessionDescription(&sessionDescription, sdp), STATUS_SUCCESS);
 
-        EXPECT_EQ(sessionDescription.sessionAttributesCount, 2);
+        EXPECT_EQ(sessionDescription.sessionAttributesCount, 3);
 
         EXPECT_STREQ(sessionDescription.sdpAttributes[0].attributeName, "group");
         EXPECT_STREQ(sessionDescription.sdpAttributes[0].attributeValue, "BUNDLE 0 1");
 
-        EXPECT_STREQ(sessionDescription.sdpAttributes[1].attributeName, "msid-semantic");
-        EXPECT_STREQ(sessionDescription.sdpAttributes[1].attributeValue, " WMS f327e13b-3518-47fc-8b53-9cf74d22d03e");
+        EXPECT_STREQ(sessionDescription.sdpAttributes[1].attributeName, "ice-options");
+        EXPECT_STREQ(sessionDescription.sdpAttributes[1].attributeValue, "trickle");
+
+        EXPECT_STREQ(sessionDescription.sdpAttributes[2].attributeName, "msid-semantic");
+        EXPECT_STREQ(sessionDescription.sdpAttributes[2].attributeValue, " WMS f327e13b-3518-47fc-8b53-9cf74d22d03e");
     });
 }
 
@@ -448,6 +452,7 @@ a=rtpmap:102 H264/90000
         STRCPY(rtcSessionDescriptionInit.sdp, (PCHAR) sdp);
         rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
         EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+        EXPECT_EQ(TRUE, canTrickleIceCandidates(pRtcPeerConnection).value);
         EXPECT_EQ(createAnswer(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
         EXPECT_PRED_FORMAT2(testing::IsNotSubstring, "fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
                             rtcSessionDescriptionInit.sdp);
@@ -530,6 +535,7 @@ s=-
 t=0 0
 a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5
 a=group:BUNDLE 0 1 2
+a=ice-options:trickle
 )");
     offer += sdpdata;
     offer += "\n";
@@ -569,6 +575,7 @@ a=group:BUNDLE 0 1 2
         EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &track2, nullptr, &transceiver2));
 
         EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(pRtcPeerConnection, &offerSdp));
+        EXPECT_EQ(TRUE, canTrickleIceCandidates(pRtcPeerConnection).value);
         EXPECT_EQ(STATUS_SUCCESS, createAnswer(pRtcPeerConnection, &answerSdp));
 
         std::string answer = answerSdp.sdp;


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

It turns out that firefox sets ice-options:trickle in the leading portion of an SDP offer. This commit extends the ice-options attribute search to include the non-media portion of the SDP offer.

In the draft RFC for trickle ICE, it looks like this is allowable:
https://tools.ietf.org/html/draft-ietf-ice-trickle-21#section-3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
