### PR TITLE
Add LINK_PROFILER CMake option to enable profiler

### DIFF
--- a/CMake/Dependencies/libgperftools-CMakeLists.txt
+++ b/CMake/Dependencies/libgperftools-CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(libgperftools-download NONE)
+
+set(CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libgperftools/configure --prefix=${OPEN_SRC_INSTALL_PREFIX})
+
+include(ExternalProject)
+ExternalProject_Add(project_libgperftools
+    URL               https://github.com/gperftools/gperftools/releases/download/gperftools-2.8/gperftools-2.8.zip
+    PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
+    CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
+    TEST_COMMAND      ""
+)

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -1,6 +1,7 @@
 # build library from source
 function(build_dependency lib_name)
   set(supported_libs
+      gperftools
       gtest
       jsmn
       openssl
@@ -22,6 +23,8 @@ function(build_dependency lib_name)
     set(lib_file_name ssl)
   elseif(${lib_name} STREQUAL "srtp")
     set(lib_file_name srtp2)
+  elseif(${lib_name} STREQUAL "gperftools")
+    set(lib_file_name profiler)
   endif()
   set(library_found NOTFOUND)
   find_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(ADDRESS_SANITIZER "Build with AddressSanitizer." OFF)
 option(MEMORY_SANITIZER "Build with MemorySanitizer." OFF)
 option(THREAD_SANITIZER "Build with ThreadSanitizer." OFF)
 option(UNDEFINED_BEHAVIOR_SANITIZER "Build with UndefinedBehaviorSanitizer." OFF)
+option(LINK_PROFILER "Link gperftools profiler" OFF) 
 
 if(NOT WIN32)
 CHECK_INCLUDE_FILES(ifaddrs.h       KVSWEBRTC_HAVE_IFADDRS_H)
@@ -121,6 +122,10 @@ if(BUILD_DEPENDENCIES)
    build_dependency(gtest)
   endif()
 
+  if (LINK_PROFILER)
+    build_dependency(gperftools)
+  endif()
+
   # building kvsCommonLws also builds kvspic
   set(BUILD_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -145,8 +150,17 @@ endif()
 
 if (OPEN_SRC_INSTALL_PREFIX)
   find_library(SRTP_LIBRARIES srtp2 REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+
+  if (LINK_PROFILER)
+    find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+    find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+  endif()
 else()
   find_library(SRTP_LIBRARIES srtp2 REQUIRED )
+  if (LINK_PROFILER)
+    find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED)
+    find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED)
+  endif()
 endif()
 
 if (WIN32)
@@ -281,6 +295,8 @@ target_link_libraries(
           ${SRTP_LIBRARIES}
           ${Usrsctp}
           ${MBEDTLS_LIBRARIES}
+          ${GPERFTOOLS_MALLOC_LIBRARIES}
+          ${GPERFTOOLS_PROFILER_LIBRARIES}
           ${EXTRA_DEPS})
 
 add_library(kvsWebrtcSignalingClient ${LINKAGE} ${WEBRTC_SIGNALING_CLIENT_SOURCE_FILES})
@@ -296,6 +312,8 @@ target_link_libraries(
          ${EXTRA_DEPS}
          ${OPENSSL_SSL_LIBRARY}
          ${OPENSSL_CRYPTO_LIBRARY}
+         ${GPERFTOOLS_MALLOC_LIBRARIES}
+         ${GPERFTOOLS_PROFILER_LIBRARIES}
          ${MBEDTLS_LIBRARIES})
 
 if (WIN32)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ You can pass the following options to `cmake ..`.
 * `-DADDRESS_SANITIZER` -- Build with AddressSanitizer
 * `-DMEMORY_SANITIZER` --  Build with MemorySanitizer
 * `-DTHREAD_SANITIZER` -- Build with ThreadSanitizer
-* `-DUNDEFINED_BEHAVIOR_SANITIZER` Build with UndefinedBehaviorSanitizer`
+* `-DUNDEFINED_BEHAVIOR_SANITIZER` -- Build with UndefinedBehaviorSanitizer
+* `-DLINK_PROFILER` -- Link with gperftools (available profiler options are listed [here](https://github.com/gperftools/gperftools))
 
 ### Build
 To build the library and the provided samples run make in the build directory you executed CMake.
@@ -242,6 +243,28 @@ You can also change settings such as buffer size, number of log files for rotati
 ## Clang Checks
 This SDK has clang format checks enforced in builds. In order to avoid re-iterating and make sure your code
 complies, use the `check-clang.sh` to check for compliance and `clang-format.sh` to ensure compliance.
+
+## Tracing high memory and/or cpu usage
+If you would like to specifically find the code path that causes high memory and/or cpu usage, you need to recompile the SDK with this command:
+`cmake .. -DENABLE_PROFILE=ON`
+
+The flag will link the SDK with [gperftools](https://github.com/gperftools/gperftools) profiler.
+
+### Heap Profile
+
+You can run your program as you normally would. You only need to specify the following environment variable to get the heap profile:
+
+`HEAPPROFILE=/tmp/heap.prof /path/to/your/binary`
+
+More information about what environment variables you can configure can be found [here](https://gperftools.github.io/gperftools/heapprofile.html)
+
+### CPU Profile
+
+Similar to the heap profile, you only need to specify the following environment variable to get the CPU profile:
+
+`CPUPROFILE=/tmp/cpu.prof /path/to/your/binary`
+
+More information about what environment variables you can configure can be found [here](https://gperftools.github.io/gperftools/cpuprofile.html)
 
 ## Documentation
 All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.


### PR DESCRIPTION
After linking gperftools with ENABLE_PROFILER, CPU profile can be retrieved from specifying CPUPROFILE environment variable, and heap profile can be retrieved from specifying HEAPPROFILE environment variable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
