### PR TITLE
Add Dtls encrypt and decrypt benchmarks

### DIFF
--- a/CMake/Dependencies/libbenchmark-CMakeLists.txt
+++ b/CMake/Dependencies/libbenchmark-CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(libbenchmark-download NONE)
+
+include(ExternalProject)
+
+ExternalProject_Add(
+  project_libbenchmark
+  GIT_REPOSITORY  https://github.com/google/benchmark
+  GIT_TAG         v1.5.1
+  PREFIX          ${CMAKE_CURRENT_BINARY_DIR}/build
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
+    -DCMAKE_BUILD_TYPE=Release
+    -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
+  BUILD_ALWAYS    TRUE
+  TEST_COMMAND    "")

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -2,6 +2,7 @@
 function(build_dependency lib_name)
   set(supported_libs
       gtest
+      benchmark
       jsmn
       openssl
       srtp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(ENABLE_DATA_CHANNEL "Enable support for data channel" ON)
 
 # Developer Flags
 option(BUILD_TEST "Build the testing tree." OFF)
+option(BUILD_BENCHMARK "Build the benchmark tree." OFF)
 option(CODE_COVERAGE "Enable coverage reporting" OFF)
 option(COMPILER_WARNINGS "Enable all compiler warnings." OFF)
 option(ADDRESS_SANITIZER "Build with AddressSanitizer." OFF)
@@ -118,7 +119,11 @@ if(BUILD_DEPENDENCIES)
 
   build_dependency(usrsctp)
   if(BUILD_TEST)
-   build_dependency(gtest)
+    build_dependency(gtest)
+  endif()
+
+  if(BUILD_BENCHMARK)
+    build_dependency(benchmark)
   endif()
 
   # building kvsCommonLws also builds kvspic
@@ -357,4 +362,8 @@ endif()
 
 if(BUILD_TEST)
   add_subdirectory(tst)
+endif()
+
+if(BUILD_BENCHMARK)
+  add_subdirectory(bench)
 endif()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 2.8)
+
+project (WebRTCClientBenchmark)
+
+set(CMAKE_CXX_STANDARD 11)
+set(KINESIS_VIDEO_WebRTCClient_SRC "${CMAKE_CURRENT_SOURCE_DIR}/..")
+
+if (OPEN_SRC_INSTALL_PREFIX)
+  find_package(benchmark REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+else()
+  find_package(benchmark REQUIRED)
+endif()
+
+include_directories(${KINESIS_VIDEO_WebRTCClient_SRC})
+
+file(GLOB WEBRTC_CLIENT_BENCHMARK_SOURCE_FILES "*.cpp" )
+
+add_executable(webrtc_client_benchmark ${WEBRTC_CLIENT_BENCHMARK_SOURCE_FILES})
+target_link_libraries(webrtc_client_benchmark
+    kvsWebrtcClient
+    kvsWebrtcSignalingClient
+    kvspicUtils
+    benchmark::benchmark)

--- a/bench/DtlsBenchmark.cpp
+++ b/bench/DtlsBenchmark.cpp
@@ -1,0 +1,181 @@
+#include "WebRTCClientBenchmarkFixture.h"
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+class DtlsBenchmark : public WebRtcClientBenchmarkBase {
+  public:
+    STATUS createAndConnect(TIMER_QUEUE_HANDLE timerQueueHandle, PDtlsSession* ppClient, PDtlsSession* ppServer)
+    {
+        struct Context {
+            std::mutex mtx;
+            std::queue<std::vector<BYTE>> queue;
+        };
+        STATUS retStatus = STATUS_SUCCESS;
+        DtlsSessionCallbacks callbacks;
+        SIZE_T connectedCount = 0;
+        PDtlsSession pClient = NULL, pServer = NULL;
+        UINT64 sleepDelay = 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        Context clientCtx, serverCtx;
+
+        MEMSET(&callbacks, 0, SIZEOF(callbacks));
+        callbacks.stateChangeFn = [](UINT64 customData, RTC_DTLS_TRANSPORT_STATE state) {
+            if (state == CONNECTED) {
+                ATOMIC_INCREMENT((PSIZE_T) customData);
+            }
+        };
+        callbacks.stateChangeFnCustomData = (UINT64) &connectedCount;
+
+        DtlsSessionOutboundPacketFunc outboundPacketFn = [](UINT64 customData, PBYTE pData, UINT32 dataLen) {
+            Context* pCtx = (Context*) customData;
+            assert(pCtx != NULL);
+            assert(pData != NULL);
+            pCtx->mtx.lock();
+            pCtx->queue.push(std::vector<BYTE>(pData, pData + dataLen));
+            pCtx->mtx.unlock();
+        };
+
+        auto consumeMessages = [](Context* pCtx, PDtlsSession pPeer) -> STATUS {
+            STATUS retStatus = STATUS_SUCCESS;
+            assert(pCtx != NULL);
+            assert(pPeer != NULL);
+
+            pCtx->mtx.lock();
+            std::queue<std::vector<BYTE>> pendingMessages;
+            pCtx->queue.swap(pendingMessages);
+            pCtx->mtx.unlock();
+
+            while (!pendingMessages.empty()) {
+                auto& msg = pendingMessages.front();
+                auto readLen = (INT32) msg.size();
+                CHK_STATUS(dtlsSessionProcessPacket(pPeer, (PBYTE) &msg.front(), &readLen));
+                pendingMessages.pop();
+            }
+
+        CleanUp:
+
+            return retStatus;
+        };
+
+        CHK_STATUS(createDtlsSession(&callbacks, timerQueueHandle, 0, FALSE, NULL, &pServer));
+        CHK_STATUS(createDtlsSession(&callbacks, timerQueueHandle, 0, FALSE, NULL, &pClient));
+
+        CHK_STATUS(dtlsSessionOnOutBoundData(pServer, (UINT64) &clientCtx, outboundPacketFn));
+        CHK_STATUS(dtlsSessionOnOutBoundData(pClient, (UINT64) &serverCtx, outboundPacketFn));
+
+        CHK_STATUS(dtlsSessionStart(pServer, FALSE));
+        CHK_STATUS(dtlsSessionStart(pClient, TRUE));
+
+        for (UINT64 duration = 0; duration < MAX_BENCHMARK_AWAIT_DURATION && ATOMIC_LOAD(&connectedCount) != 2; duration += sleepDelay) {
+            CHK_STATUS(consumeMessages(&serverCtx, pServer));
+            CHK_STATUS(consumeMessages(&clientCtx, pClient));
+            THREAD_SLEEP(sleepDelay);
+        }
+
+        CHK_ERR(ATOMIC_LOAD(&connectedCount) == 2, STATUS_OPERATION_TIMED_OUT, "timeout: failed to finish initial handshake");
+
+        *ppClient = pClient;
+        *ppServer = pServer;
+
+    CleanUp:
+
+        if (STATUS_FAILED(retStatus)) {
+            if (pClient != NULL) {
+                freeDtlsSession(&pClient);
+            }
+
+            if (pServer != NULL) {
+                freeDtlsSession(&pServer);
+            }
+        }
+
+        return STATUS_SUCCESS;
+    }
+};
+
+VOID outboundPacketFnNoop(UINT64 customData, PBYTE pData, UINT32 dataLen)
+{
+    UNUSED_PARAM(customData);
+    UNUSED_PARAM(pData);
+    UNUSED_PARAM(dataLen);
+}
+
+BENCHMARK_DEFINE_F(DtlsBenchmark, BM_DtlsEncrypt)(benchmark::State& state)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PDtlsSession pClient = NULL, pServer = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    INT32 dataSize = state.range(0);
+    PBYTE data = (PBYTE) MEMALLOC(dataSize);
+
+    CHK(data != NULL, STATUS_NOT_ENOUGH_MEMORY);
+    MEMSET(data, 0x11, dataSize);
+    CHK_STATUS(timerQueueCreate(&timerQueueHandle));
+    CHK_STATUS(createAndConnect(timerQueueHandle, &pClient, &pServer));
+
+    CHK_STATUS(dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
+    CHK_STATUS(dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
+
+    for (auto _ : state) {
+        CHK_STATUS(dtlsSessionPutApplicationData(pClient, data, dataSize));
+    }
+    state.SetBytesProcessed((INT64) state.iterations() * dataSize);
+
+CleanUp:
+
+    if (STATUS_FAILED(retStatus)) {
+        DLOGE("Dtls benchmark failed with 0x%08x", retStatus);
+    }
+
+    freeDtlsSession(&pClient);
+    freeDtlsSession(&pServer);
+    timerQueueFree(&timerQueueHandle);
+    MEMFREE(data);
+}
+
+BENCHMARK_DEFINE_F(DtlsBenchmark, BM_DtlsDecrypt)(benchmark::State& state)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PDtlsSession pClient = NULL, pServer = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    INT32 dataSize = state.range(0);
+    PBYTE data = (PBYTE) MEMALLOC(dataSize);
+    INT32 readDataSize;
+
+    CHK(data != NULL, STATUS_NOT_ENOUGH_MEMORY);
+    MEMSET(data, 0x11, dataSize);
+    CHK_STATUS(timerQueueCreate(&timerQueueHandle));
+    CHK_STATUS(createAndConnect(timerQueueHandle, &pClient, &pServer));
+
+    CHK_STATUS(dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
+    CHK_STATUS(dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
+
+    for (auto _ : state) {
+        readDataSize = dataSize;
+        CHK_STATUS(dtlsSessionProcessPacket(pServer, data, &readDataSize));
+    }
+    state.SetBytesProcessed((INT64) state.iterations() * dataSize);
+
+CleanUp:
+
+    if (STATUS_FAILED(retStatus)) {
+        DLOGE("Dtls benchmark failed with 0x%08x", retStatus);
+    }
+
+    freeDtlsSession(&pClient);
+    freeDtlsSession(&pServer);
+    timerQueueFree(&timerQueueHandle);
+    MEMFREE(data);
+}
+
+BENCHMARK_REGISTER_F(DtlsBenchmark, BM_DtlsEncrypt)->Range(8, 8 << 10);
+BENCHMARK_REGISTER_F(DtlsBenchmark, BM_DtlsDecrypt)->Range(8, 8 << 10);
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/bench/WebRTCClientBenchmarkFixture.cpp
+++ b/bench/WebRTCClientBenchmarkFixture.cpp
@@ -1,0 +1,26 @@
+#include "WebRTCClientBenchmarkFixture.h"
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+VOID WebRtcClientBenchmarkBase::SetUp(const ::benchmark::State& state)
+{
+    UNUSED_PARAM(state);
+    SET_LOGGER_LOG_LEVEL(LOG_LEVEL_WARN);
+    initKvsWebRtc();
+}
+
+VOID WebRtcClientBenchmarkBase::TearDown(const ::benchmark::State& state)
+{
+    UNUSED_PARAM(state);
+    deinitKvsWebRtc();
+}
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/bench/WebRTCClientBenchmarkFixture.h
+++ b/bench/WebRTCClientBenchmarkFixture.h
@@ -1,0 +1,26 @@
+#include <benchmark/benchmark.h>
+#include "../src/source/Include_i.h"
+#include <thread>
+#include <mutex>
+#include <queue>
+#include <atomic>
+
+#define MAX_BENCHMARK_AWAIT_DURATION (2 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+class WebRtcClientBenchmarkBase : public benchmark::Fixture {
+  protected:
+    virtual VOID SetUp(const ::benchmark::State& state);
+    virtual VOID TearDown(const ::benchmark::State& state);
+};
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,0 +1,3 @@
+#include "benchmark/benchmark.h"
+
+BENCHMARK_MAIN();

--- a/src/source/Crypto/Dtls.c
+++ b/src/source/Crypto/Dtls.c
@@ -37,7 +37,7 @@ STATUS dtlsValidateRtcCertificates(PRtcCertificate pRtcCertificates, PUINT32 pCo
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT32 i;
+    UINT32 i = 0;
 
     CHK(pRtcCertificates != NULL && pCount != NULL, retStatus);
 
@@ -45,9 +45,12 @@ STATUS dtlsValidateRtcCertificates(PRtcCertificate pRtcCertificates, PUINT32 pCo
         CHK(pRtcCertificates[i].privateKeySize == 0 || pRtcCertificates[i].pPrivateKey != NULL, STATUS_SSL_INVALID_CERTIFICATE_BITS);
     }
 
-    *pCount = i;
-
 CleanUp:
+
+    // If pRtcCertificates is NULL, default pCount to 0
+    if (pCount != NULL) {
+        *pCount = i;
+    }
 
     LEAVES();
     return retStatus;

--- a/src/source/Crypto/Tls_mbedtls.c
+++ b/src/source/Crypto/Tls_mbedtls.c
@@ -222,7 +222,6 @@ CleanUp:
 STATUS tlsSessionShutdown(PTlsSession pTlsSession)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    INT32 sslRet;
 
     CHK(pTlsSession != NULL, STATUS_NULL_ARG);
     CHK(pTlsSession->state != TLS_SESSION_STATE_CLOSED, retStatus);

--- a/tst/DtlsFunctionalityTest.cpp
+++ b/tst/DtlsFunctionalityTest.cpp
@@ -1,0 +1,174 @@
+#include "WebRTCClientTestFixture.h"
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+class DtlsFunctionalityTest : public WebRtcClientTestBase {
+  public:
+    STATUS createAndConnect(TIMER_QUEUE_HANDLE timerQueueHandle, PDtlsSession* ppClient, PDtlsSession* ppServer)
+    {
+        struct Context {
+            std::mutex mtx;
+            std::queue<std::vector<BYTE>> queue;
+        };
+        STATUS retStatus = STATUS_SUCCESS;
+        DtlsSessionCallbacks callbacks;
+        SIZE_T connectedCount = 0;
+        PDtlsSession pClient = NULL, pServer = NULL;
+        UINT64 sleepDelay = 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        Context clientCtx, serverCtx;
+
+        MEMSET(&callbacks, 0, SIZEOF(callbacks));
+        callbacks.stateChangeFn = [](UINT64 customData, RTC_DTLS_TRANSPORT_STATE state) {
+            if (state == CONNECTED) {
+                ATOMIC_INCREMENT((PSIZE_T) customData);
+            }
+        };
+        callbacks.stateChangeFnCustomData = (UINT64) &connectedCount;
+
+        DtlsSessionOutboundPacketFunc outboundPacketFn = [](UINT64 customData, PBYTE pData, UINT32 dataLen) {
+            Context* pCtx = (Context*) customData;
+            // since we're not in google test block, we can't use ASSERT_TRUE
+            assert(pCtx != NULL);
+            assert(pData != NULL);
+            pCtx->mtx.lock();
+            pCtx->queue.push(std::vector<BYTE>(pData, pData + dataLen));
+            pCtx->mtx.unlock();
+        };
+
+        auto consumeMessages = [](Context* pCtx, PDtlsSession pPeer) -> STATUS {
+            STATUS retStatus = STATUS_SUCCESS;
+            // since we're not in google test block, we can't use ASSERT_TRUE
+            assert(pCtx != NULL);
+            assert(pPeer != NULL);
+
+            pCtx->mtx.lock();
+            std::queue<std::vector<BYTE>> pendingMessages;
+            pCtx->queue.swap(pendingMessages);
+            pCtx->mtx.unlock();
+
+            while (!pendingMessages.empty()) {
+                auto& msg = pendingMessages.front();
+                auto readLen = (INT32) msg.size();
+                CHK_STATUS(dtlsSessionProcessPacket(pPeer, (PBYTE) &msg.front(), &readLen));
+                pendingMessages.pop();
+            }
+
+        CleanUp:
+
+            return retStatus;
+        };
+
+        CHK_STATUS(createDtlsSession(&callbacks, timerQueueHandle, 0, FALSE, NULL, &pServer));
+        CHK_STATUS(createDtlsSession(&callbacks, timerQueueHandle, 0, FALSE, NULL, &pClient));
+
+        CHK_STATUS(dtlsSessionOnOutBoundData(pServer, (UINT64) &clientCtx, outboundPacketFn));
+        CHK_STATUS(dtlsSessionOnOutBoundData(pClient, (UINT64) &serverCtx, outboundPacketFn));
+
+        CHK_STATUS(dtlsSessionStart(pServer, FALSE));
+        CHK_STATUS(dtlsSessionStart(pClient, TRUE));
+
+        for (UINT64 duration = 0; duration < MAX_TEST_AWAIT_DURATION && ATOMIC_LOAD(&connectedCount) != 2; duration += sleepDelay) {
+            CHK_STATUS(consumeMessages(&serverCtx, pServer));
+            CHK_STATUS(consumeMessages(&clientCtx, pClient));
+            THREAD_SLEEP(sleepDelay);
+        }
+
+        CHK_ERR(ATOMIC_LOAD(&connectedCount) == 2, STATUS_OPERATION_TIMED_OUT, "timeout: failed to finish initial handshake");
+
+        *ppClient = pClient;
+        *ppServer = pServer;
+
+    CleanUp:
+
+        if (STATUS_FAILED(retStatus)) {
+            if (pClient != NULL) {
+                freeDtlsSession(&pClient);
+            }
+
+            if (pServer != NULL) {
+                freeDtlsSession(&pServer);
+            }
+        }
+
+        return STATUS_SUCCESS;
+    }
+};
+
+VOID outboundPacketFnNoop(UINT64 customData, PBYTE pData, UINT32 dataLen)
+{
+    UNUSED_PARAM(customData);
+    UNUSED_PARAM(pData);
+    UNUSED_PARAM(dataLen);
+}
+
+TEST_F(DtlsFunctionalityTest, putApplicationDataWithVariedSizes)
+{
+    PDtlsSession pClient = NULL, pServer = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    PBYTE pData = NULL;
+    INT32 dataSizes[] = {
+        4,                      // very small packet
+        DEFAULT_MTU_SIZE - 200, // small packet but should be still under mtu
+        DEFAULT_MTU_SIZE + 200, // big packet and bigger than even a jumbo frame
+    };
+
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer));
+
+    EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
+    EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
+
+    for (int i = 0; i < (INT32) ARRAY_SIZE(dataSizes); i++) {
+        pData = (PBYTE) MEMREALLOC(pData, dataSizes[i]);
+        ASSERT_TRUE(pData != NULL);
+        MEMSET(pData, 0x11, dataSizes[i]);
+        EXPECT_EQ(STATUS_SUCCESS, dtlsSessionPutApplicationData(pClient, pData, dataSizes[i]));
+    }
+
+    freeDtlsSession(&pClient);
+    freeDtlsSession(&pServer);
+    timerQueueFree(&timerQueueHandle);
+    MEMFREE(pData);
+}
+
+TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizes)
+{
+    PDtlsSession pClient = NULL, pServer = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    PBYTE pData = NULL;
+    INT32 dataSizes[] = {
+        4,                      // very small packet
+        DEFAULT_MTU_SIZE - 200, // small packet but should be still under mtu
+        DEFAULT_MTU_SIZE + 200, // big packet and bigger than even a jumbo frame
+    };
+    INT32 readDataSize;
+
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer));
+
+    EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
+    EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
+
+    for (int i = 0; i < (INT32) ARRAY_SIZE(dataSizes); i++) {
+        pData = (PBYTE) MEMREALLOC(pData, dataSizes[i]);
+        readDataSize = dataSizes[i];
+        ASSERT_TRUE(pData != NULL);
+        MEMSET(pData, 0x11, dataSizes[i]);
+        EXPECT_EQ(STATUS_SUCCESS, dtlsSessionProcessPacket(pServer, pData, &readDataSize));
+    }
+
+    freeDtlsSession(&pClient);
+    freeDtlsSession(&pServer);
+    timerQueueFree(&timerQueueHandle);
+    MEMFREE(pData);
+}
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <thread>
 #include <mutex>
+#include <queue>
+#include <atomic>
 
 #define TEST_DEFAULT_REGION                     ((PCHAR) "us-west-2")
 #define TEST_STREAMING_TOKEN_DURATION           (40 * HUNDREDS_OF_NANOS_IN_A_SECOND)
@@ -16,6 +18,7 @@
 #define TEST_ICE_CONFIG_INFO_POLL_PERIOD        (20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 #define TEST_ASYNC_ICE_CONFIG_INFO_WAIT_TIMEOUT (3 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 #define TEST_FILE_CREDENTIALS_FILE_PATH         (PCHAR) "credsFile"
+#define MAX_TEST_AWAIT_DURATION                 (2 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
 namespace com {
 namespace amazonaws {

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -155,6 +155,35 @@ race:generateSignatureDateTime
 #    #3 timerQueueExecutor /usr/src/amazon-kinesis-video-streams-webrtc-sdk-c/open-source/amazon-kinesis-video-streams-pic/src/utils/src/TimerQueue.c:561 (libkvsWebrtcClient.so+0x000000064c61)
 deadlock:dtlsSessionStart
 
+# ==================
+# WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=3774182)
+#   Cycle in lock order graph: M358 (0x7b0c00001088) => M346 (0x7b0c00000f98) => M358
+# 
+#   Mutex M346 acquired here while holding mutex M358 in main thread:
+#     #0 pthread_mutex_lock <null> (webrtc_client_test+0x52d866)
+#     #1 defaultLockMutex /home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/open-source/libkvsCommonLws/build/src/libkvsCommonLws-download/dependency/libkvspic/kvspic-src/src/utils/src/Mutex.c:202:5 (libkvsWebrtcClient.so+0x845e4)
+#     #2 com::amazonaws::kinesis::video::webrtcclient::DtlsFunctionalityTest::createAndConnect(unsigned long, __DtlsSession**, __DtlsSession**) /home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/tst/DtlsFunctionalityTest.cpp:72:9 (webrtc_client_test+0x5c4f7b)
+#     #3 com::amazonaws::kinesis::video::webrtcclient::DtlsFunctionalityTest_processPacketWithVariedSizes_Test::TestBody() /home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/tst/DtlsFunctionalityTest.cpp:151:5 (webrtc_client_test+0x5c41a0)
+#     #4 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (webrtc_client_test+0x785a93)
+#     #5 main /home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/tst/main.cpp:68:14 (webrtc_client_test+0x744825)
+# 
+#     Hint: use TSAN_OPTIONS=second_deadlock_stack=1 to get more informative warning message
+# 
+#   Mutex M358 acquired here while holding mutex M346 in thread T10:
+#     #0 pthread_mutex_lock <null> (webrtc_client_test+0x52d866)
+#     #1 defaultLockMutex /home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/open-source/libkvsCommonLws/build/src/libkvsCommonLws-download/dependency/libkvspic/kvspic-src/src/utils/src/Mutex.c:202:5 (libkvsWebrtcClient.so+0x845e4)
+#     #2 timerQueueExecutor /home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/open-source/libkvsCommonLws/build/src/libkvsCommonLws-download/dependency/libkvspic/kvspic-src/src/utils/src/TimerQueue.c:562:37 (libkvsWebrtcClient.so+0x88388)
+# 
+#   Thread T10 (tid=3774194, running) created by main thread at:
+#     #0 pthread_create <null> (webrtc_client_test+0x51049b)
+#     #1 defaultCreateThread /home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/open-source/libkvsCommonLws/build/src/libkvsCommonLws-download/dependency/libkvspic/kvspic-src/src/utils/src/Thread.c:171:14 (libkvsWebrtcClient.so+0x865a3)
+#     #2 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (webrtc_client_test+0x785a93)
+#     #3 main /home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/tst/main.cpp:68:14 (webrtc_client_test+0x744825)
+# 
+# SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock) (/home/ubuntu/Documents/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c-mbedtls-perf/build/tst/webrtc_client_test+0x52d866) in pthread_mutex_lock
+# ==================
+deadlock:com::amazonaws::kinesis::video::webrtcclient::DtlsFunctionalityTest::createAndConnect
+
 # WARNING: ThreadSanitizer: data race (pid=16168)
 #   Read of size 8 at 0x7f843023d030 by main thread:
 #     #0 freeSctpSession /usr/src/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sctp/Sctp.c:134 (libkvsWebrtcClient.so+0x00000005ebea)


### PR DESCRIPTION
This PR replaces https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/903. For some reasons, Travis doesn't want to run on that PR.

# Changelog

## Add Dtls encrypt and decrypt benchmarks
  * Initiate benchmark tree
  * Add Google benchmark to the dependency list
  * Add USE_BENCHMARK to CMakeList
  * Add Dtls benchmark

## Fix uncaught too large application data in DTLS
  * Breaks apart application data into multiple chunks when they're bigger than the MTU in DTLS
  * When given certificates are NULL, cert count is defaulted to 0
  * dtlsSessionPutApplication now catches error codes
  * Add Dtls functionality tests for putApplicationData and processPacket

# Benchmark Results

## mbedTLS

```
Run on (8 X 2300.26 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 46080 KiB (x1)
Load Average: 0.68, 0.48, 0.39
--------------------------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------
DtlsBenchmark/BM_DtlsEncrypt/8           809 ns          809 ns       864708 bytes_per_second=9.42568M/s
DtlsBenchmark/BM_DtlsEncrypt/64          871 ns          871 ns       802971 bytes_per_second=70.0713M/s
DtlsBenchmark/BM_DtlsEncrypt/512        2966 ns         2966 ns       235678 bytes_per_second=164.647M/s
DtlsBenchmark/BM_DtlsEncrypt/4096      22662 ns        22662 ns        30625 bytes_per_second=172.369M/s
DtlsBenchmark/BM_DtlsEncrypt/8192      43555 ns        43554 ns        15917 bytes_per_second=179.374M/s
DtlsBenchmark/BM_DtlsDecrypt/8          2055 ns         2055 ns       340066 bytes_per_second=3.71175M/s
DtlsBenchmark/BM_DtlsDecrypt/64         2055 ns         2055 ns       339479 bytes_per_second=29.7013M/s
DtlsBenchmark/BM_DtlsDecrypt/512        2076 ns         2076 ns       335501 bytes_per_second=235.149M/s
DtlsBenchmark/BM_DtlsDecrypt/4096       2176 ns         2176 ns       315139 bytes_per_second=1.75296G/s
DtlsBenchmark/BM_DtlsDecrypt/8192       2499 ns         2499 ns       281089 bytes_per_second=3.05296G/s
```

## OpenSSL

```
Run on (8 X 2300.26 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 46080 KiB (x1)
Load Average: 0.23, 0.54, 0.40
--------------------------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------
DtlsBenchmark/BM_DtlsEncrypt/8           380 ns          380 ns      1831531 bytes_per_second=20.0797M/s
DtlsBenchmark/BM_DtlsEncrypt/64          414 ns          414 ns      1700009 bytes_per_second=147.531M/s
DtlsBenchmark/BM_DtlsEncrypt/512         649 ns          648 ns      1069451 bytes_per_second=752.955M/s
DtlsBenchmark/BM_DtlsEncrypt/4096       2413 ns         2413 ns       295161 bytes_per_second=1.5812G/s
DtlsBenchmark/BM_DtlsEncrypt/8192       4513 ns         4513 ns       155526 bytes_per_second=1.69049G/s
DtlsBenchmark/BM_DtlsDecrypt/8           262 ns          262 ns      2682502 bytes_per_second=29.1663M/s
DtlsBenchmark/BM_DtlsDecrypt/64          368 ns          368 ns      1947016 bytes_per_second=165.815M/s
DtlsBenchmark/BM_DtlsDecrypt/512        1581 ns         1581 ns       449202 bytes_per_second=308.898M/s
DtlsBenchmark/BM_DtlsDecrypt/4096      20053 ns        20053 ns        31790 bytes_per_second=194.792M/s
DtlsBenchmark/BM_DtlsDecrypt/8192      75407 ns        75403 ns         9358 bytes_per_second=103.61M/s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
