### PR TITLE
Windows: fix assertion when close socket

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -128,6 +128,7 @@ extern "C" {
 #define STATUS_SOCKET_SET_SEND_BUFFER_SIZE_FAILED  STATUS_NETWORKING_BASE + 0x00000023
 #define STATUS_GET_SOCKET_FLAG_FAILED              STATUS_NETWORKING_BASE + 0x00000024
 #define STATUS_SET_SOCKET_FLAG_FAILED              STATUS_NETWORKING_BASE + 0x00000025
+#define STATUS_CLOSE_SOCKET_FAILED                 STATUS_NETWORKING_BASE + 0x00000026
 /*!@} */
 
 /*===========================================================================================*/

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -197,6 +197,21 @@ CleanUp:
     return retStatus;
 }
 
+STATUS closeSocket(INT32 sockfd)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+
+#ifdef _WIN32
+    CHK_ERR(closesocket(sockfd) == 0, STATUS_CLOSE_SOCKET_FAILED, "Failed to close the socket %s", strerror(errno));
+#else
+    CHK_ERR(close(sockfd) == 0, STATUS_CLOSE_SOCKET_FAILED, "Failed to close the socket %s", strerror(errno));
+#endif
+
+CleanUp:
+
+    return retStatus;
+}
+
 STATUS socketBind(PKvsIpAddress pHostIpAddress, INT32 sockfd)
 {
     STATUS retStatus = STATUS_SUCCESS;

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -62,6 +62,13 @@ STATUS getLocalhostIpAddresses(PKvsIpAddress, PUINT32, IceSetInterfaceFilterFunc
 STATUS createSocket(KVS_IP_FAMILY_TYPE, KVS_SOCKET_PROTOCOL, UINT32, PINT32);
 
 /**
+ * @param - INT32 - IN - INT32 for the socketfd
+ *
+ * @return - STATUS status of execution
+ */
+STATUS closeSocket(INT32);
+
+/**
  * @param - PKvsIpAddress - IN - address for the socket to bind. PKvsIpAddress->port will be changed to the actual port number
  * @param - INT32 - IN - valid socket fd
  *

--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -74,7 +74,7 @@ STATUS freeSocketConnection(PSocketConnection* ppSocketConnection)
         freeTlsSession(&pSocketConnection->pTlsSession);
     }
 
-    close(pSocketConnection->localSocket);
+    CHK_STATUS(closeSocket(pSocketConnection->localSocket));
 
     MEMFREE(pSocketConnection);
 


### PR DESCRIPTION
Windows: fix assertion when close socket

Signed-off-by: Alex.Li <zhiqinli@amazon.com>

*Issue #, if available:*
#688 
*Description of changes:*
socket() on windows do not use *nix-style file descriptors but returns a
handle to a kernel object instead, it must be closed via closesocket()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
