### PR TITLE
Enable compiler warning for OSX GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       os: osx
       compiler: gcc
       before_script:
-        - mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE
+        - mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
       script:
         - make
         - export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:`pwd`/../open-source/lib"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enable compiler warning for OSX GCC. Currently, we set it only for OSX Clang. 

Todo: 
Add compiler warning for Windows and linux as well. For Windows, the W4 flag needs to be set. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
