### PR TITLE
Add internal getErrorCode() and getErrorString()

### DIFF
--- a/src/source/Ice/ConnectionListener.c
+++ b/src/source/Ice/ConnectionListener.c
@@ -319,7 +319,7 @@ PVOID connectionListenerReceiveDataRoutine(PVOID arg)
         retval = select(nfds, &rfds, NULL, NULL, &tv);
 
         if (retval == -1) {
-            DLOGE("select() failed with errno %s", strerror(errno));
+            DLOGE("select() failed with errno %s", getErrorString(getErrorCode()));
             continue;
         } else if (retval == 0) {
             continue;
@@ -336,13 +336,14 @@ PVOID connectionListenerReceiveDataRoutine(PVOID arg)
                     readLen = recvfrom(pSocketConnection->localSocket, pConnectionListener->pBuffer, pConnectionListener->bufferLen, 0,
                                        (struct sockaddr*) &srcAddrBuff, &srcAddrBuffLen);
                     if (readLen < 0) {
-                        switch (errno) {
+                        switch (getErrorCode()) {
                             case EWOULDBLOCK:
                                 break;
                             default:
                                 /* on any other error, close connection */
                                 CHK_STATUS(socketConnectionClosed(pSocketConnection));
-                                DLOGD("recvfrom() failed with errno %s for socket %d", strerror(errno), pSocketConnection->localSocket);
+                                DLOGD("recvfrom() failed with errno %s for socket %d", getErrorString(getErrorCode()),
+                                      pSocketConnection->localSocket);
                                 break;
                         }
 

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -436,8 +436,8 @@ PCHAR getErrorString(INT32 error)
             break;
     }
     if (FormatMessage((FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS), NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), buffer,
-                      sizeof(buffer), NULL) == 0) {
-        sprintf_s(buffer, sizeof(buffer), "error code %d", error);
+                      SIZEOF(buffer), NULL) == 0) {
+        SNPRINTF(buffer, SIZEOF(buffer), "error code %d", error);
     }
 
     return buffer;

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -97,6 +97,18 @@ STATUS getIpAddrStr(PKvsIpAddress, PCHAR, UINT32);
 
 BOOL isSameIpAddress(PKvsIpAddress, PKvsIpAddress, BOOL);
 
+/**
+ * @return - INT32 error code
+ */
+INT32 getErrorCode(VOID);
+
+/**
+ * @param - INT32 - IN - error code
+ *
+ * @return - PCHAR string associated with error code
+ */
+PCHAR getErrorString(INT32);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
*Issue #, if available:*
#756 references `WSAGetLastError()`. So this pull request might relate to that issue.

*Description of changes:*
These functions allow the addition of error handling support for
Windows Sockets Error Codes. On Windows the functions use `WSAGetLastError()` and
`FormatMessage()`, and on non-Windows platforms they use `errno` and
`strerror()`.

In addition, these functions provide mapping from Windows Sockets
Error Codes to BSD error codes for the error codes that are explicitly
checked in code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
