### PR TITLE
Enable build parallelism for openssl via the CMAKE_BUILD_PARALLEL_LEVEL env variable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ doc/
 open-source/
 outputs
 tags
+CMakeLists.txt.user

--- a/CMake/Dependencies/libmbedtls-CMakeLists.txt
+++ b/CMake/Dependencies/libmbedtls-CMakeLists.txt
@@ -30,6 +30,6 @@ ExternalProject_Add(
     -DENABLE_TESTING=OFF
     -DENABLE_PROGRAMS=OFF
     -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-  BUILD_COMMAND   make -j4
+  BUILD_COMMAND   ${CMAKE_COMMAND} --build . --parallel
   BUILD_ALWAYS    TRUE
   TEST_COMMAND    "")

--- a/CMake/Dependencies/libmbedtls-CMakeLists.txt
+++ b/CMake/Dependencies/libmbedtls-CMakeLists.txt
@@ -30,6 +30,5 @@ ExternalProject_Add(
     -DENABLE_TESTING=OFF
     -DENABLE_PROGRAMS=OFF
     -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-  BUILD_COMMAND   ${CMAKE_COMMAND} --build . --parallel
   BUILD_ALWAYS    TRUE
   TEST_COMMAND    "")

--- a/CMake/Dependencies/libopenssl-CMakeLists.txt
+++ b/CMake/Dependencies/libopenssl-CMakeLists.txt
@@ -7,6 +7,11 @@ if (WIN32)
   SET(CONFIGURE_COMMAND perl ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libopenssl/Configure VC-WIN64A no-asm --prefix=${OPEN_SRC_INSTALL_PREFIX} --openssldir=${OPEN_SRC_INSTALL_PREFIX})
 else()
   find_program(MAKE_EXE NAMES make)
+  # OpenSSL takes a while to compile, so allow some parallelism.
+  if (DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})
+    list(APPEND MAKE_EXE "-j$ENV{CMAKE_BUILD_PARALLEL_LEVEL}")
+  endif()
+
   if (BUILD_STATIC_LIBS)
     SET(OPENSSL_EXTRA ${OPENSSL_EXTRA} no-shared no-dso)
   endif()

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -44,14 +44,6 @@ function(build_dependency lib_name)
 
   file(REMOVE_RECURSE ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
 
-  # CMake 3.12 and higher support the --parallel build flag.
-  # https://cmake.org/cmake/help/latest/release/3.12.html
-  if(${CMAKE_VERSION} VERSION_LESS "3.12")
-    set(CUSTOM_BUILD_COMMAND ${CMAKE_COMMAND} --build .)
-  else()
-    set(CUSTOM_BUILD_COMMAND ${CMAKE_COMMAND} --build . --parallel)
-  endif()
-
   # build library
   configure_file(
     ./CMake/Dependencies/lib${lib_name}-CMakeLists.txt
@@ -66,7 +58,7 @@ function(build_dependency lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CUSTOM_BUILD_COMMAND}
+    COMMAND ${CMAKE_COMMAND} --build .
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
   if(result)

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -44,6 +44,14 @@ function(build_dependency lib_name)
 
   file(REMOVE_RECURSE ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
 
+  # CMake 3.12 and higher support the --parallel build flag.
+  # https://cmake.org/cmake/help/latest/release/3.12.html
+  if(${CMAKE_VERSION} VERSION_LESS "3.12")
+    set(CUSTOM_BUILD_COMMAND ${CMAKE_COMMAND} --build .)
+  else()
+    set(CUSTOM_BUILD_COMMAND ${CMAKE_COMMAND} --build . --parallel)
+  endif()
+
   # build library
   configure_file(
     ./CMake/Dependencies/lib${lib_name}-CMakeLists.txt
@@ -58,7 +66,7 @@ function(build_dependency lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
+    COMMAND ${CUSTOM_BUILD_COMMAND}
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
   if(result)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/943

*Description of changes:*

This change enables build parallelism in the openssl job by seeding the make command with the CMAKE_BUILD_PARALLEL_LEVEL environment variable setting, if provided.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
