### PR TITLE
Bump CMake minimum required version 2.8 -> 3.6.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.6.3)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 include(Utilities)
 include(CheckIncludeFiles)


### PR DESCRIPTION
In our cmake scripts, we've been using features that are only available in versions above 2.8. Users should not see weird errors as reported https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/875, but instead it should bail out with the correct minimum required version.

Related Issue: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/875


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
