### PR TITLE
Optimize startup latency from ~9s to ~80ms

### DIFF
--- a/bench/DtlsBenchmark.cpp
+++ b/bench/DtlsBenchmark.cpp
@@ -23,7 +23,7 @@ class DtlsBenchmark : public WebRtcClientBenchmarkBase {
 
         MEMSET(&callbacks, 0, SIZEOF(callbacks));
         callbacks.stateChangeFn = [](UINT64 customData, RTC_DTLS_TRANSPORT_STATE state) {
-            if (state == CONNECTED) {
+            if (state == RTC_DTLS_TRANSPORT_STATE_CONNECTED) {
                 ATOMIC_INCREMENT((PSIZE_T) customData);
             }
         };

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -32,14 +32,17 @@ VOID onDataChannel(UINT64 customData, PRtcDataChannel pRtcDataChannel)
 VOID onConnectionStateChange(UINT64 customData, RTC_PEER_CONNECTION_STATE newState)
 {
     PSampleStreamingSession pSampleStreamingSession = (PSampleStreamingSession) customData;
+    PSampleConfiguration pSampleConfiguration = pSampleStreamingSession->pSampleConfiguration;
     STATUS retStatus = STATUS_SUCCESS;
     DLOGI("New connection state %u", newState);
 
     if (newState == RTC_PEER_CONNECTION_STATE_FAILED || newState == RTC_PEER_CONNECTION_STATE_CLOSED ||
         newState == RTC_PEER_CONNECTION_STATE_DISCONNECTED) {
         ATOMIC_STORE_BOOL(&pSampleStreamingSession->terminateFlag, TRUE);
-        CVAR_BROADCAST(pSampleStreamingSession->pSampleConfiguration->cvar);
+        CVAR_BROADCAST(pSampleConfiguration->cvar);
     } else if (newState == RTC_PEER_CONNECTION_STATE_CONNECTED) {
+        ATOMIC_STORE_BOOL(&pSampleConfiguration->connected, TRUE);
+        CVAR_BROADCAST(pSampleConfiguration->cvar);
         if (STATUS_FAILED(retStatus = logSelectedIceCandidatesInformation(pSampleStreamingSession))) {
             DLOGW("Failed to get information about selected Ice candidates: 0x%08x", retStatus);
         }

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -70,8 +70,7 @@ typedef struct {
     UINT32 audioBufferSize;
     PBYTE pVideoFrameBuffer;
     UINT32 videoBufferSize;
-    TID videoSenderTid;
-    TID audioSenderTid;
+    TID mediaSenderTid;
     TIMER_QUEUE_HANDLE timerQueueHandle;
     UINT32 iceCandidatePairStatsTimerId;
     SampleStreamingMediaType mediaType;

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -60,6 +60,7 @@ typedef struct {
     volatile ATOMIC_BOOL interrupted;
     volatile ATOMIC_BOOL mediaThreadStarted;
     volatile ATOMIC_BOOL recreateSignalingClient;
+    volatile ATOMIC_BOOL connected;
     BOOL useTestSrc;
     ChannelInfo channelInfo;
     PCHAR pCaCertPath;

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -113,15 +113,8 @@ CleanUp:
         // Kick of the termination sequence
         ATOMIC_STORE_BOOL(&pSampleConfiguration->appTerminateFlag, TRUE);
 
-        // Join the threads
-        if (pSampleConfiguration->videoSenderTid != (UINT64) NULL) {
-            // Join the threads
-            THREAD_JOIN(pSampleConfiguration->videoSenderTid, NULL);
-        }
-
-        if (pSampleConfiguration->audioSenderTid != (UINT64) NULL) {
-            // Join the threads
-            THREAD_JOIN(pSampleConfiguration->audioSenderTid, NULL);
+        if (pSampleConfiguration->mediaSenderTid != INVALID_TID_VALUE) {
+            THREAD_JOIN(pSampleConfiguration->mediaSenderTid, NULL);
         }
 
         if (pSampleConfiguration->enableFileLogging) {
@@ -198,12 +191,6 @@ PVOID sendVideoPackets(PVOID args)
         printf("[KVS Master] sendVideoPackets(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
         goto CleanUp;
     }
-
-    MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
-    while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->connected)) {
-        CHK_STATUS(CVAR_WAIT(pSampleConfiguration->cvar, pSampleConfiguration->sampleConfigurationObjLock, INFINITE_TIME_VALUE));
-    }
-    MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
 
     frame.presentationTs = 0;
     startTime = GETTIME();
@@ -291,12 +278,6 @@ PVOID sendAudioPackets(PVOID args)
         printf("[KVS Master] sendAudioPackets(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
         goto CleanUp;
     }
-
-    MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
-    while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->connected)) {
-        CHK_STATUS(CVAR_WAIT(pSampleConfiguration->cvar, pSampleConfiguration->sampleConfigurationObjLock, INFINITE_TIME_VALUE));
-    }
-    MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
 
     frame.presentationTs = 0;
 

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -199,6 +199,12 @@ PVOID sendVideoPackets(PVOID args)
         goto CleanUp;
     }
 
+    MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
+    while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->connected)) {
+        CHK_STATUS(CVAR_WAIT(pSampleConfiguration->cvar, pSampleConfiguration->sampleConfigurationObjLock, INFINITE_TIME_VALUE));
+    }
+    MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
+
     frame.presentationTs = 0;
     startTime = GETTIME();
     lastFrameTime = startTime;
@@ -266,6 +272,8 @@ PVOID sendVideoPackets(PVOID args)
 
 CleanUp:
 
+    CHK_LOG_ERR(retStatus);
+
     return (PVOID)(ULONG_PTR) retStatus;
 }
 
@@ -283,6 +291,12 @@ PVOID sendAudioPackets(PVOID args)
         printf("[KVS Master] sendAudioPackets(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
         goto CleanUp;
     }
+
+    MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
+    while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->connected)) {
+        CHK_STATUS(CVAR_WAIT(pSampleConfiguration->cvar, pSampleConfiguration->sampleConfigurationObjLock, INFINITE_TIME_VALUE));
+    }
+    MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);
 
     frame.presentationTs = 0;
 

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -454,9 +454,8 @@ CleanUp:
         // Kick of the termination sequence
         ATOMIC_STORE_BOOL(&pSampleConfiguration->appTerminateFlag, TRUE);
 
-        if (pSampleConfiguration->videoSenderTid != (UINT64) NULL) {
-            // Join the threads
-            THREAD_JOIN(pSampleConfiguration->videoSenderTid, NULL);
+        if (pSampleConfiguration->mediaSenderTid != INVALID_TID_VALUE) {
+            THREAD_JOIN(pSampleConfiguration->mediaSenderTid, NULL);
         }
 
         if (pSampleConfiguration->enableFileLogging) {

--- a/src/source/Crypto/Dtls.c
+++ b/src/source/Crypto/Dtls.c
@@ -64,7 +64,7 @@ STATUS dtlsSessionChangeState(PDtlsSession pDtlsSession, RTC_DTLS_TRANSPORT_STAT
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->state != newState, retStatus);
 
-    if (pDtlsSession->state == CONNECTING && newState == CONNECTED) {
+    if (pDtlsSession->state == RTC_DTLS_TRANSPORT_STATE_CONNECTING && newState == RTC_DTLS_TRANSPORT_STATE_CONNECTED) {
         DLOGD("DTLS init completed. Time taken %" PRIu64 " ms",
               (GETTIME() - pDtlsSession->dtlsSessionStartTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }

--- a/src/source/Crypto/Dtls.h
+++ b/src/source/Crypto/Dtls.h
@@ -35,11 +35,11 @@ extern "C" {
 #define HUNDREDS_OF_NANOS_IN_A_DAY (HUNDREDS_OF_NANOS_IN_AN_HOUR * 24LL)
 
 typedef enum {
-    NEW,
-    CONNECTING, /* DTLS is in the process of negotiating a secure connection and verifying the remote fingerprint. */
-    CONNECTED,  /* DTLS has completed negotiation of a secure connection and verified the remote fingerprint. */
-    CLOSED,     /* The transport has been closed intentionally as the result of receipt of a close_notify alert */
-    FAILED,     /* The transport has failed as the result of an error */
+    RTC_DTLS_TRANSPORT_STATE_NEW,
+    RTC_DTLS_TRANSPORT_STATE_CONNECTING, /* DTLS is in the process of negotiating a secure connection and verifying the remote fingerprint. */
+    RTC_DTLS_TRANSPORT_STATE_CONNECTED,  /* DTLS has completed negotiation of a secure connection and verified the remote fingerprint. */
+    RTC_DTLS_TRANSPORT_STATE_CLOSED,     /* The transport has been closed intentionally as the result of receipt of a close_notify alert */
+    RTC_DTLS_TRANSPORT_STATE_FAILED,     /* The transport has failed as the result of an error */
 } RTC_DTLS_TRANSPORT_STATE;
 
 /* Callback that is fired when Dtls Server wishes to send packet */

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -558,10 +558,10 @@ VOID onDtlsStateChange(UINT64 customData, RTC_DTLS_TRANSPORT_STATE newDtlsState)
     pKvsPeerConnection = (PKvsPeerConnection) customData;
 
     switch (newDtlsState) {
-        case CONNECTED:
+        case RTC_DTLS_TRANSPORT_STATE_CONNECTED:
             changePeerConnectionState(pKvsPeerConnection, RTC_PEER_CONNECTION_STATE_CONNECTED);
             break;
-        case CLOSED:
+        case RTC_DTLS_TRANSPORT_STATE_CLOSED:
             changePeerConnectionState(pKvsPeerConnection, RTC_PEER_CONNECTION_STATE_CLOSED);
             break;
         default:

--- a/tst/DtlsFunctionalityTest.cpp
+++ b/tst/DtlsFunctionalityTest.cpp
@@ -23,7 +23,7 @@ class DtlsFunctionalityTest : public WebRtcClientTestBase {
 
         MEMSET(&callbacks, 0, SIZEOF(callbacks));
         callbacks.stateChangeFn = [](UINT64 customData, RTC_DTLS_TRANSPORT_STATE state) {
-            if (state == CONNECTED) {
+            if (state == RTC_DTLS_TRANSPORT_STATE_CONNECTED) {
                 ATOMIC_INCREMENT((PSIZE_T) customData);
             }
         };

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -610,8 +610,8 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
     RtcConfiguration configuration;
     Context context;
     PRtcPeerConnection offerPc = NULL, answerPc = NULL;
-    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack, offerAudioTrack, answerAudioTrack;
-    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver, offerAudioTransceiver, answerAudioTransceiver;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver;
     RtcSessionDescriptionInit sdp;
     ATOMIC_BOOL seenFirstFrame = FALSE;
     Frame videoFrame;

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -599,6 +599,115 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersExpectFailureBecauseNoCan
     freePeerConnection(&answerPc);
 }
 
+TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
+{
+    struct Context {
+        MUTEX mutex;
+        ATOMIC_BOOL done;
+        CVAR cvar;
+    };
+
+    RtcConfiguration configuration;
+    Context context;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack, offerAudioTrack, answerAudioTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver, offerAudioTransceiver, answerAudioTransceiver;
+    RtcSessionDescriptionInit sdp;
+    ATOMIC_BOOL seenFirstFrame = FALSE;
+    Frame videoFrame;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+
+    videoFrame.frameData = (PBYTE) MEMALLOC(1);
+    videoFrame.size = 1;
+    videoFrame.presentationTs = 0;
+
+    context.mutex = MUTEX_CREATE(FALSE);
+    ASSERT_NE(context.mutex, INVALID_MUTEX_VALUE);
+    context.cvar = CVAR_CREATE();
+    ASSERT_NE(context.cvar, INVALID_CVAR_VALUE);
+    ATOMIC_STORE_BOOL(&context.done, FALSE);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+
+    auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
+        UNUSED_PARAM(pFrame);
+        if (pFrame->frameData[0] == 1) {
+            ATOMIC_STORE_BOOL((PSIZE_T) customData, 1);
+        }
+    };
+    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &seenFirstFrame, onFrameHandler), STATUS_SUCCESS);
+
+    auto onICECandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
+        if (candidateStr != NULL) {
+            std::thread(
+                [customData](std::string candidate) {
+                    RtcIceCandidateInit iceCandidate;
+                    EXPECT_EQ(STATUS_SUCCESS, deserializeRtcIceCandidateInit((PCHAR) candidate.c_str(), STRLEN(candidate.c_str()), &iceCandidate));
+                    EXPECT_EQ(STATUS_SUCCESS, addIceCandidate((PRtcPeerConnection) customData, iceCandidate.candidate));
+                },
+                std::string(candidateStr))
+                .detach();
+        }
+    };
+
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) answerPc, onICECandidateHdlr));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) offerPc, onICECandidateHdlr));
+
+    auto onICEConnectionStateChangeHdlr = [](UINT64 customData, RTC_PEER_CONNECTION_STATE newState) -> void {
+        Context* pContext = (Context*) customData;
+
+        if (newState == RTC_PEER_CONNECTION_STATE_CONNECTED) {
+            ATOMIC_STORE_BOOL(&pContext->done, TRUE);
+            CVAR_SIGNAL(pContext->cvar);
+        }
+    };
+
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnConnectionStateChange(offerPc, (UINT64) &context, onICEConnectionStateChangeHdlr));
+
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(offerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(answerPc, &sdp));
+
+    EXPECT_EQ(STATUS_SUCCESS, createAnswer(answerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(answerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(offerPc, &sdp));
+
+    MUTEX_LOCK(context.mutex);
+    while (!ATOMIC_LOAD_BOOL(&context.done)) {
+        CVAR_WAIT(context.cvar, context.mutex, INFINITE_TIME_VALUE);
+    }
+    MUTEX_UNLOCK(context.mutex);
+
+    for (BYTE i = 1; i <= 3; i++) {
+        videoFrame.frameData[0] = i;
+        EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+        videoFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 25);
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND / 25);
+    }
+
+    for (auto i = 0; i <= 1000 && !ATOMIC_LOAD_BOOL(&seenFirstFrame); i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    }
+
+    MEMFREE(videoFrame.frameData);
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+
+    CVAR_FREE(context.cvar);
+    MUTEX_FREE(context.mutex);
+
+    EXPECT_EQ(ATOMIC_LOAD_BOOL(&seenFirstFrame), TRUE);
+}
+
 // Assert that two PeerConnections can connect and then send media until the receiver gets both audio/video
 TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
 {


### PR DESCRIPTION
The startup latency is measured with the following procedures:
  * Modified the JS example, https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html,
    which basically listen to "loadeddata" event which basically it lets us
    know when the video starts flowing on the UI. When this event happens,
    it send a data channel message to the Webrtc C SDK
  * Modified the Webrtc C sample to measure the duration between connected
    to the time when it receives the data channel message from the UI

In my test, I got ~9 s delay. After the fix, the delay became ~80 ms.

The issue was that we started sending frames when the connection was still
not ready. Consequently, the first I-frame was lost, and the receiver needs
to wait until the next I-frame. So, for the delay itself, it'll be varied
depending on the configured keyframe interval. With our stock sample, I
calculated the delay to be ~8 s, which is matched to the observed delay.

The details about the sample video:
  * Keyframe interval is 250
  * Frame lost: first 16 frames
  * Frame per second: 30
  * Initial delay: (Keyframe interval - frame lost) / frame per second = 7.8 s

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
