### PR TITLE
Fix NULL pointer dereference

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2193,7 +2193,8 @@ STATUS incomingDataHandler(UINT64 customData, PSocketConnection pSocketConnectio
     if ((bufferLen < 8 || !IS_STUN_PACKET(pBuffer)) && pIceAgent->iceAgentCallbacks.inboundPacketFn != NULL) {
         // release lock early
         addrLen = IS_IPV4_ADDR(pSrc) ? IPV4_ADDRESS_LENGTH : IPV6_ADDRESS_LENGTH;
-        if (pIceAgent->pDataSendingIceCandidatePair->local->pSocketConnection == pSocketConnection &&
+        if (pIceAgent->pDataSendingIceCandidatePair != NULL &&
+            pIceAgent->pDataSendingIceCandidatePair->local->pSocketConnection == pSocketConnection &&
             pIceAgent->pDataSendingIceCandidatePair->remote->ipAddress.family == pSrc->family &&
             MEMCMP(pIceAgent->pDataSendingIceCandidatePair->remote->ipAddress.address, pSrc->address, addrLen) == 0 &&
             (pIceAgent->pDataSendingIceCandidatePair->remote->ipAddress.port == pSrc->port)) {


### PR DESCRIPTION
Resolves https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/760

A NULL pointer dereference at `pDataSendingIceCandidatePair` can occur when the ICE agent receives data before it's finished setup. Since ICE gathering starts as soon as the user calls `setLocalDescription` and the `pDataSendingIceCandidatePair` setup is done after calling `setRemoteDescription` within the `iceAgentStartAgent`, it's possible that the ICE agent receives data in between `setLocalDescription` and `setRemoteDescription`, which will lead to a NULL pointer dereference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
