### PR TITLE
Generate pc file for libsrtp

### DIFF
--- a/CMake/Dependencies/libsrtp-CMakeLists.txt
+++ b/CMake/Dependencies/libsrtp-CMakeLists.txt
@@ -2,17 +2,47 @@ cmake_minimum_required(VERSION 2.8)
 
 project(libsrtp-download NONE)
 
+
+SET(CONFIGURE_COMMAND "")
+
+# There is known bug in libsrtp where cross compiling using configure on ARM fails. Do not
+# enable this option if cross compilng on ARM
+# Check https://github.com/cisco/libsrtp/pull/496
+if(BUILD_LIBSRTP_DESTINATION_PLATFORM STREQUAL BUILD_LIBSRTP_HOST_PLATFORM)
+  if(UNIX OR APPLE)
+    if(USE_OPENSSL)
+      SET(CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libsrtp/configure "CFLAGS=${CMAKE_C_FLAGS}" --prefix=${OPEN_SRC_INSTALL_PREFIX}  --enable-openssl --with-openssl-dir=${OPENSSL_DIR})
+    else()
+      SET(CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libsrtp/configure "CFLAGS=${CMAKE_C_FLAGS}" --prefix=${OPEN_SRC_INSTALL_PREFIX})
+    endif()
+
+    if (DEFINED BUILD_LIBSRTP_DESTINATION_PLATFORM AND NOT BUILD_LIBSRTP_DESTINATION_PLATFORM STREQUAL OFF)
+      set(CONFIGURE_COMMAND ${CONFIGURE_COMMAND} --host=${BUILD_LIBSRTP_DESTINATION_PLATFORM})
+    endif()
+
+    if (DEFINED BUILD_LIBSRTP_HOST_PLATFORM AND NOT BUILD_LIBSRTP_HOST_PLATFORM STREQUAL OFF)
+      set(CONFIGURE_COMMAND ${CONFIGURE_COMMAND} --build=${BUILD_LIBSRTP_HOST_PLATFORM})
+    endif()
+
+    if (DEFINED CMAKE_OSX_SYSROOT AND NOT CMAKE_OSX_SYSROOT STREQUAL "")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isysroot${CMAKE_OSX_SYSROOT}")
+    endif()
+  endif()
+endif()
+
 if (BUILD_STATIC_LIBS OR WIN32)
   set(LIBSRTP_SHARED_LIBS OFF)
 else()
   set(LIBSRTP_SHARED_LIBS ON)
 endif()
 
+
 if (USE_OPENSSL)
   set(LIBSRTP_ENABLE_OPENSSL ON)
 else()
   set(LIBSRTP_ENABLE_OPENSSL OFF)
 endif()
+
 
 include(ExternalProject)
 ExternalProject_Add(project_libsrtp
@@ -24,4 +54,6 @@ ExternalProject_Add(project_libsrtp
                       -D ENABLE_OPENSSL=${LIBSRTP_ENABLE_OPENSSL}
                       -D BUILD_SHARED_LIBS=${LIBSRTP_SHARED_LIBS}
                       -D OPENSSL_ROOT_DIR=${OPEN_SRC_INSTALL_PREFIX}
+    CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
+    TEST_COMMAND      ""
 )


### PR DESCRIPTION
*Issue #, if available:*
 #538 

*Description of changes:*

This PR generates a PC file for unix and apple platforms by running `configure`.
There is a known issue in libsrtp2.3.0 which leads to `./configure` to fail when cross compiling for ARM platforms with the error: 

```checking if OPENSSL_cleanse is broken... configure: error: in .....
configure: error: cannot run test program while cross compiling
```

SRTP Issue reference: `https://github.com/cisco/libsrtp/issues/479`

As a workaround, this PR checks if `BUILD_LIBSRTP_HOST_PLATFORM == BUILD_LIBSRTP_DESTINATION_PLATFORM` to ensure `./configure` is run only in non cross compile mode. This check can be removed once we can update libsrtp with the fix in the libsrtp repo. There is no timeline on that yet. 

We can also move to 2.2.0 but there might be some fixes in 2.3.0 which we might lose, which is not ideal.

Resolves  #538 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
