### PR TITLE
lws_client_connect_via_info API is not multi-thread reentrant. Simply…

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           3f437b936adf1899533a8f82c9f374e7041004eb
+    GIT_TAG           15f124e5a5561679cf001bb36c2c758073740681
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -736,7 +736,6 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     // free timer queue first to remove liveness provided by timer
     if (IS_VALID_TIMER_QUEUE_HANDLE(pKvsPeerConnection->timerQueueHandle)) {
         timerQueueShutdown(pKvsPeerConnection->timerQueueHandle);
-        timerQueueFree(&pKvsPeerConnection->timerQueueHandle);
     }
 
     /* Free structs that have their own thread. SCTP has threads created by SCTP library. IceAgent has the
@@ -769,6 +768,10 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
 
     if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->peerConnectionObjLock)) {
         MUTEX_FREE(pKvsPeerConnection->peerConnectionObjLock);
+    }
+
+    if (IS_VALID_TIMER_QUEUE_HANDLE(pKvsPeerConnection->timerQueueHandle)) {
+        timerQueueFree(&pKvsPeerConnection->timerQueueHandle);
     }
 
     SAFE_MEMFREE(pKvsPeerConnection);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -736,6 +736,7 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     // free timer queue first to remove liveness provided by timer
     if (IS_VALID_TIMER_QUEUE_HANDLE(pKvsPeerConnection->timerQueueHandle)) {
         timerQueueShutdown(pKvsPeerConnection->timerQueueHandle);
+        timerQueueFree(&pKvsPeerConnection->timerQueueHandle);
     }
 
     /* Free structs that have their own thread. SCTP has threads created by SCTP library. IceAgent has the
@@ -768,10 +769,6 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
 
     if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->peerConnectionObjLock)) {
         MUTEX_FREE(pKvsPeerConnection->peerConnectionObjLock);
-    }
-
-    if (IS_VALID_TIMER_QUEUE_HANDLE(pKvsPeerConnection->timerQueueHandle)) {
-        timerQueueFree(&pKvsPeerConnection->timerQueueHandle);
     }
 
     SAFE_MEMFREE(pKvsPeerConnection);

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1736,6 +1736,7 @@ STATUS terminateConnectionWithStatus(PSignalingClient pSignalingClient, SERVICE_
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
+    UINT32 i;
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
 
@@ -1750,8 +1751,11 @@ STATUS terminateConnectionWithStatus(PSignalingClient pSignalingClient, SERVICE_
         ATOMIC_STORE_BOOL(&pSignalingClient->pOngoingCallInfo->cancelService, TRUE);
     }
 
-    // Wake up the service event loop
-    CHK_STATUS(wakeLwsServiceEventLoop(pSignalingClient, PROTOCOL_INDEX_WSS));
+    // Wake up the service event loop for all of the protocols
+    for (i = 0; i < LWS_PROTOCOL_COUNT; i++) {
+        CHK_STATUS(wakeLwsServiceEventLoop(pSignalingClient, i));
+    }
+
     CHK_STATUS(awaitForThreadTermination(&pSignalingClient->listenerTracker, SIGNALING_CLIENT_SHUTDOWN_TIMEOUT));
 
 CleanUp:

--- a/src/source/Signaling/LwsApiCalls.h
+++ b/src/source/Signaling/LwsApiCalls.h
@@ -218,7 +218,7 @@ STATUS writeLwsData(PSignalingClient, BOOL);
 STATUS terminateLwsListenerLoop(PSignalingClient);
 STATUS receiveLwsMessage(PSignalingClient, PCHAR, UINT32);
 STATUS getMessageTypeFromString(PCHAR, UINT32, SIGNALING_MESSAGE_TYPE*);
-STATUS wakeLwsServiceEventLoop(PSignalingClient);
+STATUS wakeLwsServiceEventLoop(PSignalingClient, UINT32);
 STATUS terminateConnectionWithStatus(PSignalingClient, SERVICE_CALL_RESULT);
 
 #ifdef __cplusplus

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -104,6 +104,7 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     ATOMIC_STORE_BOOL(&pSignalingClient->deleting, FALSE);
     ATOMIC_STORE_BOOL(&pSignalingClient->deleted, FALSE);
     ATOMIC_STORE_BOOL(&pSignalingClient->iceConfigRetrieved, FALSE);
+    ATOMIC_STORE_BOOL(&pSignalingClient->serviceLockContention, FALSE);
 
     // Add to the signal handler
     // signal(SIGINT, lwsSignalHandler);

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -79,6 +79,9 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     pSignalingClient->signalingProtocols[PROTOCOL_INDEX_WSS].name = WSS_SCHEME_NAME;
     pSignalingClient->signalingProtocols[PROTOCOL_INDEX_WSS].callback = lwsWssCallbackRoutine;
 
+    pSignalingClient->currentWsi[PROTOCOL_INDEX_HTTPS] = NULL;
+    pSignalingClient->currentWsi[PROTOCOL_INDEX_WSS] = NULL;
+
     MEMSET(&creationInfo, 0x00, SIZEOF(struct lws_context_creation_info));
     creationInfo.options = LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
     creationInfo.port = CONTEXT_PORT_NO_LISTEN;

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -201,10 +201,10 @@ STATUS freeSignaling(PSignalingClient* ppSignalingClient)
     terminateOngoingOperations(pSignalingClient, TRUE);
 
     if (pSignalingClient->pLwsContext != NULL) {
-        MUTEX_LOCK(pSignalingClient->lwsSerializerLock);
+        MUTEX_LOCK(pSignalingClient->lwsServiceLock);
         lws_context_destroy(pSignalingClient->pLwsContext);
         pSignalingClient->pLwsContext = NULL;
-        MUTEX_UNLOCK(pSignalingClient->lwsSerializerLock);
+        MUTEX_UNLOCK(pSignalingClient->lwsServiceLock);
     }
 
     freeStateMachine(pSignalingClient->pStateMachine);

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -174,6 +174,9 @@ typedef struct {
     // Indicate whether the ICE configuration has been retrieved at least once
     volatile ATOMIC_BOOL iceConfigRetrieved;
 
+    // Indicates that there is another thread attempting to grab the service lock
+    volatile ATOMIC_BOOL serviceLockContention;
+
     // Current version of the structure
     UINT32 version;
 

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -50,6 +50,9 @@ extern "C" {
 // Async ICE config refresh delay in case if the signaling is not yet in READY state
 #define SIGNALING_ASYNC_ICE_CONFIG_REFRESH_DELAY (50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
+// Max libWebSockets protocol count. IMPORTANT: Ensure it's 1 + PROTOCOL_INDEX_WSS
+#define LWS_PROTOCOL_COUNT 2
+
 // API call latency calculation
 #define SIGNALING_API_LATENCY_CALCULATION(pClient, time, isCpApi)                                                                                    \
     MUTEX_LOCK((pClient)->diagnosticsLock);                                                                                                          \
@@ -249,8 +252,11 @@ typedef struct {
     // LWS context to use for Restful API
     struct lws_context* pLwsContext;
 
-    // Signaling protocols
-    struct lws_protocols signalingProtocols[3];
+    // Signaling protocols - one more for the NULL terminator protocol
+    struct lws_protocols signalingProtocols[LWS_PROTOCOL_COUNT + 1];
+
+    // Stored wsi objects
+    struct lws* currentWsi[LWS_PROTOCOL_COUNT];
 
     // List of the ongoing messages
     PStackQueue pMessageQueue;


### PR DESCRIPTION
… interlocking it will lead to live locks.

LibWebSockets assumes a single threaded execution. While we are connected to websocket we need to run ICE server info refresh which requires interlacing a few of the API calls with the callbacks.
This leaves us with two choices - either disconnect from the connected websocket when we do ICE refresh and reconnect it once that's done or to spin up two separate contexts. The first solution is more straight forward but at the expense of potentially losing a message (if it falls out of TTL) or having high latency when viewers are connecting. The dual context solution is bad because it doesn't scale down to small footprint devices. So we decided to use the same context to drive synchronous in-flight requests.
The interlocking is not a trivial thing to have as it leads to live-locks in case where the service thread is blocked on a socket and has the lock and there is no way to wake it up as the wake up API itself would require a lock. The problem is more exacerbated by the fact that we could have multiple entities in-flight - connection listener, ICE refresh and the reconnect thread and they need to be carefully coordinated and interlocked during the negative cases and teardown.

The solution here is to store the WSI when connecting in an interlocked fashion which uses a separate serialization lock and not the service lock to avoid live locking. While acquiring the lock, we try to ackquire it and if we fail, that means another thread is locked (for example the listener thread servicing a websocket while we are executing ICE refresh). As the holder can be blocked on the socket, we need to "wake it up" without having the lock held. Apparently, there are only TWO APIs that can do that. From https://libwebsockets.org/lws-api-doc-master/html/md_READMEs_README_8coding.html

<
Therefore the two apis mentioned above that may be used from another thread are

For LWS using the default poll() event loop, lws_callback_on_writable()
For LWS using libuv/libev/libevent event loop, lws_cancel_service()
>

Issue #870 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
