### PR TITLE
Document gstreamer install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Create a build directory in the newly checked out repository, and execute CMake 
 We have provided an example of using GStreamer to capture/encode video, and then send via this library. This is only build if `pkg-config` finds
 GStreamer is installed on your system.
 
+On Ubuntu and Raspberry Pi OS you can get the libraries by running
+```
+$ sudo apt-get install libssl-dev libcurl4-openssl-dev liblog4cplus-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base-apps gstreamer1.0-plugins-bad gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
+```
+
 By default we download all the libraries from GitHub and build them locally, so should require nothing to be installed ahead of time.
 If you do wish to link to existing libraries you can use the following flags to customize your build.
 


### PR DESCRIPTION
Copy the gstreamer install command from the CPP producer SDK to ease installation of the gstreamer samples for WebRTC

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
