### PR TITLE
Sample refactor

### DIFF
--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -74,7 +74,6 @@ typedef struct {
     RtcOnDataChannel onDataChannel;
 
     TID signalingProcessor;
-    PStackQueue pSignalingMessageQueue;
     PHashTable pPendingSignalingMessageForRemoteClient;
     PHashTable pRtcPeerConnectionForRemoteClient;
 
@@ -86,6 +85,7 @@ typedef struct {
     UINT64 customData;
     PSampleStreamingSession sampleStreamingSessionList[DEFAULT_MAX_CONCURRENT_STREAMING_SESSION];
     UINT32 streamingSessionCount;
+    MUTEX streamingSessionListReadLock;
     UINT32 iceUriCount;
     SignalingClientCallbacks signalingClientCallbacks;
     SignalingClientInfo clientInfo;
@@ -151,7 +151,6 @@ STATUS awaitGetIceConfigInfoCount(SIGNALING_CLIENT_HANDLE, PUINT32);
 STATUS logSignalingClientStats(PSignalingClientMetrics);
 STATUS logSelectedIceCandidatesInformation(PSampleStreamingSession);
 STATUS logStartUpLatency(PSampleConfiguration);
-PVOID signalingProcessingRoutine(PVOID args);
 
 #ifdef __cplusplus
 }

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -32,6 +32,10 @@ extern "C" {
 
 #define FILE_LOGGING_BUFFER_SIZE (100 * 1024)
 #define MAX_NUMBER_OF_LOG_FILES  5
+
+#define SAMPLE_HASH_TABLE_BUCKET_COUNT  50
+#define SAMPLE_HASH_TABLE_BUCKET_LENGTH 2
+
 typedef enum {
     SAMPLE_STREAMING_VIDEO_ONLY,
     SAMPLE_STREAMING_AUDIO_VIDEO,
@@ -108,7 +112,6 @@ struct __SampleStreamingSession {
     UINT32 videoTimestamp;
     CHAR peerId[MAX_SIGNALING_CLIENT_ID_LEN + 1];
     TID receiveAudioVideoSenderTid;
-    UINT64 firstSdpMsgReceiveTime;
     UINT64 offerReceiveTime;
     UINT64 startUpLatency;
     BOOL firstFrame;
@@ -125,7 +128,7 @@ STATUS readFrameFromDisk(PBYTE, PUINT32, PCHAR);
 PVOID sendVideoPackets(PVOID);
 PVOID sendAudioPackets(PVOID);
 PVOID sendGstreamerAudioVideo(PVOID);
-PVOID sampleReceiveAudioFrame(PVOID args);
+PVOID sampleReceiveVideoFrame(PVOID args);
 PVOID getPeriodicIceCandidatePairStats(PVOID);
 STATUS getIceCandidatePairStatsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData);
 STATUS createSampleConfiguration(PCHAR, SIGNALING_CHANNEL_ROLE_TYPE, BOOL, BOOL, PSampleConfiguration*);

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -68,7 +68,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     }
     printf("[KVS Master] KVS WebRTC initialization completed successfully\n");
 
-    pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = masterMessageReceived;
+    pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = signalingMessageReceived;
 
     strcpy(pSampleConfiguration->clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -234,7 +234,7 @@ PVOID sendVideoPackets(PVOID args)
         encoderStats.targetBitrate = 262000;
         frame.presentationTs += SAMPLE_VIDEO_FRAME_DURATION;
 
-        MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
+        MUTEX_LOCK(pSampleConfiguration->streamingSessionListReadLock);
         for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
             status = writeFrame(pSampleConfiguration->sampleStreamingSessionList[i]->pVideoRtcRtpTransceiver, &frame);
             encoderStats.encodeTimeMsec = 4; // update encode time to an arbitrary number to demonstrate stats update
@@ -253,7 +253,7 @@ PVOID sendVideoPackets(PVOID args)
                 }
             }
         }
-        MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
+        MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);
 
         // Adjust sleep in the case the sleep itself and writeFrame take longer than expected. Since sleep makes sure that the thread
         // will be paused at least until the given amount, we can assume that there's no too early frame scenario.
@@ -317,7 +317,7 @@ PVOID sendAudioPackets(PVOID args)
 
         frame.presentationTs += SAMPLE_AUDIO_FRAME_DURATION;
 
-        MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
+        MUTEX_LOCK(pSampleConfiguration->streamingSessionListReadLock);
         for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
             status = writeFrame(pSampleConfiguration->sampleStreamingSessionList[i]->pAudioRtcRtpTransceiver, &frame);
             if (status != STATUS_SRTP_NOT_READY_YET) {
@@ -334,7 +334,7 @@ PVOID sendAudioPackets(PVOID args)
                 }
             }
         }
-        MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
+        MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);
         THREAD_SLEEP(SAMPLE_AUDIO_FRAME_DURATION);
     }
 

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -39,7 +39,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     // Set the audio and video handlers
     pSampleConfiguration->audioSource = sendAudioPackets;
     pSampleConfiguration->videoSource = sendVideoPackets;
-    pSampleConfiguration->receiveAudioVideoSource = sampleReceiveAudioFrame;
+    pSampleConfiguration->receiveAudioVideoSource = sampleReceiveVideoFrame;
     pSampleConfiguration->onDataChannel = onDataChannel;
     pSampleConfiguration->mediaType = SAMPLE_STREAMING_AUDIO_VIDEO;
     printf("[KVS Master] Finished setting audio and video handlers\n");
@@ -244,12 +244,6 @@ PVOID sendVideoPackets(PVOID args)
 #ifdef VERBOSE
                     printf("writeFrame() failed with 0x%08x\n", status);
 #endif
-                } else if (pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame) {
-                    pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame = FALSE;
-                    pSampleConfiguration->sampleStreamingSessionList[i]->startUpLatency =
-                        (GETTIME() - pSampleConfiguration->sampleStreamingSessionList[i]->offerReceiveTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
-                    printf("Start up latency from offer to first frame: %" PRIu64 "ms\n",
-                           pSampleConfiguration->sampleStreamingSessionList[i]->startUpLatency);
                 }
             }
         }
@@ -325,12 +319,6 @@ PVOID sendAudioPackets(PVOID args)
 #ifdef VERBOSE
                     printf("writeFrame() failed with 0x%08x\n", status);
 #endif
-                } else if (pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame) {
-                    pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame = FALSE;
-                    pSampleConfiguration->sampleStreamingSessionList[i]->startUpLatency =
-                        (GETTIME() - pSampleConfiguration->sampleStreamingSessionList[i]->offerReceiveTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
-                    printf("Start up latency from offer to first frame: %" PRIu64 "ms\n",
-                           pSampleConfiguration->sampleStreamingSessionList[i]->startUpLatency);
                 }
             }
         }
@@ -343,16 +331,16 @@ CleanUp:
     return (PVOID)(ULONG_PTR) retStatus;
 }
 
-PVOID sampleReceiveAudioFrame(PVOID args)
+PVOID sampleReceiveVideoFrame(PVOID args)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PSampleStreamingSession pSampleStreamingSession = (PSampleStreamingSession) args;
     if (pSampleStreamingSession == NULL) {
-        printf("[KVS Master] sampleReceiveAudioFrame(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+        printf("[KVS Master] sampleReceiveVideoFrame(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
         goto CleanUp;
     }
 
-    retStatus = transceiverOnFrame(pSampleStreamingSession->pAudioRtcRtpTransceiver, (UINT64) pSampleStreamingSession, sampleFrameHandler);
+    retStatus = transceiverOnFrame(pSampleStreamingSession->pVideoRtcRtpTransceiver, (UINT64) pSampleStreamingSession, sampleFrameHandler);
     if (retStatus != STATUS_SUCCESS) {
         printf("[KVS Master] transceiverOnFrame(): operation returned status code: 0x%08x \n", retStatus);
         goto CleanUp;

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -60,7 +60,7 @@ GstFlowReturn on_new_sample(GstElement* sink, gpointer data, UINT64 trackid)
         frame.size = (UINT32) info.size;
         frame.frameData = (PBYTE) info.data;
 
-        MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
+        MUTEX_LOCK(pSampleConfiguration->streamingSessionListReadLock);
         for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
             pSampleStreamingSession = pSampleConfiguration->sampleStreamingSessionList[i];
             frame.index = (UINT32) ATOMIC_INCREMENT(&pSampleStreamingSession->frameIndex);
@@ -85,7 +85,7 @@ GstFlowReturn on_new_sample(GstElement* sink, gpointer data, UINT64 trackid)
 #endif
             }
         }
-        MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
+        MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);
     }
 
 CleanUp:

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -410,7 +410,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     }
     printf("[KVS GStreamer Master] KVS WebRTC initialization completed successfully\n");
 
-    pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = masterMessageReceived;
+    pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = signalingMessageReceived;
 
     strcpy(pSampleConfiguration->clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -47,7 +47,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     printf("[KVS Viewer] KVS WebRTC initialization completed successfully\n");
 
-    pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = viewerMessageReceived;
+    pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = signalingMessageReceived;
 
     sprintf(pSampleConfiguration->clientInfo.clientId, "%s_%u", SAMPLE_VIEWER_CLIENT_ID, RAND() % MAX_UINT32);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Organize signaling message handling by first putting them into a queue, then use a dedicated thread to process them one by one. 
- use a separate lock for media thread to access sampleStreamingSessionList to avoid media flow blocked by some potentially time consuming operations such as getIceServerConfig.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
