### PR TITLE
Fix bug with transceiver direction when offer has recvonly; ensure answer is sendonly

### DIFF
--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -16,7 +16,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     signal(SIGINT, sigintHandler);
 #endif
 
-    // do tricketIce by default
+    // do trickeIce by default
     printf("[KVS Master] Using trickleICE by default\n");
     retStatus =
         createSampleConfiguration(argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME, SIGNALING_CHANNEL_ROLE_TYPE_MASTER, TRUE, TRUE, &pSampleConfiguration);

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -16,7 +16,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     signal(SIGINT, sigintHandler);
 #endif
 
-    // do trickeIce by default
+    // do trickleIce by default
     printf("[KVS Master] Using trickleICE by default\n");
     retStatus =
         createSampleConfiguration(argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME, SIGNALING_CHANNEL_ROLE_TYPE_MASTER, TRUE, TRUE, &pSampleConfiguration);

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -781,6 +781,7 @@ typedef enum {
     RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV = 1, //!< This indicates that peer can send and receive data
     RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY = 2, //!< This indicates that the peer can only send information
     RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY = 3, //!< This indicates that the peer can only receive information
+    RTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE = 4, //!< This indicates that the peer can not send or receive data
 } RTC_RTP_TRANSCEIVER_DIRECTION;
 
 /**
@@ -1022,7 +1023,7 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc/#rtcsessiondescription-class
  */
 typedef struct {
-    SDP_TYPE type;                                      //!< Indicates an offer/anser SDP type
+    SDP_TYPE type;                                      //!< Indicates an offer/answer SDP type
     CHAR sdp[MAX_SESSION_DESCRIPTION_INIT_SDP_LEN + 1]; //!< SDP Data containing media capabilities, transport addresses
                                                         //!< and related metadata in a transport agnostic manner
 } RtcSessionDescriptionInit, *PRtcSessionDescriptionInit;
@@ -1033,7 +1034,7 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc/#rtcicecandidate-interface
  */
 typedef struct {
-    CHAR candidate[MAX_ICE_CANDIDATE_INIT_CANDIDATE_LEN + 1]; //!< Candidate information contaiing details such as protocol
+    CHAR candidate[MAX_ICE_CANDIDATE_INIT_CANDIDATE_LEN + 1]; //!< Candidate information containing details such as protocol
                                                               //!< (udp/tcp), IP Address, priority and port
 } RtcIceCandidateInit, *PRtcIceCandidateInit;
 

--- a/src/source/Metrics/Metrics.c
+++ b/src/source/Metrics/Metrics.c
@@ -84,7 +84,7 @@ STATUS getRtpRemoteInboundStats(PRtcPeerConnection pRtcPeerConnection, PRtcRtpTr
     CHK(pRtcPeerConnection != NULL || pRtcRemoteInboundRtpStreamStats != NULL, STATUS_NULL_ARG);
     PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pTransceiver;
     if (pKvsRtpTransceiver == NULL) {
-        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceievers, &node));
+        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &node));
         CHK_STATUS(doubleListGetNodeData(node, (PUINT64) &pKvsRtpTransceiver));
         CHK(pKvsRtpTransceiver != NULL, STATUS_NOT_FOUND);
     }
@@ -106,7 +106,7 @@ STATUS getRtpOutboundStats(PRtcPeerConnection pRtcPeerConnection, PRtcRtpTransce
     CHK(pRtcPeerConnection != NULL || pRtcOutboundRtpStreamStats != NULL, STATUS_NULL_ARG);
     PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pTransceiver;
     if (pKvsRtpTransceiver == NULL) {
-        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceievers, &node));
+        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &node));
         CHK_STATUS(doubleListGetNodeData(node, (PUINT64) &pKvsRtpTransceiver));
         CHK(pKvsRtpTransceiver != NULL, STATUS_NOT_FOUND);
     }
@@ -127,7 +127,7 @@ STATUS getRtpInboundStats(PRtcPeerConnection pRtcPeerConnection, PRtcRtpTranscei
     CHK(pRtcPeerConnection != NULL || pRtcInboundRtpStreamStats != NULL, STATUS_NULL_ARG);
     PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pTransceiver;
     if (pKvsRtpTransceiver == NULL) {
-        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceievers, &node));
+        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &node));
         CHK_STATUS(doubleListGetNodeData(node, (PUINT64) &pKvsRtpTransceiver));
         CHK(pKvsRtpTransceiver != NULL, STATUS_NOT_FOUND);
     }

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -55,7 +55,7 @@ typedef struct {
     PSctpSession pSctpSession;
 
     SessionDescription remoteSessionDescription;
-    PDoubleList pTransceievers;
+    PDoubleList pTransceivers;
     BOOL sctpIsEnabled;
 
     CHAR localIceUfrag[LOCAL_ICE_UFRAG_LEN + 1];

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -212,7 +212,7 @@ STATUS onRtcpRembPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
     CHK_STATUS(rembValueGet(pRtcpPacket->payload, pRtcpPacket->payloadLength, &maximumBitRate, (PUINT32) &ssrcList, &ssrcListLen));
 
     for (i = 0; i < ssrcListLen; i++) {
-        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceievers, &pCurNode));
+        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
         while (pCurNode != NULL && pTransceiver == NULL) {
             CHK_STATUS(doubleListGetNodeData(pCurNode, &item));
             CHK(item != 0, STATUS_INTERNAL_ERROR);

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -415,7 +415,7 @@ STATUS findTransceiverBySsrc(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTrans
     PKvsRtpTransceiver pTransceiver = NULL;
     CHK(pKvsPeerConnection != NULL && ppTransceiver != NULL, STATUS_NULL_ARG);
 
-    CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceievers, &pCurNode));
+    CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
     while (pCurNode != NULL) {
         CHK_STATUS(doubleListGetNodeData(pCurNode, &item));
         pTransceiver = (PKvsRtpTransceiver) item;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -310,7 +310,8 @@ PCHAR fmtpForPayloadType(UINT64 payloadType, PSessionDescription pSessionDescrip
 
 // Populate a single media section from a PKvsRtpTransceiver
 STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTransceiver pKvsRtpTransceiver,
-                                  PSdpMediaDescription pSdpMediaDescription, PCHAR pCertificateFingerprint, UINT32 mediaSectionId, PCHAR pDtlsRole)
+                                  PSdpMediaDescription pSdpMediaDescription, PSessionDescription pRemoteSessionDescription,
+                                  PCHAR pCertificateFingerprint, UINT32 mediaSectionId, PCHAR pDtlsRole)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -436,20 +437,47 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     SPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "%d", mediaSectionId);
     attributeCount++;
 
-    switch (pKvsRtpTransceiver->transceiver.direction) {
-        case RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV:
-            STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendrecv");
-            break;
-        case RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY:
-            STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendonly");
-            break;
-        case RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY:
-            STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "recvonly");
-            break;
-        default:
-            // https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverdirection
-            DLOGW("Incorrect/no transceiver direction set...this attribute will be set to inactive");
-            STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "inactive");
+
+    if ( pKvsPeerConnection->isOffer ) {
+        switch (pKvsRtpTransceiver->transceiver.direction) {
+            case RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV:
+                STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendrecv");
+                break;
+            case RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY:
+                STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendonly");
+                break;
+            case RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY:
+                STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "recvonly");
+                break;
+            default:
+                // https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverdirection
+                DLOGW("Incorrect/no transceiver direction set...this attribute will be set to inactive");
+                STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "inactive");
+        }
+    } else {
+        for ( int i = 0; i < pRemoteSessionDescription->mediaCount; i++ ) {
+
+            PSdpMediaDescription pSdpMediaDescriptionRemote = &pRemoteSessionDescription->mediaDescriptions[i];
+
+            UINT32 remoteAttributeCount = pSdpMediaDescriptionRemote->mediaAttributesCount;
+
+            for (int i = 0; i < remoteAttributeCount; i++) {
+                if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[i].attributeName, "sendrecv") == 0) {
+                    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendrecv");
+                    break;
+                }
+
+                if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[i].attributeName, "recvonly") == 0) {
+                    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendonly");
+                    break;
+                }
+
+                if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[i].attributeName, "sendonly") == 0) {
+                    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "recvonly");
+                    break;
+                }
+            }
+        }
     }
 
     attributeCount++;
@@ -582,6 +610,42 @@ CleanUp:
     return retStatus;
 }
 
+BOOL isPresentInRemote(PKvsRtpTransceiver pKvsRtpTransceiver, PSessionDescription pRemoteSessionDescription) {
+
+    PCHAR remoteAttributeValue, end;
+    UINT32 remoteTokenLen;
+
+    MEDIA_STREAM_TRACK_KIND localTrackKind = pKvsRtpTransceiver->sender.track.kind;
+
+    for (int i = 0; i < pRemoteSessionDescription->mediaCount; i++) {
+        PSdpMediaDescription pRemoteMediaDescription = &pRemoteSessionDescription->mediaDescriptions[i];
+        remoteAttributeValue = pRemoteMediaDescription->mediaName;
+        
+        if ((end = STRCHR(remoteAttributeValue, ' ')) != NULL) {
+            remoteTokenLen = (end - remoteAttributeValue);
+        } else {
+            remoteTokenLen = STRLEN(remoteAttributeValue);
+        }
+
+        switch (localTrackKind) {
+            case MEDIA_STREAM_TRACK_KIND_AUDIO:
+                if ( remoteTokenLen == STRLEN(MEDIA_SECTION_AUDIO_VALUE) && STRNCMP(MEDIA_SECTION_AUDIO_VALUE, remoteAttributeValue, remoteTokenLen) == 0 ) {
+                    return TRUE;
+                }
+                break;
+            case MEDIA_STREAM_TRACK_KIND_VIDEO:
+                if ( remoteTokenLen == STRLEN(MEDIA_SECTION_VIDEO_VALUE) && STRNCMP(MEDIA_SECTION_VIDEO_VALUE, remoteAttributeValue, remoteTokenLen) == 0 ) {
+                    return TRUE;
+                }
+                break;
+            default:
+                return FALSE;
+        }
+    }
+
+    return FALSE;
+}
+
 // Populate the media sections of a SessionDescription with the current state of the KvsPeerConnection
 STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PSessionDescription pRemoteSessionDescription,
                                        PSessionDescription pLocalSessionDescription)
@@ -603,17 +667,24 @@ STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PS
         CHK_STATUS(reorderTransceiverByRemoteDescription(pKvsPeerConnection, pRemoteSessionDescription));
     }
 
-    CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceievers, &pCurNode));
+    CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
     while (pCurNode != NULL) {
         CHK_STATUS(doubleListGetNodeData(pCurNode, &data));
         pCurNode = pCurNode->pNext;
         pKvsRtpTransceiver = (PKvsRtpTransceiver) data;
         if (pKvsRtpTransceiver != NULL) {
             CHK(pLocalSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT);
-            CHK_STATUS(populateSingleMediaSection(pKvsPeerConnection, pKvsRtpTransceiver,
-                                                  &(pLocalSessionDescription->mediaDescriptions[pLocalSessionDescription->mediaCount]),
-                                                  certificateFingerprint, pLocalSessionDescription->mediaCount, pDtlsRole));
-            pLocalSessionDescription->mediaCount++;
+
+            // If generating answer, need to check if Local Description is present in remote -- if not, we don't need to create a local description for it
+            // or else our Answer will have an extra m-line, for offer the local is the offer itself, don't care about remote
+            if ( pKvsPeerConnection->isOffer || isPresentInRemote(pKvsRtpTransceiver, pRemoteSessionDescription) ) {
+                    CHK_STATUS(populateSingleMediaSection(pKvsPeerConnection, pKvsRtpTransceiver,
+                                                          &(pLocalSessionDescription->mediaDescriptions[pLocalSessionDescription->mediaCount]),
+                                                          pRemoteSessionDescription,
+                                                          certificateFingerprint, pLocalSessionDescription->mediaCount,
+                                                          pDtlsRole));
+                    pLocalSessionDescription->mediaCount++;
+            }
         }
     }
 
@@ -685,7 +756,7 @@ CleanUp:
 }
 
 // primarily meant to be used by reorderTransceiverByRemoteDescription
-// Find a Transceiver with n codec, and then copy it to the end of the transceievers
+// Find a Transceiver with n codec, and then copy it to the end of the transceivers
 // this allows us to re-order by the order the remote dictates
 STATUS copyTransceiverWithCodec(PKvsPeerConnection pKvsPeerConnection, RTC_CODEC rtcCodec, PBOOL pDidFindCodec)
 {
@@ -698,19 +769,19 @@ STATUS copyTransceiverWithCodec(PKvsPeerConnection pKvsPeerConnection, RTC_CODEC
 
     *pDidFindCodec = FALSE;
 
-    CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceievers, &pCurNode));
+    CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
     while (pCurNode != NULL) {
         CHK_STATUS(doubleListGetNodeData(pCurNode, &data));
         pKvsRtpTransceiver = (PKvsRtpTransceiver) data;
         if (pKvsRtpTransceiver != NULL && pKvsRtpTransceiver->sender.track.codec == rtcCodec) {
             pTargetKvsRtpTransceiver = pKvsRtpTransceiver;
-            doubleListDeleteNode(pKvsPeerConnection->pTransceievers, pCurNode);
+            doubleListDeleteNode(pKvsPeerConnection->pTransceivers, pCurNode);
             break;
         }
         pCurNode = pCurNode->pNext;
     }
     if (pTargetKvsRtpTransceiver != NULL) {
-        CHK_STATUS(doubleListInsertItemTail(pKvsPeerConnection->pTransceievers, (UINT64) pTargetKvsRtpTransceiver));
+        CHK_STATUS(doubleListInsertItemTail(pKvsPeerConnection->pTransceivers, (UINT64) pTargetKvsRtpTransceiver));
         *pDidFindCodec = TRUE;
     }
 
@@ -723,14 +794,14 @@ STATUS reorderTransceiverByRemoteDescription(PKvsPeerConnection pKvsPeerConnecti
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT32 currentMedia, currentAttribute, transceieverCount = 0, tokenLen;
+    UINT32 currentMedia, currentAttribute, transceiverCount = 0, tokenLen;
     PSdpMediaDescription pMediaDescription = NULL;
     PCHAR attributeValue, end;
     BOOL supportCodec, foundMediaSectionWithCodec;
     RTC_CODEC rtcCodec;
 
-    // change the order of pKvsPeerConnection->pTransceievers to have the same codec order in pRemoteSessionDescription
-    CHK_STATUS(doubleListGetNodeCount(pKvsPeerConnection->pTransceievers, &transceieverCount));
+    // change the order of pKvsPeerConnection->pTransceivers to have the same codec order in pRemoteSessionDescription
+    CHK_STATUS(doubleListGetNodeCount(pKvsPeerConnection->pTransceivers, &transceiverCount));
 
     for (currentMedia = 0; currentMedia < pRemoteSessionDescription->mediaCount; currentMedia++) {
         pMediaDescription = &(pRemoteSessionDescription->mediaDescriptions[currentMedia]);
@@ -738,6 +809,7 @@ STATUS reorderTransceiverByRemoteDescription(PKvsPeerConnection pKvsPeerConnecti
 
         // Scan the media section name for any codecs we support
         attributeValue = pMediaDescription->mediaName;
+
         do {
             if ((end = STRCHR(attributeValue, ' ')) != NULL) {
                 tokenLen = (end - attributeValue);
@@ -755,7 +827,7 @@ STATUS reorderTransceiverByRemoteDescription(PKvsPeerConnection pKvsPeerConnecti
                 supportCodec = FALSE;
             }
 
-            // find transceiever with rtcCodec and duplicate it at tail
+            // find transceiver with rtcCodec and duplicate it at tail
             if (supportCodec) {
                 CHK_STATUS(copyTransceiverWithCodec(pKvsPeerConnection, rtcCodec, &foundMediaSectionWithCodec));
             }
@@ -785,7 +857,7 @@ STATUS reorderTransceiverByRemoteDescription(PKvsPeerConnection pKvsPeerConnecti
                 supportCodec = FALSE;
             }
 
-            // find transceiever with rtcCodec and duplicate it at tail
+            // find transceiver with rtcCodec and duplicate it at tail
             if (supportCodec) {
                 CHK_STATUS(copyTransceiverWithCodec(pKvsPeerConnection, rtcCodec, &foundMediaSectionWithCodec));
             }
@@ -832,7 +904,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS setReceiversSsrc(PSessionDescription pRemoteSessionDescription, PDoubleList pTransceievers)
+STATUS setReceiversSsrc(PSessionDescription pRemoteSessionDescription, PDoubleList pTransceivers)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PSdpMediaDescription pMediaDescription = NULL;
@@ -863,7 +935,7 @@ STATUS setReceiversSsrc(PSessionDescription pRemoteSessionDescription, PDoubleLi
             }
 
             if (foundSsrc) {
-                CHK_STATUS(doubleListGetHeadNode(pTransceievers, &pCurNode));
+                CHK_STATUS(doubleListGetHeadNode(pTransceivers, &pCurNode));
                 while (pCurNode != NULL) {
                     CHK_STATUS(doubleListGetNodeData(pCurNode, &data));
                     pKvsRtpTransceiver = (PKvsRtpTransceiver) data;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -318,7 +318,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     UINT64 payloadType, rtxPayloadType;
     BOOL containRtx = FALSE;
     BOOL directionFound = FALSE;
-    UINT32 i, j, remoteAttributeCount, attributeCount = 0;
+    UINT32 i, remoteAttributeCount, attributeCount = 0;
     PRtcMediaStreamTrack pRtcMediaStreamTrack = &(pKvsRtpTransceiver->sender.track);
     PSdpMediaDescription pSdpMediaDescriptionRemote;
     PCHAR currentFmtp = NULL;
@@ -456,21 +456,19 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
                 STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "inactive");
         }
     } else {
-        for (i = 0; i < pRemoteSessionDescription->mediaCount && directionFound == FALSE; i++) {
-            pSdpMediaDescriptionRemote = &pRemoteSessionDescription->mediaDescriptions[i];
-            remoteAttributeCount = pSdpMediaDescriptionRemote->mediaAttributesCount;
+        pSdpMediaDescriptionRemote = &pRemoteSessionDescription->mediaDescriptions[mediaSectionId];
+        remoteAttributeCount = pSdpMediaDescriptionRemote->mediaAttributesCount;
 
-            for (j = 0; j < remoteAttributeCount && directionFound == FALSE; j++) {
-                if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[j].attributeName, "sendrecv") == 0) {
-                    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendrecv");
-                    directionFound = TRUE;
-                } else if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[j].attributeName, "recvonly") == 0) {
-                    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendonly");
-                    directionFound = TRUE;
-                } else if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[j].attributeName, "sendonly") == 0) {
-                    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "recvonly");
-                    directionFound = TRUE;
-                }
+        for (i = 0; i < remoteAttributeCount && directionFound == FALSE; i++) {
+            if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[i].attributeName, "sendrecv") == 0) {
+                STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendrecv");
+                directionFound = TRUE;
+            } else if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[i].attributeName, "recvonly") == 0) {
+                STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "sendonly");
+                directionFound = TRUE;
+            } else if (STRCMP(pSdpMediaDescriptionRemote->sdpAttributes[i].attributeName, "sendonly") == 0) {
+                STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "recvonly");
+                directionFound = TRUE;
             }
         }
     }


### PR DESCRIPTION
Fix bug with transceiver direction to correctly respond to offer according to:
https://tools.ietf.org/html/rfc3264#section-6.1

*Issue #, 468*

*Description of changes:*
(1) If offer is recvonly, response should be sendonly (This fixes master sample in FF)
(2) If remote offer has only video m-line (no audio) and local (answer side) has multiple transceivers set up, the answer should still only contain 1 m-line ignoring extra local transceivers.  (This fixes master sample in Safari)
(3) Unit tests for both cases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
