### PR TITLE
Removing the ldexp from the codebase

### DIFF
--- a/src/source/Rtcp/RtcpPacket.c
+++ b/src/source/Rtcp/RtcpPacket.c
@@ -122,7 +122,7 @@ STATUS rembValueGet(PBYTE pPayload, UINT32 payloadLen, PDOUBLE pMaximumBitRate, 
     mantissa &= RTCP_PACKET_REMB_MANTISSA_BITMASK;
 
     exponent = pPayload[RTCP_PACKET_REMB_IDENTIFIER_OFFSET + SIZEOF(UINT32) + SIZEOF(BYTE)] >> 2;
-    maximumBitRate = ldexp(mantissa, exponent);
+    maximumBitRate = mantissa * (1 << exponent);
 
     // Only populate SSRC list if caller requests
     ssrcListLen = pPayload[RTCP_PACKET_REMB_IDENTIFIER_OFFSET + SIZEOF(UINT32)];
@@ -135,7 +135,7 @@ STATUS rembValueGet(PBYTE pPayload, UINT32 payloadLen, PDOUBLE pMaximumBitRate, 
 CleanUp:
     if (STATUS_SUCCEEDED(retStatus)) {
         *pSsrcListLen = ssrcListLen;
-        *pMaximumBitRate = ldexp(mantissa, exponent);
+        *pMaximumBitRate = maximumBitRate;
     }
 
     LEAVES();


### PR DESCRIPTION
Issue #556 

No need for ldexp which will also remove the need to link against libm library on some platforms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
