### PR TITLE
Change Sample App timestamps to UINT64 to prevent overflow

### DIFF
--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -112,8 +112,8 @@ struct __SampleStreamingSession {
     PRtcRtpTransceiver pAudioRtcRtpTransceiver;
     RtcSessionDescriptionInit answerSessionDescriptionInit;
     PSampleConfiguration pSampleConfiguration;
-    UINT32 audioTimestamp;
-    UINT32 videoTimestamp;
+    UINT64 audioTimestamp;
+    UINT64 videoTimestamp;
     CHAR peerId[MAX_SIGNALING_CLIENT_ID_LEN + 1];
     TID receiveAudioVideoSenderTid;
     UINT64 offerReceiveTime;


### PR DESCRIPTION
*Issue #957 *

*Description of changes:*
Current Samples have UINT32 timestamps, this means that they will easily overflow in a few minutes given 10,000,000 incremented per second. When this overflow occurs, the resulting RTP frame timestamp will decrement in value, and some decoder will fail to decode RTP frames for at least a minute. By changing them to UINT64, we delay this overflow to at least a few hours.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
