### PR TITLE
Fix a deadlock in usrsctp_finish

### DIFF
--- a/CMake/Dependencies/libusrsctp-CMakeLists.txt
+++ b/CMake/Dependencies/libusrsctp-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(project_libusrsctp
     GIT_REPOSITORY    https://github.com/sctplab/usrsctp.git
-    GIT_TAG           913de3599feded8322882bdae69f346da5a258fc
+    GIT_TAG           939d48f9632d69bf170c7a84514b312b6b42257d
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -Dsctp_werror=0
     BUILD_ALWAYS      TRUE


### PR DESCRIPTION
The deadlock occurs when it's running on 2 virtual cores ubuntu machines with some very specific sequences.

References:
* Discussions on usrsctp, https://github.com/sctplab/usrsctp/issues/325
* Fix commit on usrsctp, https://github.com/sctplab/usrsctp/commit/939d48f9632d69bf170c7a84514b312b6b42257d

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
