### PR TITLE
Resolve link error when using createLwsIotCredentialProvider on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,8 +288,8 @@ add_library(kvsWebrtcSignalingClient ${LINKAGE} ${WEBRTC_SIGNALING_CLIENT_SOURCE
 target_link_libraries(
   kvsWebrtcSignalingClient
   PUBLIC
-        ${LIBWEBSOCKETS_LIBRARIES} 
         kvsCommonLws
+        ${LIBWEBSOCKETS_LIBRARIES} 
   PRIVATE kvspicUtils
          kvspicState
          ${CMAKE_THREAD_LIBS_INIT}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/838
*Description of changes:*
Changing the link ordering for kvsWebrtcSignalingClient resolves link failures when using createLwsIotCredentialProvider on Ubuntu.  I cannot verify if this breaks Windows or Mac builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
