### PR TITLE
Serialize signaling message sending to ensure no race condition could…

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -188,17 +188,14 @@ STATUS sendSignalingMessage(PSampleStreamingSession pSampleStreamingSession, PSi
     BOOL locked = FALSE;
 
     // Validate the input params
-    CHK(pSampleStreamingSession != NULL &&
-        pSampleStreamingSession->pSampleConfiguration != NULL &&
-        pMessage != NULL, STATUS_NULL_ARG);
+    CHK(pSampleStreamingSession != NULL && pSampleStreamingSession->pSampleConfiguration != NULL && pMessage != NULL, STATUS_NULL_ARG);
     CHK(IS_VALID_MUTEX_VALUE(pSampleStreamingSession->pSampleConfiguration->signalingSendMessageLock) &&
-        IS_VALID_SIGNALING_CLIENT_HANDLE(pSampleStreamingSession->pSampleConfiguration->signalingClientHandle),
+            IS_VALID_SIGNALING_CLIENT_HANDLE(pSampleStreamingSession->pSampleConfiguration->signalingClientHandle),
         STATUS_INVALID_OPERATION);
 
     MUTEX_LOCK(pSampleStreamingSession->pSampleConfiguration->signalingSendMessageLock);
     locked = TRUE;
-    CHK_STATUS(signalingClientSendMessageSync(pSampleStreamingSession->pSampleConfiguration->signalingClientHandle,
-                                              pMessage));
+    CHK_STATUS(signalingClientSendMessageSync(pSampleStreamingSession->pSampleConfiguration->signalingClientHandle, pMessage));
 
 CleanUp:
 

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -182,22 +182,49 @@ CleanUp:
     return retStatus;
 }
 
+STATUS sendSignalingMessage(PSampleStreamingSession pSampleStreamingSession, PSignalingMessage pMessage)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    // Validate the input params
+    CHK(pSampleStreamingSession != NULL &&
+        pSampleStreamingSession->pSampleConfiguration != NULL &&
+        pMessage != NULL, STATUS_NULL_ARG);
+    CHK(IS_VALID_MUTEX_VALUE(pSampleStreamingSession->pSampleConfiguration->signalingSendMessageLock) &&
+        IS_VALID_SIGNALING_CLIENT_HANDLE(pSampleStreamingSession->pSampleConfiguration->signalingClientHandle),
+        STATUS_INVALID_OPERATION);
+
+    MUTEX_LOCK(pSampleStreamingSession->pSampleConfiguration->signalingSendMessageLock);
+    locked = TRUE;
+    CHK_STATUS(signalingClientSendMessageSync(pSampleStreamingSession->pSampleConfiguration->signalingClientHandle,
+                                              pMessage));
+
+CleanUp:
+
+    if (locked) {
+        MUTEX_UNLOCK(pSampleStreamingSession->pSampleConfiguration->signalingSendMessageLock);
+    }
+
+    CHK_LOG_ERR(retStatus);
+    return retStatus;
+}
+
 STATUS respondWithAnswer(PSampleStreamingSession pSampleStreamingSession)
 {
     STATUS retStatus = STATUS_SUCCESS;
     SignalingMessage message;
-    UINT32 buffLen = 0;
+    UINT32 buffLen = MAX_SIGNALING_MESSAGE_LEN;
 
-    CHK_STATUS(serializeSessionDescriptionInit(&pSampleStreamingSession->answerSessionDescriptionInit, NULL, &buffLen));
     CHK_STATUS(serializeSessionDescriptionInit(&pSampleStreamingSession->answerSessionDescriptionInit, message.payload, &buffLen));
 
     message.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     message.messageType = SIGNALING_MESSAGE_TYPE_ANSWER;
-    STRCPY(message.peerClientId, pSampleStreamingSession->peerId);
+    STRNCPY(message.peerClientId, pSampleStreamingSession->peerId, MAX_SIGNALING_CLIENT_ID_LEN);
     message.payloadLen = (UINT32) STRLEN(message.payload);
     message.correlationId[0] = '\0';
 
-    retStatus = signalingClientSendMessageSync(pSampleStreamingSession->pSampleConfiguration->signalingClientHandle, &message);
+    CHK_STATUS(sendSignalingMessage(pSampleStreamingSession, &message));
 
 CleanUp:
 
@@ -232,11 +259,11 @@ VOID onIceCandidateHandler(UINT64 customData, PCHAR candidateJson)
     } else if (pSampleStreamingSession->remoteCanTrickleIce && ATOMIC_LOAD_BOOL(&pSampleStreamingSession->peerIdReceived)) {
         message.version = SIGNALING_MESSAGE_CURRENT_VERSION;
         message.messageType = SIGNALING_MESSAGE_TYPE_ICE_CANDIDATE;
-        STRCPY(message.peerClientId, pSampleStreamingSession->peerId);
-        message.payloadLen = (UINT32) STRLEN(candidateJson);
-        STRCPY(message.payload, candidateJson);
+        STRNCPY(message.peerClientId, pSampleStreamingSession->peerId, MAX_SIGNALING_CLIENT_ID_LEN);
+        message.payloadLen = (UINT32) STRNLEN(candidateJson, MAX_SIGNALING_MESSAGE_LEN);
+        STRNCPY(message.payload, candidateJson, message.payloadLen);
         message.correlationId[0] = '\0';
-        CHK_STATUS(signalingClientSendMessageSync(pSampleStreamingSession->pSampleConfiguration->signalingClientHandle, &message));
+        CHK_STATUS(sendSignalingMessage(pSampleStreamingSession, &message));
     }
 
 CleanUp:
@@ -606,6 +633,7 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
     pSampleConfiguration->sampleConfigurationObjLock = MUTEX_CREATE(TRUE);
     pSampleConfiguration->cvar = CVAR_CREATE();
     pSampleConfiguration->streamingSessionListReadLock = MUTEX_CREATE(FALSE);
+    pSampleConfiguration->signalingSendMessageLock = MUTEX_CREATE(FALSE);
     /* This is ignored for master. Master can extract the info from offer. Viewer has to know if peer can trickle or
      * not ahead of time. */
     pSampleConfiguration->trickleIce = trickleIce;
@@ -834,6 +862,10 @@ STATUS freeSampleConfiguration(PSampleConfiguration* ppSampleConfiguration)
 
     if (IS_VALID_MUTEX_VALUE(pSampleConfiguration->streamingSessionListReadLock)) {
         MUTEX_FREE(pSampleConfiguration->streamingSessionListReadLock);
+    }
+
+    if (IS_VALID_MUTEX_VALUE(pSampleConfiguration->signalingSendMessageLock)) {
+        MUTEX_FREE(pSampleConfiguration->signalingSendMessageLock);
     }
 
     if (IS_VALID_CVAR_VALUE(pSampleConfiguration->cvar)) {

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -96,6 +96,8 @@ typedef struct {
     SignalingClientCallbacks signalingClientCallbacks;
     SignalingClientInfo clientInfo;
     RtcStats rtcIceCandidatePairMetrics;
+
+    MUTEX signalingSendMessageLock;
 } SampleConfiguration, *PSampleConfiguration;
 
 typedef VOID (*StreamSessionShutdownCallback)(UINT64, PSampleStreamingSession);
@@ -145,6 +147,7 @@ STATUS lookForSslCert(PSampleConfiguration*);
 STATUS createSampleStreamingSession(PSampleConfiguration, PCHAR, BOOL, PSampleStreamingSession*);
 STATUS freeSampleStreamingSession(PSampleStreamingSession*);
 STATUS streamingSessionOnShutdown(PSampleStreamingSession, UINT64, StreamSessionShutdownCallback);
+STATUS sendSignalingMessage(PSampleStreamingSession, PSignalingMessage);
 STATUS respondWithAnswer(PSampleStreamingSession);
 STATUS resetSampleConfigurationState(PSampleConfiguration);
 VOID sampleFrameHandler(UINT64, PFrame);

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -27,7 +27,7 @@ CleanUp:
     return retStatus;
 }
 
-// TODO handle SLI packet https://tools.ietf.org/html/rfc2032#section-5.2.1
+// TODO handle SLI packet https://tools.ietf.org/html/rfc4585#section-6.3.2
 static STATUS onRtcpSLIPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
 {
     STATUS retStatus = STATUS_SUCCESS;

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -369,7 +369,7 @@ INT32 lwsWssCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, P
             CHK(!lws_frame_is_binary(wsi), STATUS_SIGNALING_RECEIVE_BINARY_DATA_NOT_SUPPORTED);
 
             // Skip if it's the first and last fragment and the size is 0
-            CHK (!(lws_is_first_fragment(wsi) && lws_is_final_fragment(wsi) && dataSize == 0), retStatus);
+            CHK(!(lws_is_first_fragment(wsi) && lws_is_final_fragment(wsi) && dataSize == 0), retStatus);
 
             // Check what type of a message it is. We will set the size to 0 on first and flush on last
             if (lws_is_first_fragment(wsi)) {

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -368,6 +368,9 @@ INT32 lwsWssCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, P
             // Check if it's a binary data
             CHK(!lws_frame_is_binary(wsi), STATUS_SIGNALING_RECEIVE_BINARY_DATA_NOT_SUPPORTED);
 
+            // Skip if it's the first and last fragment and the size is 0
+            CHK (!(lws_is_first_fragment(wsi) && lws_is_final_fragment(wsi) && dataSize == 0), retStatus);
+
             // Check what type of a message it is. We will set the size to 0 on first and flush on last
             if (lws_is_first_fragment(wsi)) {
                 pLwsCallInfo->receiveBufferSize = 0;

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -720,7 +720,7 @@ STATUS signalingGetOngoingMessage(PSignalingClient pSignalingClient, PCHAR corre
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     BOOL locked = FALSE, checkPeerClientId = TRUE;
-    PSignalingMessage pExistingMessage;
+    PSignalingMessage pExistingMessage = NULL;
     StackQueueIterator iterator;
     UINT64 data;
 
@@ -751,10 +751,11 @@ STATUS signalingGetOngoingMessage(PSignalingClient pSignalingClient, PCHAR corre
         CHK_STATUS(stackQueueIteratorNext(&iterator));
     }
 
-    // Didn't find a match
-    *ppSignalingMessage = NULL;
-
 CleanUp:
+
+    if (ppSignalingMessage != NULL) {
+        *ppSignalingMessage = pExistingMessage;
+    }
 
     if (locked) {
         MUTEX_UNLOCK(pSignalingClient->messageQueueLock);

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -1243,7 +1243,7 @@ TEST_F(SignalingApiFunctionalityTest, iceRefreshEmulationWithFaultInjectionAuthE
     EXPECT_EQ(0, signalingStatesCounts[SIGNALING_CLIENT_STATE_DISCONNECTED]);
 
     // Wait for ICE refresh while connected
-    THREAD_SLEEP(7 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
     // This time the states will circle through connecting/connected again
     EXPECT_EQ(1, signalingStatesCounts[SIGNALING_CLIENT_STATE_NEW]);
@@ -1414,7 +1414,7 @@ TEST_F(SignalingApiFunctionalityTest, iceRefreshEmulationWithFaultInjectionError
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
-    clientInfoInternal.iceRefreshPeriod = 5 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    clientInfoInternal.iceRefreshPeriod = 10 * HUNDREDS_OF_NANOS_IN_A_SECOND;
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
@@ -1446,7 +1446,7 @@ TEST_F(SignalingApiFunctionalityTest, iceRefreshEmulationWithFaultInjectionError
     pSignalingClient->pAwsCredentials->secretKey[0] = 'A';
 
     // Wait for ICE refresh while connected
-    THREAD_SLEEP(6 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(15 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 
     // While the background ICE refresh is happening, we will be blocked for the refresh thread to finish
     // In this case, the ICE refresh will eventually fail, however, we should still be able to send the


### PR DESCRIPTION
… possibly arise from non serialized offers/answers/ice candidates. Fixing a warning message with 0 length messages which are both start and end of the received message fragment. Added extra checks for buffer size in sample.

Possible fix for reported 
Issue #848 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
