### PR TITLE
Enable compiler warning on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
         # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
         - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
       before_script:
-        - mkdir build && cd build && cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
+        - mkdir build && cd build && cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
       after_success:
         - for test_file in $(find CMakeFiles/kvsWebrtcClient.dir CMakeFiles/kvsWebrtcSignalingClient.dir -name '*.gcno'); do gcov $test_file; done
         - bash <(curl -s https://codecov.io/bash)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,8 +342,8 @@ if (WIN32)
 endif()
 
 if(COMPILER_WARNINGS)
-  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)
-  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -Wextra -Wno-error=unused-function -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -Wextra -Wno-error=unused-function -Wno-unknown-warning-option)
 endif()
 
 install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enable compiler warning on Linux. This was removed at some point of time, but, we should have this enabled and reported as errors to catch any serious warnings. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
