### PR TITLE
Fix gperftools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ option(ADDRESS_SANITIZER "Build with AddressSanitizer." OFF)
 option(MEMORY_SANITIZER "Build with MemorySanitizer." OFF)
 option(THREAD_SANITIZER "Build with ThreadSanitizer." OFF)
 option(UNDEFINED_BEHAVIOR_SANITIZER "Build with UndefinedBehaviorSanitizer." OFF)
-option(LINK_PROFILER "Link gperftools profiler" OFF) 
+option(LINK_PROFILER "Link gperftools profiler" OFF)
 
 if(NOT WIN32)
 CHECK_INCLUDE_FILES(ifaddrs.h       KVSWEBRTC_HAVE_IFADDRS_H)
@@ -42,6 +42,11 @@ endif()
 
 set(CMAKE_MACOSX_RPATH TRUE)
 get_filename_component(ROOT "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+
+if (LINK_PROFILER)
+  add_link_options("-Wl,--no-as-needed")
+endif()
+
 
 # static settings
 if(BUILD_STATIC_LIBS OR WIN32)


### PR DESCRIPTION
*Issue #, if available:*
Fix the abnormal behavior of gperftools.
*Description of changes:*
I can not run this sdk with gperftools correctly, since this sdk did not add the correct link option for gcc.
The similar issue is as below. 
https://stackoverflow.com/questions/26636570/using-pprof-with-gperftools-resulting-in-curl-error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
