### PR TITLE
Fix readme for pre-gen cert section

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,18 +210,18 @@ freeIotCredentialProvider(&pSampleConfiguration->pCredentialProvider);
 ## Use Pre-generated Certificates
 The certificate generating function (createCertificateAndKey) in createDtlsSession() can take between 5 - 15 seconds in low performance embedded devices, it is called for every peer connection creation when KVS WebRTC receives an offer. To avoid this extra start-up latency, certificate can be pre-generated and passed in when offer comes.
 
-Important Note: It is recommended to rotate the certificates often - preferably for every peer connection to avoid a compromised client weakening the security of the new connections.
+**Important Note: It is recommended to rotate the certificates often - preferably for every peer connection to avoid a compromised client weakening the security of the new connections.**
 
-Take kvsWebRTCClientMaster as sample, add RtcCertificate certificates[CERT_COUNT]; to **SampleConfiguration** in Samples.h, call create certificate before signalingClientCallbacks.messageReceivedFn = masterMessageReceived; in kvsWebRTCClientMaster.c
-```
-createCertificateAndKey(GENERATED_CERTIFICATE_BITS, &pSampleConfiguration->certificates[0].pCertificate, &pSampleConfiguration->certificates[0].pPrivateKey);
-```
-
-Then pass in the pre-generated certificate in initializePeerConnection() in common.c.
+Take kvsWebRTCClientMaster as sample, add RtcCertificate certificates[CERT_COUNT]; to **SampleConfiguration** in Samples.h.
+Then pass in the pre-generated certificate in initializePeerConnection() in Common.c.
 
 ```
-configuration.certificates[0].pCertificate = pSampleConfiguration->rtcConfig.certificates[0].pCertificate;
-configuration.certificates[0].pPrivateKey = pSampleConfiguration->rtcConfig.certificates[0].pPrivateKey;
+configuration.certificates[0].pCertificate = pSampleConfiguration->certificates[0].pCertificate;
+configuration.certificates[0].pPrivateKey = pSampleConfiguration->certificates[0].pPrivateKey;
+
+where, `configuration` is of type `RtcConfiguration` in the function that calls `initializePeerConnection()`.
+
+Doing this will make sure that `createCertificateAndKey() would not execute since a certificate is already available.`
 ```
 
 ## DEBUG


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We do not expose `createCertificateAndKey()` as a public API as mentioned in the README. This PR changes the wording around pre-gen certificate section

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
