### PR TITLE
Handle separate error codes from connect()

### DIFF
--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -291,7 +291,7 @@ STATUS socketConnect(PKvsIpAddress pPeerAddress, INT32 sockfd)
     }
 
     retVal = connect(sockfd, peerSockAddr, addrLen);
-    CHK_ERR(retVal >= 0 || getErrorCode() == EINPROGRESS, STATUS_SOCKET_CONNECT_FAILED, "connect() failed with errno %s",
+    CHK_ERR(retVal >= 0 || getErrorCode() == KVS_SOCKET_IN_PROGRESS, STATUS_SOCKET_CONNECT_FAILED, "connect() failed with errno %s",
             getErrorString(getErrorCode()));
 
 CleanUp:

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -33,6 +33,14 @@ extern "C" {
 #define EAI_SYSTEM -11
 #endif
 
+// Windows uses EWOULDBLOCK (WSAEWOULDBLOCK) to indicate connection attempt
+// cannot be completed immediately, whereas POSIX uses EINPROGRESS.
+#ifdef _WIN32
+    #define KVS_SOCKET_IN_PROGRESS EWOULDBLOCK
+#else
+    #define KVS_SOCKET_IN_PROGRESS EINPROGRESS
+#endif
+
 typedef enum {
     KVS_SOCKET_PROTOCOL_NONE,
     KVS_SOCKET_PROTOCOL_TCP,

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -36,9 +36,9 @@ extern "C" {
 // Windows uses EWOULDBLOCK (WSAEWOULDBLOCK) to indicate connection attempt
 // cannot be completed immediately, whereas POSIX uses EINPROGRESS.
 #ifdef _WIN32
-    #define KVS_SOCKET_IN_PROGRESS EWOULDBLOCK
+#define KVS_SOCKET_IN_PROGRESS EWOULDBLOCK
 #else
-    #define KVS_SOCKET_IN_PROGRESS EINPROGRESS
+#define KVS_SOCKET_IN_PROGRESS EINPROGRESS
 #endif
 
 typedef enum {


### PR DESCRIPTION
*Issue #, if available:*
#756 
*Description of changes:*
On Windows when calling connect() with a non-blocking socket, the
error code WSAEWOULDBLOCK is used to indicate the connection attempt
cannot be completed immediately. However the POSIX error code for this
case is EINPROGRESS.

This commit updates socketConnect() to handle both the WIN32 and POSIX
error codes mentioned above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
