### PR TITLE
Use commondefs implementation of max values

### DIFF
--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -30,7 +30,7 @@ STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEU
 
     CHK_STATUS(createIOBuffer(DEFAULT_MTU_SIZE, &pDtlsSession->pReadBuffer));
     pDtlsSession->timerQueueHandle = timerQueueHandle;
-    pDtlsSession->timerId = UINT32_MAX;
+    pDtlsSession->timerId = MAX_UINT32;
     pDtlsSession->sslLock = MUTEX_CREATE(TRUE);
     pDtlsSession->dtlsSessionCallbacks = *pDtlsSessionCallbacks;
     if (certificateBits == 0) {
@@ -82,7 +82,7 @@ STATUS freeDtlsSession(PDtlsSession* ppDtlsSession)
     pDtlsSession = *ppDtlsSession;
     CHK(pDtlsSession != NULL, retStatus);
 
-    if (pDtlsSession->timerId != UINT32_MAX) {
+    if (pDtlsSession->timerId != MAX_UINT32) {
         timerQueueCancelTimer(pDtlsSession->timerQueueHandle, pDtlsSession->timerId, (UINT64) pDtlsSession);
     }
 

--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -280,7 +280,7 @@ STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEU
     CHK(pDtlsSession != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
     pDtlsSession->timerQueueHandle = timerQueueHandle;
-    pDtlsSession->timerId = UINT32_MAX;
+    pDtlsSession->timerId = MAX_UINT32;
     pDtlsSession->sslLock = MUTEX_CREATE(TRUE);
     pDtlsSession->state = NEW;
     ATOMIC_STORE_BOOL(&pDtlsSession->isStarted, FALSE);
@@ -407,7 +407,7 @@ STATUS freeDtlsSession(PDtlsSession* ppDtlsSession)
 
     CHK(pDtlsSession != NULL, retStatus);
 
-    if (pDtlsSession->timerId != UINT32_MAX) {
+    if (pDtlsSession->timerId != MAX_UINT32) {
         timerQueueCancelTimer(pDtlsSession->timerQueueHandle, pDtlsSession->timerId, (UINT64) pDtlsSession);
     }
 

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -52,9 +52,9 @@ STATUS createIceAgent(PCHAR username, PCHAR password, PIceAgentCallbacks pIceAge
     CHK_STATUS(createStateMachine(ICE_AGENT_STATE_MACHINE_STATES, ICE_AGENT_STATE_MACHINE_STATE_COUNT, (UINT64) pIceAgent, iceAgentGetCurrentTime,
                                   (UINT64) pIceAgent, &pIceAgent->pStateMachine));
     pIceAgent->iceAgentStatus = STATUS_SUCCESS;
-    pIceAgent->iceAgentStateTimerTask = UINT32_MAX;
-    pIceAgent->keepAliveTimerTask = UINT32_MAX;
-    pIceAgent->iceCandidateGatheringTimerTask = UINT32_MAX;
+    pIceAgent->iceAgentStateTimerTask = MAX_UINT32;
+    pIceAgent->keepAliveTimerTask = MAX_UINT32;
+    pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
     pIceAgent->timerQueueHandle = timerQueueHandle;
     pIceAgent->lastDataReceivedTime = INVALID_TIMESTAMP_VALUE;
     pIceAgent->detectedDisconnection = FALSE;
@@ -673,19 +673,19 @@ STATUS iceAgentShutdown(PIceAgent pIceAgent)
     CHK(pIceAgent != NULL, STATUS_NULL_ARG);
     CHK(!ATOMIC_EXCHANGE_BOOL(&pIceAgent->shutdown, TRUE), retStatus);
 
-    if (pIceAgent->iceAgentStateTimerTask != UINT32_MAX) {
+    if (pIceAgent->iceAgentStateTimerTask != MAX_UINT32) {
         CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->iceAgentStateTimerTask, (UINT64) pIceAgent));
-        pIceAgent->iceAgentStateTimerTask = UINT32_MAX;
+        pIceAgent->iceAgentStateTimerTask = MAX_UINT32;
     }
 
-    if (pIceAgent->keepAliveTimerTask != UINT32_MAX) {
+    if (pIceAgent->keepAliveTimerTask != MAX_UINT32) {
         CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->keepAliveTimerTask, (UINT64) pIceAgent));
-        pIceAgent->keepAliveTimerTask = UINT32_MAX;
+        pIceAgent->keepAliveTimerTask = MAX_UINT32;
     }
 
-    if (pIceAgent->iceCandidateGatheringTimerTask != UINT32_MAX) {
+    if (pIceAgent->iceCandidateGatheringTimerTask != MAX_UINT32) {
         CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->iceCandidateGatheringTimerTask, (UINT64) pIceAgent));
-        pIceAgent->iceCandidateGatheringTimerTask = UINT32_MAX;
+        pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
     }
 
     MUTEX_LOCK(pIceAgent->lock);
@@ -762,19 +762,19 @@ STATUS iceAgentRestart(PIceAgent pIceAgent, PCHAR localIceUfrag, PCHAR localIceP
     alreadyRestarting = ATOMIC_EXCHANGE_BOOL(&pIceAgent->restart, TRUE);
     CHK(!alreadyRestarting, retStatus);
 
-    if (pIceAgent->iceAgentStateTimerTask != UINT32_MAX) {
+    if (pIceAgent->iceAgentStateTimerTask != MAX_UINT32) {
         CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->iceAgentStateTimerTask, (UINT64) pIceAgent));
-        pIceAgent->iceAgentStateTimerTask = UINT32_MAX;
+        pIceAgent->iceAgentStateTimerTask = MAX_UINT32;
     }
 
-    if (pIceAgent->keepAliveTimerTask != UINT32_MAX) {
+    if (pIceAgent->keepAliveTimerTask != MAX_UINT32) {
         CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->keepAliveTimerTask, (UINT64) pIceAgent));
-        pIceAgent->keepAliveTimerTask = UINT32_MAX;
+        pIceAgent->keepAliveTimerTask = MAX_UINT32;
     }
 
-    if (pIceAgent->iceCandidateGatheringTimerTask != UINT32_MAX) {
+    if (pIceAgent->iceCandidateGatheringTimerTask != MAX_UINT32) {
         CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->iceCandidateGatheringTimerTask, (UINT64) pIceAgent));
-        pIceAgent->iceCandidateGatheringTimerTask = UINT32_MAX;
+        pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
     }
 
     MUTEX_LOCK(pIceAgent->lock);
@@ -850,9 +850,9 @@ STATUS iceAgentRestart(PIceAgent pIceAgent, PCHAR localIceUfrag, PCHAR localIceP
     pIceAgent->localNetworkInterfaceCount = ARRAY_SIZE(pIceAgent->localNetworkInterfaces);
     pIceAgent->candidateGatheringEndTime = INVALID_TIMESTAMP_VALUE;
 
-    pIceAgent->iceAgentStateTimerTask = UINT32_MAX;
-    pIceAgent->keepAliveTimerTask = UINT32_MAX;
-    pIceAgent->iceCandidateGatheringTimerTask = UINT32_MAX;
+    pIceAgent->iceAgentStateTimerTask = MAX_UINT32;
+    pIceAgent->keepAliveTimerTask = MAX_UINT32;
+    pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
     pIceAgent->detectedDisconnection = FALSE;
     pIceAgent->disconnectionGracePeriodEndTime = INVALID_TIMESTAMP_VALUE;
 
@@ -1479,7 +1479,7 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
     if ((totalCandidateCount > 0 && pendingCandidateCount == 0) || currentTime >= pIceAgent->candidateGatheringEndTime) {
         DLOGD("Candidate gathering completed.");
         stopScheduling = TRUE;
-        pIceAgent->iceCandidateGatheringTimerTask = UINT32_MAX;
+        pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
     }
 
     CHK_STATUS(doubleListGetHeadNode(pIceAgent->localCandidates, &pCurNode));

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -31,7 +31,7 @@ STATUS createTurnConnection(PIceServer pTurnServer, TIMER_QUEUE_HANDLE timerQueu
     pTurnConnection->state = TURN_STATE_NEW;
     pTurnConnection->stateTimeoutTime = INVALID_TIMESTAMP_VALUE;
     pTurnConnection->errorStatus = STATUS_SUCCESS;
-    pTurnConnection->timerCallbackId = UINT32_MAX;
+    pTurnConnection->timerCallbackId = MAX_UINT32;
     pTurnConnection->pTurnPacket = NULL;
     pTurnConnection->pTurnChannelBindPacket = NULL;
     pTurnConnection->pConnectionListener = pConnectionListener;
@@ -90,8 +90,8 @@ STATUS freeTurnConnection(PTurnConnection* ppTurnConnection)
 
     pTurnConnection = *ppTurnConnection;
 
-    timerCallbackId = ATOMIC_EXCHANGE(&pTurnConnection->timerCallbackId, UINT32_MAX);
-    if (timerCallbackId != UINT32_MAX) {
+    timerCallbackId = ATOMIC_EXCHANGE(&pTurnConnection->timerCallbackId, MAX_UINT32);
+    if (timerCallbackId != MAX_UINT32) {
         CHK_LOG_ERR(timerQueueCancelTimer(pTurnConnection->timerQueueHandle, (UINT32) timerCallbackId, (UINT64) pTurnConnection));
     }
 
@@ -748,8 +748,8 @@ STATUS turnConnectionStart(PTurnConnection pTurnConnection)
     MUTEX_UNLOCK(pTurnConnection->lock);
     locked = FALSE;
 
-    timerCallbackId = ATOMIC_EXCHANGE(&pTurnConnection->timerCallbackId, UINT32_MAX);
-    if (timerCallbackId != UINT32_MAX) {
+    timerCallbackId = ATOMIC_EXCHANGE(&pTurnConnection->timerCallbackId, MAX_UINT32);
+    if (timerCallbackId != MAX_UINT32) {
         CHK_STATUS(timerQueueCancelTimer(pTurnConnection->timerQueueHandle, (UINT32) timerCallbackId, (UINT64) pTurnConnection));
     }
 
@@ -1326,7 +1326,7 @@ CleanUp:
     if (stopScheduling) {
         retStatus = STATUS_TIMER_QUEUE_STOP_SCHEDULING;
         if (pTurnConnection != NULL) {
-            ATOMIC_STORE(&pTurnConnection->timerCallbackId, UINT32_MAX);
+            ATOMIC_STORE(&pTurnConnection->timerCallbackId, MAX_UINT32);
         }
     }
 

--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -13,7 +13,7 @@ class IceFunctionalityTest : public WebRtcClientTestBase {
 BOOL candidatePairsInOrder(PDoubleList iceCandidatePairs)
 {
     BOOL inOrder = TRUE;
-    UINT64 previousPriority = UINT64_MAX;
+    UINT64 previousPriority = MAX_UINT64;
     PDoubleListNode pCurNode = NULL;
     PIceCandidatePair pIceCandidatePair = NULL;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Using UINTx_MAX causes Windows build to fail if stdint.h is not included for Windows platform. So far, it worked without a glitch because the Windows specific header files included in `Include_i.h` included stdint.h. This PR replaces UINTx_MAX usage with the definitions in [CommonDefs.h](https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/master/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h)
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
