### PR TITLE
Fix linking error for createLwsIotCredentialProvider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,14 +270,15 @@ add_library(kvsWebrtcSignalingClient ${LINKAGE} ${WEBRTC_SIGNALING_CLIENT_SOURCE
 target_link_libraries(
   kvsWebrtcSignalingClient
   PRIVATE kvspicUtils
-          kvspicState
-          ${CMAKE_THREAD_LIBS_INIT}
-          ${LIBWEBSOCKETS_LIBRARIES}
-          ${EXTRA_DEPS}
-          ${OPENSSL_SSL_LIBRARY}
-          ${OPENSSL_CRYPTO_LIBRARY}
-          ${MBEDTLS_LIBRARIES}
-  PUBLIC kvsCommonLws)
+         kvspicState
+         ${CMAKE_THREAD_LIBS_INIT}
+         ${EXTRA_DEPS}
+         ${OPENSSL_SSL_LIBRARY}
+         ${OPENSSL_CRYPTO_LIBRARY}
+         ${MBEDTLS_LIBRARIES}
+  PUBLIC
+        ${LIBWEBSOCKETS_LIBRARIES} 
+        kvsCommonLws)
 
 if (WIN32)
   target_link_libraries(kvsWebrtcClient PRIVATE "Ws2_32" "iphlpapi")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since libwebsockets is linked as private, the public headers are not usable. Moving libwebsockets to public fixes it on Mac. Need to verify if the fix works on other platforms through Travis.

Resolves #777 .


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
