### PR TITLE
Fix overflow RTP timestamp calculation

### DIFF
--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -77,7 +77,7 @@ STATUS freeKvsRtpTransceiver(PKvsRtpTransceiver*);
 
 STATUS kvsRtpTransceiverSetJitterBuffer(PKvsRtpTransceiver, PJitterBuffer);
 
-#define CONVERT_TIMESTAMP_TO_RTP(clockRate, pts) (pts * clockRate / HUNDREDS_OF_NANOS_IN_A_SECOND)
+#define CONVERT_TIMESTAMP_TO_RTP(clockRate, pts) ((UINT64)((DOUBLE) pts * ((DOUBLE) clockRate / HUNDREDS_OF_NANOS_IN_A_SECOND)))
 
 STATUS writeRtpPacket(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPacket);
 

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -153,6 +153,13 @@ a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
     EXPECT_STREQ(fmtpForPayloadType(25, &sessionDescription), NULL);
 }
 
+TEST_F(PeerConnectionApiTest, CONVERT_TIMESTAMP_TO_RTP_BigTimestamp)
+{
+    UINT64 timestamp = 16034753564030000;
+    UINT64 rtpTimestamp = CONVERT_TIMESTAMP_TO_RTP(VIDEO_CLOCKRATE, timestamp);
+    EXPECT_EQ(144312782076270, rtpTimestamp);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
Resolves https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/894

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
