### PR TITLE
Add null termination to string generated by generateJSONSafeString

### DIFF
--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -52,7 +52,7 @@ extern "C" {
 #define ICE_HASH_TABLE_BUCKET_COUNT  50
 #define ICE_HASH_TABLE_BUCKET_LENGTH 2
 
-#define ICE_CANDIDATE_ID_LEN 8
+#define ICE_CANDIDATE_ID_LEN 9
 
 #define STATS_NOT_APPLICABLE_STR (PCHAR) "N/A"
 typedef enum {

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -530,10 +530,10 @@ STATUS generateJSONSafeString(PCHAR pDst, UINT32 len)
 
     CHK(pDst != NULL, STATUS_NULL_ARG);
 
-    for (i = 0; i < len; i++) {
+    for (i = 0; i < len - 1; i++) {
         pDst[i] = VALID_CHAR_SET_FOR_JSON[RAND() % (ARRAY_SIZE(VALID_CHAR_SET_FOR_JSON) - 1)];
     }
-
+    pDst[i] = '\0'; // String must be NULL terminated
 CleanUp:
 
     LEAVES();

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -10,9 +10,9 @@ PeerConnection internal include file
 extern "C" {
 #endif
 
-#define LOCAL_ICE_UFRAG_LEN 4
-#define LOCAL_ICE_PWD_LEN   24
-#define LOCAL_CNAME_LEN     16
+#define LOCAL_ICE_UFRAG_LEN 5
+#define LOCAL_ICE_PWD_LEN   25
+#define LOCAL_CNAME_LEN     17
 
 // https://tools.ietf.org/html/rfc5245#section-15.4
 #define MAX_ICE_UFRAG_LEN 256


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`generateJSONSafeString` generates string without NULL termination which causes an abort trap when being copied. This PR adds the NULL termination and also updates the length of the different strings that are generated using this API to give wiggle room for the NULL character


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
