### PR TITLE
Check for SRTP session ready in samples

### DIFF
--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -77,9 +77,8 @@ GstFlowReturn on_new_sample(GstElement* sink, gpointer data, UINT64 trackid)
                 frame.decodingTs = frame.presentationTs;
                 pSampleStreamingSession->videoTimestamp += SAMPLE_VIDEO_FRAME_DURATION; // assume video fps is 30
             }
-
             status = writeFrame(pRtcRtpTransceiver, &frame);
-            if (status != STATUS_SUCCESS) {
+            if (status != STATUS_SRTP_NOT_READY_YET && status != STATUS_SUCCESS) {
 #ifdef VERBOSE
                 printf("writeFrame() failed with 0x%08x", status);
 #endif


### PR DESCRIPTION
*Issue #, if available:*
#812 
*Description of changes:*
Add check for STATUS_SRTP_NOT_READY_YET status code in gst sample to avoid log spew of writeFrame() status code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
