### PR TITLE
Adding ability to specify the cache file path

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -663,6 +663,7 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
 
     pSampleConfiguration->clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     pSampleConfiguration->clientInfo.loggingLevel = logLevel;
+    pSampleConfiguration->clientInfo.cacheFilePath = NULL; // Use the default path
     pSampleConfiguration->iceCandidatePairStatsTimerId = MAX_UINT32;
 
     ATOMIC_STORE_BOOL(&pSampleConfiguration->interrupted, FALSE);

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -289,6 +289,7 @@ extern "C" {
 #define STATUS_SIGNALING_RECONNECT_FAILED                          STATUS_SIGNALING_BASE + 0x00000030
 #define STATUS_SIGNALING_DELETE_CALL_FAILED                        STATUS_SIGNALING_BASE + 0x00000031
 #define STATUS_SIGNALING_INVALID_METRICS_VERSION                   STATUS_SIGNALING_BASE + 0x00000032
+#define STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN   STATUS_SIGNALING_BASE + 0x00000033
 
 /*!@} */
 
@@ -475,7 +476,7 @@ extern "C" {
 /**
  * Version of SignalingClientInfo structure
  */
-#define SIGNALING_CLIENT_INFO_CURRENT_VERSION 0
+#define SIGNALING_CLIENT_INFO_CURRENT_VERSION 1
 
 /**
  * Version of SignalingClientCallbacks structure
@@ -1140,6 +1141,11 @@ typedef struct {
     UINT32 loggingLevel;                            //!< Verbosity level for the logging. One of LOG_LEVEL_XXX
                                                     //!< values or the default verbosity will be assumed. Currently,
                                                     //!< default value is LOG_LEVEL_WARNING
+    PCHAR cacheFilePath;                            //!< File cache path override. The default
+                                                    //!< path is "./.SignalingCache_vN" which might not work for
+                                                    //!< devices which have read only partition where the code is
+                                                    //!< located. For default value or when file caching is not
+                                                    //!< being used this value can be NULL or point to an EMPTY_STRING.
 } SignalingClientInfo, *PSignalingClientInfo;
 
 /**

--- a/src/source/Signaling/FileCache.c
+++ b/src/source/Signaling/FileCache.c
@@ -24,7 +24,8 @@ CleanUp:
     return retStatus;
 }
 
-STATUS deserializeSignalingCacheEntries(PCHAR cachedFileContent, UINT64 fileSize, PSignalingFileCacheEntry pSignalingFileCacheEntryList, PUINT32 pEntryCount, PCHAR cacheFilePath)
+STATUS deserializeSignalingCacheEntries(PCHAR cachedFileContent, UINT64 fileSize, PSignalingFileCacheEntry pSignalingFileCacheEntryList,
+                                        PUINT32 pEntryCount, PCHAR cacheFilePath)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -113,7 +114,8 @@ CleanUp:
     return retStatus;
 }
 
-STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, SIGNALING_CHANNEL_ROLE_TYPE role, PSignalingFileCacheEntry pSignalingFileCacheEntry, PBOOL pCacheFound, PCHAR cacheFilePath)
+STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, SIGNALING_CHANNEL_ROLE_TYPE role,
+                                  PSignalingFileCacheEntry pSignalingFileCacheEntry, PBOOL pCacheFound, PCHAR cacheFilePath)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;

--- a/src/source/Signaling/FileCache.c
+++ b/src/source/Signaling/FileCache.c
@@ -24,15 +24,14 @@ CleanUp:
     return retStatus;
 }
 
-STATUS deserializeSignalingCacheEntries(PCHAR cachedFileContent, UINT64 fileSize, PSignalingFileCacheEntry pSignalingFileCacheEntryList,
-                                        PUINT32 pEntryCount)
+STATUS deserializeSignalingCacheEntries(PCHAR cachedFileContent, UINT64 fileSize, PSignalingFileCacheEntry pSignalingFileCacheEntryList, PUINT32 pEntryCount, PCHAR cacheFilePath)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     UINT32 listSize = 0, entryCount = 0, tokenCount = 0, remainingSize, tokenSize = 0;
     PCHAR pCurrent = NULL, nextToken = NULL, nextLine = NULL;
 
-    CHK(cachedFileContent != NULL && pSignalingFileCacheEntryList != NULL && pEntryCount != NULL, STATUS_NULL_ARG);
+    CHK(cachedFileContent != NULL && pSignalingFileCacheEntryList != NULL && pEntryCount != NULL && cacheFilePath != NULL, STATUS_NULL_ARG);
     listSize = *pEntryCount;
 
     pCurrent = cachedFileContent;
@@ -106,16 +105,15 @@ CleanUp:
 
     CHK_LOG_ERR(retStatus);
 
-    if (STATUS_FAILED(retStatus)) {
-        FREMOVE(DEFAULT_CACHE_FILE_PATH);
+    if (STATUS_FAILED(retStatus) && cacheFilePath != NULL) {
+        FREMOVE(cacheFilePath);
     }
 
     LEAVES();
     return retStatus;
 }
 
-STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, SIGNALING_CHANNEL_ROLE_TYPE role,
-                                  PSignalingFileCacheEntry pSignalingFileCacheEntry, PBOOL pCacheFound)
+STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, SIGNALING_CHANNEL_ROLE_TYPE role, PSignalingFileCacheEntry pSignalingFileCacheEntry, PBOOL pCacheFound, PCHAR cacheFilePath)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -125,22 +123,22 @@ STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, SIGNALING_CHA
     UINT32 entryCount = ARRAY_SIZE(entries), i;
     BOOL cacheFound = FALSE;
 
-    CHK(channelName != NULL && region != NULL && pSignalingFileCacheEntry != NULL && pCacheFound != NULL, STATUS_NULL_ARG);
+    CHK(channelName != NULL && region != NULL && pSignalingFileCacheEntry != NULL && pCacheFound != NULL && cacheFilePath != NULL, STATUS_NULL_ARG);
     CHK(!IS_EMPTY_STRING(channelName) && !IS_EMPTY_STRING(region), STATUS_INVALID_ARG);
 
-    CHK_STATUS(createFileIfNotExist(DEFAULT_CACHE_FILE_PATH));
+    CHK_STATUS(createFileIfNotExist(cacheFilePath));
 
     MEMSET(entries, 0x00, SIZEOF(entries));
 
-    CHK_STATUS(readFile(DEFAULT_CACHE_FILE_PATH, FALSE, NULL, &fileSize));
+    CHK_STATUS(readFile(cacheFilePath, FALSE, NULL, &fileSize));
 
     if (fileSize > 0) {
         /* +1 for null terminator */
         fileBuffer = MEMCALLOC(1, (fileSize + 1) * SIZEOF(CHAR));
         CHK(fileBuffer != NULL, STATUS_NOT_ENOUGH_MEMORY);
-        CHK_STATUS(readFile(DEFAULT_CACHE_FILE_PATH, FALSE, (PBYTE) fileBuffer, &fileSize));
+        CHK_STATUS(readFile(cacheFilePath, FALSE, (PBYTE) fileBuffer, &fileSize));
 
-        CHK_STATUS(deserializeSignalingCacheEntries(fileBuffer, fileSize, entries, &entryCount));
+        CHK_STATUS(deserializeSignalingCacheEntries(fileBuffer, fileSize, entries, &entryCount, cacheFilePath));
 
         for (i = 0; !cacheFound && i < entryCount; ++i) {
             /* Assume channel name and region has been validated */
@@ -163,7 +161,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry pSignalingFileCacheEntry)
+STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry pSignalingFileCacheEntry, PCHAR cacheFilePath)
 {
     ENTERS();
 
@@ -175,7 +173,7 @@ STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry pSignalingFileCacheEntr
     PSignalingFileCacheEntry pExistingCacheEntry = NULL;
     CHAR serializedCacheEntry[MAX_SERIALIZED_SIGNALING_CACHE_ENTRY_LEN];
 
-    CHK(pSignalingFileCacheEntry != NULL, STATUS_NULL_ARG);
+    CHK(cacheFilePath != NULL && pSignalingFileCacheEntry != NULL, STATUS_NULL_ARG);
     CHK(!IS_EMPTY_STRING(pSignalingFileCacheEntry->channelArn) && !IS_EMPTY_STRING(pSignalingFileCacheEntry->channelName) &&
             !IS_EMPTY_STRING(pSignalingFileCacheEntry->region) && !IS_EMPTY_STRING(pSignalingFileCacheEntry->httpsEndpoint) &&
             !IS_EMPTY_STRING(pSignalingFileCacheEntry->wssEndpoint),
@@ -183,18 +181,18 @@ STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry pSignalingFileCacheEntr
 
     MEMSET(entries, 0x00, SIZEOF(entries));
 
-    CHK_STATUS(createFileIfNotExist(DEFAULT_CACHE_FILE_PATH));
+    CHK_STATUS(createFileIfNotExist(cacheFilePath));
 
     /* read entire file into buffer */
-    CHK_STATUS(readFile(DEFAULT_CACHE_FILE_PATH, FALSE, NULL, &fileSize));
+    CHK_STATUS(readFile(cacheFilePath, FALSE, NULL, &fileSize));
     /* deserialize if file is not empty */
     if (fileSize > 0) {
         /* +1 for null terminator */
         fileBuffer = MEMCALLOC(1, (fileSize + 1) * SIZEOF(CHAR));
         CHK(fileBuffer != NULL, STATUS_NOT_ENOUGH_MEMORY);
-        CHK_STATUS(readFile(DEFAULT_CACHE_FILE_PATH, FALSE, (PBYTE) fileBuffer, &fileSize));
+        CHK_STATUS(readFile(cacheFilePath, FALSE, (PBYTE) fileBuffer, &fileSize));
 
-        CHK_STATUS(deserializeSignalingCacheEntries(fileBuffer, fileSize, entries, &entryCount));
+        CHK_STATUS(deserializeSignalingCacheEntries(fileBuffer, fileSize, entries, &entryCount, cacheFilePath));
     } else {
         entryCount = 0;
     }
@@ -220,7 +218,7 @@ STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry pSignalingFileCacheEntr
                      entries[i].role == SIGNALING_CHANNEL_ROLE_TYPE_MASTER ? SIGNALING_FILE_CACHE_ROLE_TYPE_MASTER_STR
                                                                            : SIGNALING_FILE_CACHE_ROLE_TYPE_VIEWER_STR,
                      entries[i].region, entries[i].channelArn, entries[i].httpsEndpoint, entries[i].wssEndpoint, entries[i].creationTsEpochSeconds);
-        CHK_STATUS(writeFile(DEFAULT_CACHE_FILE_PATH, FALSE, i == 0 ? FALSE : TRUE, (PBYTE) serializedCacheEntry, serializedCacheEntryLen));
+        CHK_STATUS(writeFile(cacheFilePath, FALSE, i == 0 ? FALSE : TRUE, (PBYTE) serializedCacheEntry, serializedCacheEntryLen));
     }
 
 CleanUp:

--- a/src/source/Signaling/FileCache.h
+++ b/src/source/Signaling/FileCache.h
@@ -12,7 +12,7 @@ extern "C" {
 
 /* If SignalingFileCacheEntry layout is changed, change the version in cache file name so we wont read from older
  * cache file. */
-#define DEFAULT_CACHE_FILE_PATH                     "./.SignalingCache_v0"
+#define DEFAULT_CACHE_FILE_PATH                     (PCHAR) "./.SignalingCache_v0"
 #define MAX_SIGNALING_CACHE_ENTRY_TIMESTAMP_STR_LEN 10
 /* Max length for a serialized signaling cache entry. 8 accounts for 6 commas and 1 newline
  * char and null terminator */
@@ -32,8 +32,9 @@ typedef struct {
     CHAR wssEndpoint[MAX_SIGNALING_ENDPOINT_URI_LEN + 1];
 } SignalingFileCacheEntry, *PSignalingFileCacheEntry;
 
-STATUS signalingCacheLoadFromFile(PCHAR, PCHAR, SIGNALING_CHANNEL_ROLE_TYPE, PSignalingFileCacheEntry, PBOOL);
-STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry);
+STATUS deserializeSignalingCacheEntries(PCHAR, UINT64, PSignalingFileCacheEntry, PUINT32, PCHAR);
+STATUS signalingCacheLoadFromFile(PCHAR, PCHAR, SIGNALING_CHANNEL_ROLE_TYPE, PSignalingFileCacheEntry, PBOOL, PCHAR);
+STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry, PCHAR);
 
 #ifdef __cplusplus
 }

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -44,7 +44,9 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
 
     if (pSignalingClient->pChannelInfo->cachingPolicy == SIGNALING_API_CALL_CACHE_TYPE_FILE) {
         // Signaling channel name can be NULL in case of pre-created channels in which case we use ARN as the name
-        if (STATUS_FAILED(signalingCacheLoadFromFile(pChannelInfo->pChannelName != NULL ? pChannelInfo->pChannelName : pChannelInfo->pChannelArn, pChannelInfo->pRegion, pChannelInfo->channelRoleType, pFileCacheEntry, &cacheFound, pSignalingClient->clientInfo.cacheFilePath))) {
+        if (STATUS_FAILED(signalingCacheLoadFromFile(pChannelInfo->pChannelName != NULL ? pChannelInfo->pChannelName : pChannelInfo->pChannelArn,
+                                                     pChannelInfo->pRegion, pChannelInfo->channelRoleType, pFileCacheEntry, &cacheFound,
+                                                     pSignalingClient->clientInfo.cacheFilePath))) {
             DLOGW("Failed to load signaling cache from file");
         } else if (cacheFound) {
             STRCPY(pSignalingClient->channelDescription.channelArn, pFileCacheEntry->channelArn);
@@ -536,8 +538,10 @@ STATUS validateSignalingClientInfo(PSignalingClient pSignalingClient, PSignaling
 
         case 1:
             // If the path is specified and not empty then we validate and copy/store
-            if (pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath != NULL && pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath[0] != '\0') {
-                CHK(STRNLEN(pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath, MAX_PATH_LEN + 1) <= MAX_PATH_LEN, STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN);
+            if (pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath != NULL &&
+                pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath[0] != '\0') {
+                CHK(STRNLEN(pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath, MAX_PATH_LEN + 1) <= MAX_PATH_LEN,
+                    STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN);
                 STRCPY(pSignalingClient->clientInfo.cacheFilePath, pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath);
             } else {
                 // Set the default path

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -44,8 +44,7 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
 
     if (pSignalingClient->pChannelInfo->cachingPolicy == SIGNALING_API_CALL_CACHE_TYPE_FILE) {
         // Signaling channel name can be NULL in case of pre-created channels in which case we use ARN as the name
-        if (STATUS_FAILED(signalingCacheLoadFromFile(pChannelInfo->pChannelName != NULL ? pChannelInfo->pChannelName : pChannelInfo->pChannelArn,
-                                                     pChannelInfo->pRegion, pChannelInfo->channelRoleType, pFileCacheEntry, &cacheFound))) {
+        if (STATUS_FAILED(signalingCacheLoadFromFile(pChannelInfo->pChannelName != NULL ? pChannelInfo->pChannelName : pChannelInfo->pChannelArn, pChannelInfo->pRegion, pChannelInfo->channelRoleType, pFileCacheEntry, &cacheFound, pSignalingClient->clientInfo.cacheFilePath))) {
             DLOGW("Failed to load signaling cache from file");
         } else if (cacheFound) {
             STRCPY(pSignalingClient->channelDescription.channelArn, pFileCacheEntry->channelArn);
@@ -527,6 +526,30 @@ STATUS validateSignalingClientInfo(PSignalingClient pSignalingClient, PSignaling
     // Copy and store internally
     pSignalingClient->clientInfo = *pClientInfo;
 
+    // V1 features
+    switch (pSignalingClient->clientInfo.signalingClientInfo.version) {
+        case 0:
+            // Set the default path
+            STRCPY(pSignalingClient->clientInfo.cacheFilePath, DEFAULT_CACHE_FILE_PATH);
+
+            break;
+
+        case 1:
+            // If the path is specified and not empty then we validate and copy/store
+            if (pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath != NULL && pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath[0] != '\0') {
+                CHK(STRNLEN(pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath, MAX_PATH_LEN + 1) <= MAX_PATH_LEN, STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN);
+                STRCPY(pSignalingClient->clientInfo.cacheFilePath, pSignalingClient->clientInfo.signalingClientInfo.cacheFilePath);
+            } else {
+                // Set the default path
+                STRCPY(pSignalingClient->clientInfo.cacheFilePath, DEFAULT_CACHE_FILE_PATH);
+            }
+
+            break;
+
+        default:
+            CHK_ERR(FALSE, STATUS_INTERNAL_ERROR, "Internal error checking and validating the ClientInfo version");
+    }
+
 CleanUp:
 
     LEAVES();
@@ -1001,7 +1024,7 @@ STATUS getChannelEndpoint(PSignalingClient pSignalingClient, UINT64 time)
                         STRCPY(signalingFileCacheEntry.channelArn, pSignalingClient->channelDescription.channelArn);
                         STRCPY(signalingFileCacheEntry.httpsEndpoint, pSignalingClient->channelEndpointHttps);
                         STRCPY(signalingFileCacheEntry.wssEndpoint, pSignalingClient->channelEndpointWss);
-                        if (STATUS_FAILED(signalingCacheSaveToFile(&signalingFileCacheEntry))) {
+                        if (STATUS_FAILED(signalingCacheSaveToFile(&signalingFileCacheEntry, pSignalingClient->clientInfo.cacheFilePath))) {
                             DLOGW("Failed to save signaling cache to file");
                         }
                     }

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -81,6 +81,9 @@ typedef struct {
     // Public client info structure
     SignalingClientInfo signalingClientInfo;
 
+    // V1 features
+    CHAR cacheFilePath[MAX_PATH_LEN + 1];
+
     //
     // Below members will be used for direct injection for tests hooks
     //

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -2400,7 +2400,7 @@ TEST_F(SignalingApiFunctionalityTest, fileCachingUpdateCache)
     STRCPY(testEntry.channelArn, "testChannelArn");
     STRCPY(testEntry.channelName, "testChannel");
     testEntry.creationTsEpochSeconds = GETTIME() / HUNDREDS_OF_NANOS_IN_A_SECOND;
-    EXPECT_EQ(STATUS_SUCCESS, signalingCacheSaveToFile(&testEntry));
+    EXPECT_EQ(STATUS_SUCCESS, signalingCacheSaveToFile(&testEntry, DEFAULT_CACHE_FILE_PATH));
 
     testEntry.role = SIGNALING_CHANNEL_ROLE_TYPE_VIEWER;
     STRCPY(testEntry2.wssEndpoint, "testWssEnpoint");
@@ -2409,11 +2409,11 @@ TEST_F(SignalingApiFunctionalityTest, fileCachingUpdateCache)
     STRCPY(testEntry2.channelArn, "testChannelArn2");
     STRCPY(testEntry2.channelName, "testChannel2");
     testEntry2.creationTsEpochSeconds = GETTIME() / HUNDREDS_OF_NANOS_IN_A_SECOND;
-    EXPECT_EQ(STATUS_SUCCESS, signalingCacheSaveToFile(&testEntry2));
+    EXPECT_EQ(STATUS_SUCCESS, signalingCacheSaveToFile(&testEntry2, DEFAULT_CACHE_FILE_PATH));
 
     testEntry.creationTsEpochSeconds = GETTIME() / HUNDREDS_OF_NANOS_IN_A_SECOND;
     /* update first cache entry*/
-    EXPECT_EQ(STATUS_SUCCESS, signalingCacheSaveToFile(&testEntry));
+    EXPECT_EQ(STATUS_SUCCESS, signalingCacheSaveToFile(&testEntry, DEFAULT_CACHE_FILE_PATH));
 }
 
 TEST_F(SignalingApiFunctionalityTest, asyncIceConfigRefreshBeforeConnect)

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -211,6 +211,7 @@ TEST_F(SignalingApiFunctionalityTest, basicCreateConnectFree)
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.cacheFilePath = NULL;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
@@ -267,6 +268,7 @@ TEST_F(SignalingApiFunctionalityTest, mockMaster)
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.cacheFilePath = NULL;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
@@ -401,6 +403,7 @@ TEST_F(SignalingApiFunctionalityTest, mockViewer)
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.cacheFilePath = NULL;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_VIEWER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
@@ -500,6 +503,7 @@ TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.cacheFilePath = NULL;
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
     channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
@@ -773,6 +777,7 @@ TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.cacheFilePath = NULL;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
@@ -1493,6 +1498,7 @@ TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.cacheFilePath = NULL;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
@@ -1575,6 +1581,7 @@ TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.cacheFilePath = NULL;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -345,14 +345,16 @@ TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
 
     // Override the version of the client info struct
     mClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION + 1;
-    EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_VERSION, createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle));
+    EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_VERSION, createSignalingClientSync(&mClientInfo, &mChannelInfo,
+        &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle));
     mClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
 
     //
     // Invalid max path
     //
     mClientInfo.cacheFilePath = testPath;
-    EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN, createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle));
+    EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN, createSignalingClientSync(&mClientInfo,
+        &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle));
     mClientInfo.cacheFilePath = NULL;
 
     //
@@ -362,7 +364,8 @@ TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
     // Set the version to 0 and the path to non-default
     mClientInfo.version = 0;
     mClientInfo.cacheFilePath = (PCHAR) "/some/test/path";
-    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks,
+                                          mTestCredentialProvider, &mSignalingClientHandle);
     if (mAccessKeyIdSet) {
         EXPECT_EQ(STATUS_SUCCESS, retStatus);
 
@@ -385,7 +388,8 @@ TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
     // Set the version to 0 and the path to non-default
     mClientInfo.version = 0;
     mClientInfo.cacheFilePath = testPath;
-    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks,
+                                          mTestCredentialProvider, &mSignalingClientHandle);
     if (mAccessKeyIdSet) {
         EXPECT_EQ(STATUS_SUCCESS, retStatus);
 
@@ -406,7 +410,8 @@ TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
     //
 
     mClientInfo.cacheFilePath = EMPTY_STRING;
-    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks,
+                                          mTestCredentialProvider, &mSignalingClientHandle);
     if (mAccessKeyIdSet) {
         EXPECT_EQ(STATUS_SUCCESS, retStatus);
 
@@ -426,7 +431,8 @@ TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
     //
 
     mClientInfo.cacheFilePath = TEST_CACHE_FILE_PATH;
-    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks,
+                                          mTestCredentialProvider, &mSignalingClientHandle);
     if (mAccessKeyIdSet) {
         EXPECT_EQ(STATUS_SUCCESS, retStatus);
 

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -345,16 +345,31 @@ TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
 
     // Override the version of the client info struct
     mClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION + 1;
-    EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_VERSION, createSignalingClientSync(&mClientInfo, &mChannelInfo,
-        &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle));
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    if (mAccessKeyIdSet) {
+        EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_VERSION, retStatus);
+    } else {
+        mSignalingClientHandle = INVALID_SIGNALING_CLIENT_HANDLE_VALUE;
+        EXPECT_NE(STATUS_SUCCESS, retStatus);
+    }
+
+    deinitializeSignalingClient();
     mClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
 
     //
     // Invalid max path
     //
     mClientInfo.cacheFilePath = testPath;
-    EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN, createSignalingClientSync(&mClientInfo,
-        &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle));
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+
+    if (mAccessKeyIdSet) {
+        EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN, retStatus);
+    } else {
+        mSignalingClientHandle = INVALID_SIGNALING_CLIENT_HANDLE_VALUE;
+        EXPECT_NE(STATUS_SUCCESS, retStatus);
+    }
+
+    deinitializeSignalingClient();
     mClientInfo.cacheFilePath = NULL;
 
     //

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -229,7 +229,7 @@ TEST_F(SignalingApiTest, signalingClientGetStateString)
     for (UINT32 i = 0; i <= (UINT32) SIGNALING_CLIENT_STATE_MAX_VALUE + 1; i++) {
         PCHAR pStateStr;
         EXPECT_EQ(STATUS_SUCCESS, signalingClientGetStateString((SIGNALING_CLIENT_STATE) i, &pStateStr));
-        DLOGI("Iterating states \"%s\"", pStateStr);
+        DLOGV("Iterating states \"%s\"", pStateStr);
     }
 }
 
@@ -328,6 +328,118 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_NE(0, metrics.signalingClientStats.dpApiCallLatency);
 
     deinitializeSignalingClient();
+}
+
+TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
+{
+    STATUS retStatus;
+    CHAR testPath[MAX_PATH_LEN + 2];
+    MEMSET(testPath, 'a', MAX_PATH_LEN + 1);
+    testPath[MAX_PATH_LEN + 1] = '\0';
+
+    initializeSignalingClientStructs();
+
+    //
+    // Invalid version
+    //
+
+    // Override the version of the client info struct
+    mClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION + 1;
+    EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_VERSION, createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle));
+    mClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
+
+    //
+    // Invalid max path
+    //
+    mClientInfo.cacheFilePath = testPath;
+    EXPECT_EQ(STATUS_SIGNALING_INVALID_CLIENT_INFO_CACHE_FILE_PATH_LEN, createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle));
+    mClientInfo.cacheFilePath = NULL;
+
+    //
+    // Version 0 ignoring path
+    //
+
+    // Set the version to 0 and the path to non-default
+    mClientInfo.version = 0;
+    mClientInfo.cacheFilePath = (PCHAR) "/some/test/path";
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    if (mAccessKeyIdSet) {
+        EXPECT_EQ(STATUS_SUCCESS, retStatus);
+
+        // Validate the cache file path
+        PSignalingClient pSignalingClient = FROM_SIGNALING_CLIENT_HANDLE(mSignalingClientHandle);
+        EXPECT_EQ(0, STRCMP(DEFAULT_CACHE_FILE_PATH, pSignalingClient->clientInfo.cacheFilePath));
+    } else {
+        mSignalingClientHandle = INVALID_SIGNALING_CLIENT_HANDLE_VALUE;
+        EXPECT_NE(STATUS_SUCCESS, retStatus);
+    }
+
+    deinitializeSignalingClient();
+    mClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
+    mClientInfo.cacheFilePath = NULL;
+
+    //
+    // Version 0 setting to large path doesn't error
+    //
+
+    // Set the version to 0 and the path to non-default
+    mClientInfo.version = 0;
+    mClientInfo.cacheFilePath = testPath;
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    if (mAccessKeyIdSet) {
+        EXPECT_EQ(STATUS_SUCCESS, retStatus);
+
+        // Validate the cache file path
+        PSignalingClient pSignalingClient = FROM_SIGNALING_CLIENT_HANDLE(mSignalingClientHandle);
+        EXPECT_EQ(0, STRCMP(DEFAULT_CACHE_FILE_PATH, pSignalingClient->clientInfo.cacheFilePath));
+    } else {
+        mSignalingClientHandle = INVALID_SIGNALING_CLIENT_HANDLE_VALUE;
+        EXPECT_NE(STATUS_SUCCESS, retStatus);
+    }
+
+    deinitializeSignalingClient();
+    mClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
+    mClientInfo.cacheFilePath = NULL;
+
+    //
+    // Version 1 empty path
+    //
+
+    mClientInfo.cacheFilePath = EMPTY_STRING;
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    if (mAccessKeyIdSet) {
+        EXPECT_EQ(STATUS_SUCCESS, retStatus);
+
+        // Validate the cache file path
+        PSignalingClient pSignalingClient = FROM_SIGNALING_CLIENT_HANDLE(mSignalingClientHandle);
+        EXPECT_EQ(0, STRCMP(DEFAULT_CACHE_FILE_PATH, pSignalingClient->clientInfo.cacheFilePath));
+    } else {
+        mSignalingClientHandle = INVALID_SIGNALING_CLIENT_HANDLE_VALUE;
+        EXPECT_NE(STATUS_SUCCESS, retStatus);
+    }
+
+    deinitializeSignalingClient();
+    mClientInfo.cacheFilePath = NULL;
+
+    //
+    // Version 1 non default path
+    //
+
+    mClientInfo.cacheFilePath = TEST_CACHE_FILE_PATH;
+    retStatus = createSignalingClientSync(&mClientInfo, &mChannelInfo, &mSignalingClientCallbacks, mTestCredentialProvider, &mSignalingClientHandle);
+    if (mAccessKeyIdSet) {
+        EXPECT_EQ(STATUS_SUCCESS, retStatus);
+
+        // Validate the cache file path
+        PSignalingClient pSignalingClient = FROM_SIGNALING_CLIENT_HANDLE(mSignalingClientHandle);
+        EXPECT_EQ(0, STRCMP(TEST_CACHE_FILE_PATH, pSignalingClient->clientInfo.cacheFilePath));
+    } else {
+        mSignalingClientHandle = INVALID_SIGNALING_CLIENT_HANDLE_VALUE;
+        EXPECT_NE(STATUS_SUCCESS, retStatus);
+    }
+
+    deinitializeSignalingClient();
+    mClientInfo.cacheFilePath = NULL;
 }
 
 } // namespace webrtcclient


### PR DESCRIPTION

Issue #908 

Revving the version of ClientInfo struct to include the optional path to the cache file. Default value is used by specifying NULL or EMPTY_STRING. Adding test variations.

NOTE: This is an important change to allow cache file usage for many embedded devices where the partition for the binaries is locked/read-only.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
