### PR TITLE
Data channel stats (WIP)

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -667,6 +667,9 @@ typedef VOID (*RtcOnPictureLoss)(UINT64);
  */
 typedef struct __RtcDataChannel {
     CHAR name[MAX_DATA_CHANNEL_NAME_LEN + 1]; //!< Define name of data channel. Max length is 256 characters
+    UINT32 id;                                //!< Read only field. Setting this in the application has no effect. This field is populated with the id
+               //!< set by the peer connection's createDataChannel() call or the channel id is set in createDataChannel()
+               //!< on embedded end.
 } RtcDataChannel, *PRtcDataChannel;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -493,10 +493,10 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelstate
  */
 typedef enum {
-    RTC_DATA_CHANNEL_STATE_CONNECTING,
-    RTC_DATA_CHANNEL_STATE_OPEN,
-    RTC_DATA_CHANNEL_STATE_CLOSING,
-    RTC_DATA_CHANNEL_STATE_CLOSED
+    RTC_DATA_CHANNEL_STATE_CONNECTING, //!< Set while creating data channel
+    RTC_DATA_CHANNEL_STATE_OPEN,       //!< Set on opening data channel on embedded side or receiving onOpen event
+    RTC_DATA_CHANNEL_STATE_CLOSING,    //!< TODO: Set the state to closed after adding onClosing handler to data channel
+    RTC_DATA_CHANNEL_STATE_CLOSED      //!< TODO: Set the state to closed after adding onClose handler to data channel
 } RTC_DATA_CHANNEL_STATE;
 
 /**
@@ -506,13 +506,13 @@ typedef struct {
     DOMString label;              //!< The "label" value of the RTCDataChannel object.
     DOMString protocol;           //!< The "protocol" value of the RTCDataChannel object.
     INT32 dataChannelIdentifier;  //!< The "id" attribute of the RTCDataChannel object.
-    DOMString transportId;        //!< A stats object reference for the transport used to carry this datachannel.
+    DOMString transportId;        //!< TODO: A stats object reference for the transport used to carry this datachannel.
     RTC_DATA_CHANNEL_STATE state; //!< The "readyState" value of the RTCDataChannel object.
     UINT32 messagesSent;          //!< Represents the total number of API "message" events sent.
     UINT64 bytesSent;        //!< Represents the total number of payload bytes sent on this RTCDatachannel, i.e., not including headers or padding.
-    UINT32 messagesReceived; //<! Represents the total number of API "message" events received.
+    UINT32 messagesReceived; //!< Represents the total number of API "message" events received.
     UINT64 bytesReceived;    //!< Represents the total number of bytes received on this RTCDatachannel, i.e., not including headers or padding.
-} RTCDataChannelStats, *PRTCDataChannelStats;
+} RtcDataChannelStats, *PRtcDataChannelStats;
 
 /**
  * @brief SignalingClientMetrics Represent the stats related to the KVS WebRTC SDK signaling client
@@ -554,6 +554,7 @@ typedef struct {
     RtcOutboundRtpStreamStats outboundRtpStreamStats;           //!< Outbound RTP Stream stats object
     RtcRemoteInboundRtpStreamStats remoteInboundRtpStreamStats; //!< Remote Inbound RTP Stream stats object
     RtcInboundRtpStreamStats inboundRtpStreamStats;             //!< Inbound RTP Stream stats object
+    RtcDataChannelStats rtcDataChannelStats;
 } RtcStatsObject, *PRtcStatsObject;
 
 #ifdef __cplusplus

--- a/src/source/Metrics/Metrics.c
+++ b/src/source/Metrics/Metrics.c
@@ -140,6 +140,23 @@ CleanUp:
     return retStatus;
 }
 
+STATUS getDataChannelStats(PRtcPeerConnection pRtcPeerConnection, PRtcDataChannelStats pRtcDataChannelStats)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsDataChannel pKvsDataChannel = NULL;
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pRtcPeerConnection;
+    CHK(pRtcPeerConnection != NULL && pRtcDataChannelStats != NULL, STATUS_NULL_ARG);
+    CHK_STATUS(hashTableGet(pKvsPeerConnection->pDataChannels, pRtcDataChannelStats->dataChannelIdentifier, (PUINT64) &pKvsDataChannel));
+    pRtcDataChannelStats->bytesReceived = pKvsDataChannel->rtcDataChannelDiagnostics.bytesReceived;
+    pRtcDataChannelStats->bytesSent = pKvsDataChannel->rtcDataChannelDiagnostics.bytesSent;
+    STRCPY(pRtcDataChannelStats->label, pKvsDataChannel->rtcDataChannelDiagnostics.label);
+    pRtcDataChannelStats->messagesReceived = pKvsDataChannel->rtcDataChannelDiagnostics.messagesReceived;
+    pRtcDataChannelStats->messagesSent = pKvsDataChannel->rtcDataChannelDiagnostics.messagesSent;
+    pRtcDataChannelStats->state = pKvsDataChannel->rtcDataChannelDiagnostics.state;
+CleanUp:
+    return retStatus;
+}
+
 STATUS rtcPeerConnectionGetMetrics(PRtcPeerConnection pRtcPeerConnection, PRtcRtpTransceiver pRtcRtpTransceiver, PRtcStats pRtcMetrics)
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -173,11 +190,15 @@ STATUS rtcPeerConnectionGetMetrics(PRtcPeerConnection pRtcPeerConnection, PRtcRt
             CHK_STATUS(getIceServerStats(pRtcPeerConnection, &pRtcMetrics->rtcStatsObject.iceServerStats));
             DLOGD("ICE Server Stats requested at %" PRIu64, pRtcMetrics->timestamp);
             break;
+        case RTC_STATS_TYPE_DATA_CHANNEL:
+            pRtcMetrics->timestamp = GETTIME();
+            CHK_STATUS(getDataChannelStats(pRtcPeerConnection, &pRtcMetrics->rtcStatsObject.rtcDataChannelStats));
+            DLOGD("RTC Data Channel Stats requested at %" PRIu64, pRtcMetrics->timestamp);
+            break;
         case RTC_STATS_TYPE_CERTIFICATE:
         case RTC_STATS_TYPE_CSRC:
         case RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP:
         case RTC_STATS_TYPE_PEER_CONNECTION:
-        case RTC_STATS_TYPE_DATA_CHANNEL:
         case RTC_STATS_TYPE_RECEIVER:
         case RTC_STATS_TYPE_SENDER:
         case RTC_STATS_TYPE_TRACK:

--- a/src/source/PeerConnection/DataChannel.c
+++ b/src/source/PeerConnection/DataChannel.c
@@ -34,8 +34,13 @@ STATUS createDataChannel(PRtcPeerConnection pPeerConnection, PCHAR pDataChannelN
         NULLABLE_SET_EMPTY(pKvsDataChannel->rtcDataChannelInit.maxPacketLifeTime);
         NULLABLE_SET_EMPTY(pKvsDataChannel->rtcDataChannelInit.maxRetransmits);
     }
-
+    STRNCPY(pKvsDataChannel->rtcDataChannelDiagnostics.label, pKvsDataChannel->dataChannel.name, STRLEN(pKvsDataChannel->dataChannel.name));
+    pKvsDataChannel->rtcDataChannelDiagnostics.state = RTC_DATA_CHANNEL_STATE_CONNECTING;
     CHK_STATUS(hashTableGetCount(pKvsPeerConnection->pDataChannels, &channelId));
+    pKvsDataChannel->rtcDataChannelDiagnostics.dataChannelIdentifier = channelId;
+    pKvsDataChannel->dataChannel.id = channelId;
+    STRNCPY(pKvsDataChannel->rtcDataChannelDiagnostics.protocol, DATA_CHANNEL_PROTOCOL_STR,
+            ARRAY_SIZE(pKvsDataChannel->rtcDataChannelDiagnostics.protocol));
     CHK_STATUS(hashTablePut(pKvsPeerConnection->pDataChannels, channelId, (UINT64) pKvsDataChannel));
 
 CleanUp:
@@ -60,7 +65,8 @@ STATUS dataChannelSend(PRtcDataChannel pRtcDataChannel, BOOL isBinary, PBYTE pMe
     pSctpSession = ((PKvsPeerConnection) pKvsDataChannel->pRtcPeerConnection)->pSctpSession;
 
     CHK_STATUS(sctpSessionWriteMessage(pSctpSession, pKvsDataChannel->channelId, isBinary, pMessage, pMessageLen));
-
+    pKvsDataChannel->rtcDataChannelDiagnostics.messagesSent++;
+    pKvsDataChannel->rtcDataChannelDiagnostics.bytesSent += pMessageLen;
 CleanUp:
 
     return retStatus;

--- a/src/source/PeerConnection/DataChannel.h
+++ b/src/source/PeerConnection/DataChannel.h
@@ -10,6 +10,8 @@ DataChannel internal include file
 extern "C" {
 #endif
 
+#define DATA_CHANNEL_PROTOCOL_STR (PCHAR) "SCTP"
+
 typedef struct {
     RtcDataChannel dataChannel;
 
@@ -18,6 +20,7 @@ typedef struct {
     UINT32 channelId;
     UINT64 onMessageCustomData;
     RtcOnMessage onMessage;
+    RtcDataChannelStats rtcDataChannelDiagnostics;
 
     UINT64 onOpenCustomData;
     RtcOnOpen onOpen;

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -607,3 +607,55 @@ race:PeerConnectionFunctionalityTest_freeTurnDueToP2PFoundBeforeTurnEstablished_
 race:PeerConnectionFunctionalityTest_freeTurnDueToP2PFoundAfterTurnEstablished
 race:DataChannelFunctionalityTest_createDataChannel_Disconnected_Test
 race:SignalingApiFunctionalityTest_iceRefreshEmulationWithFaultInjectionErrorDisconnect_Test
+
+race:getDataChannelStats
+# WARNING: ThreadSanitizer: data race (pid=51832)
+#  Read of size 8 at 0x7b6800020358 by main thread:
+#    #0 getDataChannelStats Metrics.c:151 (libkvsWebrtcClient.dylib:x86_64+0x36505)
+#    #1 rtcPeerConnectionGetMetrics Metrics.c:197 (libkvsWebrtcClient.dylib:x86_64+0x36d33)
+#    #2 com::amazonaws::kinesis::video::webrtcclient::DataChannelFunctionalityTest_createDataChannel_DataChannelMetricsTest_Test::TestBody() DataChannelFunctionalityTest.cpp:580 (webrtc_client_test:x86_64+0x10001ca19)
+#    #3 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (webrtc_client_test:x86_64+0x10025b0bd)
+#    #4 main main.cpp:68 (webrtc_client_test:x86_64+0x10020be1d)
+
+#  Previous write of size 8 at 0x7b6800020358 by thread T8:
+#    #0 dataChannelSend DataChannel.c:69 (libkvsWebrtcClient.dylib:x86_64+0x375a3)
+#    #1 com::amazonaws::kinesis::video::webrtcclient::DataChannelFunctionalityTest_createDataChannel_DataChannelMetricsTest_Test::TestBody()::$_18::operator()(unsigned long long, __RtcDataChannel*) const DataChannelFunctionalityTest.cpp:542 (webrtc_client_test:x86_64+0x10002a90d)
+#    #2 com::amazonaws::kinesis::video::webrtcclient::DataChannelFunctionalityTest_createDataChannel_DataChannelMetricsTest_Test::TestBody()::$_18::__invoke(unsigned long long, __RtcDataChannel*) DataChannelFunctionalityTest.cpp:528 (webrtc_client_test:x86_64+0x10002a638)
+#    #3 onSctpSessionDataChannelOpen PeerConnection.c:490 (libkvsWebrtcClient.dylib:x86_64+0x3b504)
+#    #4 handleDcepPacket Sctp.c:317 (libkvsWebrtcClient.dylib:x86_64+0x5f34a)
+#    #5 onSctpInboundPacket Sctp.c:338 (libkvsWebrtcClient.dylib:x86_64+0x5e1ba)
+#    #6 sctp_invoke_recv_callback <null> (libusrsctp.1.dylib:x86_64+0xb501a)
+#    #7 onInboundPacket PeerConnection.c:126 (libkvsWebrtcClient.dylib:x86_64+0x3b703)
+#    #8 incomingDataHandler IceAgent.c:2156 (libkvsWebrtcClient.dylib:x86_64+0x10b15)
+#    #9 connectionListenerReceiveDataRoutine ConnectionListener.c:380 (libkvsWebrtcClient.dylib:x86_64+0xb0cb)
+
+#  As if synchronized via sleep:
+#    #0 usleep <null> (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x2953e)
+#    #1 defaultThreadSleep <null> (libkvsWebrtcClient.dylib:x86_64+0x73566)
+#    #2 com::amazonaws::kinesis::video::webrtcclient::DataChannelFunctionalityTest_createDataChannel_DataChannelMetricsTest_Test::TestBody() DataChannelFunctionalityTest.cpp:574 (webrtc_client_test:x86_64+0x10001c65a)
+#    #3 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (webrtc_client_test:x86_64+0x10025b0bd)
+#    #4 main main.cpp:68 (webrtc_client_test:x86_64+0x10020be1d)
+
+#  Location is heap block of size 1408 at 0x7b680001fe00 allocated by thread T8:
+#    #0 calloc <null> (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x4e7e2)
+#    #1 defaultMemCalloc <null> (libkvsWebrtcClient.dylib:x86_64+0x6c40c)
+#    #2 handleDcepPacket Sctp.c:317 (libkvsWebrtcClient.dylib:x86_64+0x5f34a)
+#    #3 onSctpInboundPacket Sctp.c:338 (libkvsWebrtcClient.dylib:x86_64+0x5e1ba)
+#    #4 sctp_invoke_recv_callback <null> (libusrsctp.1.dylib:x86_64+0xb501a)
+#    #5 onInboundPacket PeerConnection.c:126 (libkvsWebrtcClient.dylib:x86_64+0x3b703)
+#    #6 incomingDataHandler IceAgent.c:2156 (libkvsWebrtcClient.dylib:x86_64+0x10b15)
+#    #7 connectionListenerReceiveDataRoutine ConnectionListener.c:380 (libkvsWebrtcClient.dylib:x86_64+0xb0cb)
+
+#  Thread T8 (tid=5082892, running) created by main thread at:
+#    #0 pthread_create <null> (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x2a99d)
+#    #1 defaultCreateThread <null> (libkvsWebrtcClient.dylib:x86_64+0x73293)
+#    #2 iceAgentStartGathering IceAgent.c:537 (libkvsWebrtcClient.dylib:x86_64+0x116a9)
+#    #3 setLocalDescription PeerConnection.c:1050 (libkvsWebrtcClient.dylib:x86_64+0x423af)
+#    #4 com::amazonaws::kinesis::video::webrtcclient::WebRtcClientTestBase::connectTwoPeers(RtcPeerConnection*, RtcPeerConnection*, char*, char*) WebRTCClientTestFixture.cpp:211 (webrtc_client_test:x86_64+0x1002037b0)
+#    #5 com::amazonaws::kinesis::video::webrtcclient::DataChannelFunctionalityTest_createDataChannel_DataChannelMetricsTest_Test::TestBody() DataChannelFunctionalityTest.cpp:574 (webrtc_client_test:x86_64+0x10001c65a)
+#    #6 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (webrtc_client_test:x86_64+0x10025b0bd)
+#    #7 main main.cpp:68 (webrtc_client_test:x86_64+0x10020be1d)
+
+#SUMMARY: ThreadSanitizer: data race Metrics.c:151 in getDataChannelStats
+
+


### PR DESCRIPTION
*Issue #, if available: #578 *

*Description of changes:*

- Core logic of Data channel stats implemented. Data channel stats can be extracted using channel ID. Channel ID is populated in `RtcDataChannel` struct on creating a data channel and also in `onOpen()` callback.

Todo:
- Add dataChannelStats pulling to samples

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
