### PR TITLE
Remove log level override in createPeerConnection.

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -636,8 +636,6 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     PKvsPeerConnection pKvsPeerConnection = NULL;
     IceAgentCallbacks iceAgentCallbacks;
     DtlsSessionCallbacks dtlsSessionCallbacks;
-    UINT32 logLevel = LOG_LEVEL_DEBUG;
-    PCHAR logLevelStr = NULL;
     PConnectionListener pConnectionListener = NULL;
 
     CHK(pConfiguration != NULL && ppPeerConnection != NULL, STATUS_NULL_ARG);
@@ -665,13 +663,6 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     CHK_STATUS(hashTableCreateWithParams(CODEC_HASH_TABLE_BUCKET_COUNT, CODEC_HASH_TABLE_BUCKET_LENGTH, &pKvsPeerConnection->pDataChannels));
     CHK_STATUS(hashTableCreateWithParams(RTX_HASH_TABLE_BUCKET_COUNT, RTX_HASH_TABLE_BUCKET_LENGTH, &pKvsPeerConnection->pRtxTable));
     CHK_STATUS(doubleListCreate(&(pKvsPeerConnection->pTransceivers)));
-
-    if ((logLevelStr = GETENV(DEBUG_LOG_LEVEL_ENV_VAR)) != NULL) {
-        CHK_STATUS(STRTOUI32(logLevelStr, NULL, 10, &logLevel));
-        logLevel = MIN(MAX(logLevel, LOG_LEVEL_VERBOSE), LOG_LEVEL_SILENT);
-    }
-
-    SET_LOGGER_LOG_LEVEL(logLevel);
 
     pKvsPeerConnection->pSrtpSessionLock = MUTEX_CREATE(TRUE);
     pKvsPeerConnection->peerConnectionObjLock = MUTEX_CREATE(FALSE);


### PR DESCRIPTION
*Issue #, if available:*

N/A 

*Description of changes:*

This pull request reverts a change that causes the log level to be overridden (set to DEBUG if no env var is set) inside createPeerConnection. This results in programmatically set values being overridden.

Before this change: Any log level set via ```loggerSetLogLevel``` and/or ```SignalingClientInfo::logLevel``` would be overridden by a call to createPeerConnection.

After this change: ```loggerSetLogLevel``` and ```SignalingClientInfo::logLevel``` (in conjunction) successfully define/maintain a desired log output level.

Original commit, if helpful: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/commit/6fbedcb380f42263ff0bd8e5638912e8ad19c5f8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
