### PR TITLE
Fix incorrect RTP timestamp in RTCP SR

### DIFF
--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -77,7 +77,7 @@ STATUS freeKvsRtpTransceiver(PKvsRtpTransceiver*);
 
 STATUS kvsRtpTransceiverSetJitterBuffer(PKvsRtpTransceiver, PJitterBuffer);
 
-#define CONVERT_TIMESTAMP_TO_RTP(clockRate, pts) ((UINT64)((DOUBLE) pts * ((DOUBLE) clockRate / HUNDREDS_OF_NANOS_IN_A_SECOND)))
+#define CONVERT_TIMESTAMP_TO_RTP(clockRate, pts) ((UINT64)((DOUBLE)(pts) * ((DOUBLE)(clockRate) / HUNDREDS_OF_NANOS_IN_A_SECOND)))
 
 STATUS writeRtpPacket(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPacket);
 

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -160,6 +160,15 @@ TEST_F(PeerConnectionApiTest, CONVERT_TIMESTAMP_TO_RTP_BigTimestamp)
     EXPECT_EQ(144312782076270, rtpTimestamp);
 }
 
+TEST_F(PeerConnectionApiTest, CONVERT_TIMESTAMP_TO_RTP_MacroWithMathOperations)
+{
+    UINT64 rtpTimestamp = CONVERT_TIMESTAMP_TO_RTP(40000 + 50000, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(90000, rtpTimestamp);
+
+    rtpTimestamp = CONVERT_TIMESTAMP_TO_RTP(90000, HUNDREDS_OF_NANOS_IN_A_SECOND + HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(180000, rtpTimestamp);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
In sending RTCP SR packets, we calculate the RTP timestamp using the relative wall clock from the first frame:

https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/fddf4635e73c04044c01ed31e8b3748d355c5d5a/src/source/PeerConnection/PeerConnection.c#L602

However, this calculation becomes an error since the CONVERT_TIMESTAMP_TO_RTP doesn't have parentheses around pts and clockrate. The above calculation becomes:

Actual:
```
currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime * clockRate / HUNDREDS_OF_NANOS_IN_A_SECOND
```

Expected:
```
(currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime) * clockRate / HUNDREDS_OF_NANOS_IN_A_SECOND
```

Changes:
  * Add unit test CONVERT_TIMESTAMP_TO_RTP with math operations
  * Add parentheses in CONVERT_TIMESTAMP_TO_RTP parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
