### PR TITLE
Fix unsent ice candidates in trickle mode viewer

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -398,7 +398,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
 
     pSampleStreamingSession->pSampleConfiguration = pSampleConfiguration;
     pSampleStreamingSession->rtcMetricsHistory.prevTs = GETTIME();
-    pSampleStreamingSession->remoteCanTrickleIce = FALSE;
+    // if we're the viewer, we control the trickle ice mode
+    pSampleStreamingSession->remoteCanTrickleIce = !isMaster && pSampleConfiguration->trickleIce;
 
     ATOMIC_STORE_BOOL(&pSampleStreamingSession->terminateFlag, FALSE);
     ATOMIC_STORE_BOOL(&pSampleStreamingSession->candidateGatheringDone, FALSE);


### PR DESCRIPTION
Since the remoteCanTrickleIce is disabled for the viewer, the remote ice candidates that we retrieve from the STUN server is never sent to the other peer. From the other peer's perspective, there's no remote candidate, and, thus, no candidate was ever formed.

Related Issues:
* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/886
* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/850
* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/884

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
