### PR TITLE
Check NULL for pFrame in writeFrame

### DIFF
--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -206,7 +206,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     UINT64 tmpFrames, tmpTime;
     STATUS sendStatus;
 
-    CHK(pKvsRtpTransceiver != NULL, STATUS_NULL_ARG);
+    CHK(pKvsRtpTransceiver != NULL && pFrame != NULL, STATUS_NULL_ARG);
     pKvsPeerConnection = pKvsRtpTransceiver->pKvsPeerConnection;
     pPayloadArray = &(pKvsRtpTransceiver->sender.payloadArray);
     if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {


### PR DESCRIPTION
Signed-off-by: Alex.Li <zhiqinli@amazon.com>

*Issue #, if available:*

*Description of changes:*

Passing NULL `pFrame` to `writeFrame` might cause segfault


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
