### PR TITLE
Ignore fork builds for check-sample

### DIFF
--- a/check-sample.sh
+++ b/check-sample.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
+if [[ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]]
+then
+  echo "Couldn't find AWS credentials. Very likely this build is coming from a fork. Ignoring."
+  exit 0
+fi
+
 # Set bash to print out every command that's running to the screen
+# Set logging after checking credentials so that we don't leak them
 set -xv
 
 pwd


### PR DESCRIPTION
Currently, `check-sample` always fails when there's no AWS credentials provided. This is great and expected but we should not run the check when it's used for checking fork builds as they won't have AWS credentials in Travis.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
