### PR TITLE
transport wide congestion control

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -921,6 +921,22 @@ CleanUp:
     return retStatus;
 }
 
+/**
+ *  @brief parses string of form "$number $whatever" returns $number as uint32
+ *  @return 0 if value is not parsable or null
+ */
+UINT32 parseExtId(PCHAR extmapValue)
+{
+    UINT32 extid = 0;
+    if (extmapValue == NULL && STRCHR(extmapValue, ' ') == NULL) {
+        return 0;
+    }
+    if (STATUS_FAILED(STRTOUI32(extmapValue, STRCHR(extmapValue, ' '), 10, &extid))) {
+        return 0;
+    }
+    return extid;
+}
+
 STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescriptionInit pSessionDescriptionInit)
 {
     ENTERS();
@@ -979,6 +995,9 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
                 NULLABLE_SET_VALUE(pKvsPeerConnection->canTrickleIce, TRUE);
                 // This code is only here because Chrome does NOT adhere to the standard and adds ice-options as a media level attribute
                 // The standard dictates clearly that it should be a session level attribute:  https://tools.ietf.org/html/rfc5245#page-76
+            } else if (STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "extmap") == 0 &&
+                       STRSTR(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, TWCC_EXT_URL) != NULL) {
+                pKvsPeerConnection->twccExtId = parseExtId(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue);
             }
         }
     }

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -43,8 +43,19 @@ typedef enum {
     RTC_RTX_CODEC_VP8 = 2,
 } RTX_CODEC;
 
+// congestion control callbacks
+typedef VOID (*RtcpCCOnPacketNotReceived)(UINT64 customData, UINT16 seqNum);
+typedef VOID (*RtcpCCOnPacketReceived)(UINT64 customData, UINT16 seqNum, INT32 receiveDeltaUsec);
+
 typedef struct {
     RtcPeerConnection peerConnection;
+    // UINT32 padding padding makes transportWideSequenceNumber 64bit aligned
+    // we put atomics at the top of structs because customers application could set the packing to 0
+    // in which case any atomic operations would result in bus errors if there is a misalignment
+    // for more see https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/987#discussion_r534432907
+    UINT32 padding;
+    volatile SIZE_T transportWideSequenceNumber;
+
     PIceAgent pIceAgent;
     PDtlsSession pDtlsSession;
     BOOL dtlsIsServer;
@@ -99,6 +110,14 @@ typedef struct {
     UINT16 MTU;
 
     NullableBool canTrickleIce;
+
+    // congestion control
+    // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
+    UINT16 twccExtId;
+    UINT64 onPacketNotReceivedCustomData;
+    UINT64 onPacketReceivedCustomData;
+    RtcpCCOnPacketNotReceived onPacketNotReceived;
+    RtcpCCOnPacketReceived onPacketReceived;
 } KvsPeerConnection, *PKvsPeerConnection;
 
 typedef struct {

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -10,6 +10,32 @@ extern "C" {
 STATUS onRtcpPacket(PKvsPeerConnection, PBYTE, UINT32);
 STATUS onRtcpRembPacket(PRtcpPacket, PKvsPeerConnection);
 STATUS onRtcpPLIPacket(PRtcpPacket, PKvsPeerConnection);
+STATUS onRtcpTwccPacket(PRtcpPacket, PKvsPeerConnection);
+
+// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
+// Deltas are represented as multiples of 250us:
+#define TWCC_TICKS_PER_SECOND   (1000000LL / 250)
+#define MICROSECONDS_PER_SECOND 1000000LL
+typedef enum {
+    TWCC_STATUS_SYMBOL_NOTRECEIVED = 0,
+    TWCC_STATUS_SYMBOL_SMALLDELTA,
+    TWCC_STATUS_SYMBOL_LARGEDELTA,
+} TWCC_STATUS_SYMBOL;
+
+#define TWCC_FB_PACKETCHUNK_SIZE               2
+#define IS_TWCC_RUNLEN(packetChunk)            ((((packetChunk) >> 15u) & 1u) == 0)
+#define TWCC_RUNLEN_STATUS_SYMBOL(packetChunk) (((packetChunk) >> 13u) & 3u)
+#define TWCC_RUNLEN_GET(packetChunk)           ((packetChunk) &0x1fffu)
+#define TWCC_IS_NOTRECEIVED(statusSymbol)      ((statusSymbol) == TWCC_STATUS_SYMBOL_NOTRECEIVED)
+#define TWCC_ISRECEIVED(statusSymbol)          ((statusSymbol) == TWCC_STATUS_SYMBOL_SMALLDELTA || (statusSymbol) == TWCC_STATUS_SYMBOL_LARGEDELTA)
+#define TWCC_RUNLEN_ISRECEIVED(packetChunk)    TWCC_ISRECEIVED(TWCC_RUNLEN_STATUS_SYMBOL(packetChunk))
+#define TWCC_STATUSVECTOR_IS_2BIT(packetChunk) (((packetChunk) >> 14u) & 1u)
+#define TWCC_STATUSVECTOR_SSIZE(packetChunk)   (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 2u : 1u)
+#define TWCC_STATUSVECTOR_SMASK(packetChunk)   (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 2u : 1u)
+#define TWCC_STATUSVECTOR_STATUS(packetChunk, i)                                                                                                     \
+    (((packetChunk) >> (14u - (i) *TWCC_STATUSVECTOR_SSIZE(packetChunk))) & TWCC_STATUSVECTOR_SMASK(packetChunk))
+#define TWCC_STATUSVECTOR_COUNT(packetChunk) (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 7 : 14)
+#define TWCC_PACKET_STATUS_COUNT(payload)    (getUnalignedInt16BigEndian((payload) + 10))
 
 #ifdef __cplusplus
 }

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -623,6 +623,12 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     SPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "%" PRId64 " nack", payloadType);
     attributeCount++;
 
+    if (pKvsPeerConnection->twccExtId != 0) {
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-fb");
+        SPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "%" PRId64 " " TWCC_SDP_ATTR, payloadType);
+        attributeCount++;
+    }
+
     pSdpMediaDescription->mediaAttributesCount = attributeCount;
 
 CleanUp:

--- a/src/source/PeerConnection/SessionDescription.h
+++ b/src/source/PeerConnection/SessionDescription.h
@@ -71,6 +71,10 @@ extern "C" {
 #define OPUS_CLOCKRATE  (UINT64) 48000
 #define PCM_CLOCKRATE   (UINT64) 8000
 
+// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
+#define TWCC_SDP_ATTR "transport-cc"
+#define TWCC_EXT_URL  "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
+
 STATUS setPayloadTypesFromOffer(PHashTable, PHashTable, PSessionDescription);
 STATUS setPayloadTypesForOffer(PHashTable);
 

--- a/src/source/Rtp/RtpPacket.h
+++ b/src/source/Rtp/RtpPacket.h
@@ -34,6 +34,20 @@ extern "C" {
 
 #define GET_UINT16_SEQ_NUM(seqIndex) ((UINT16)((seqIndex) % (MAX_UINT16 + 1)))
 
+/*
+ *
+     0                   1                   2                   3
+      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |       0xBE    |    0xDE       |           length=1            |
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     |  ID   | L=1   |transport-wide sequence number | zero padding  |
+     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+// https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
+#define TWCC_EXT_PROFILE                 0xBEDE
+#define TWCC_PAYLOAD(extId, sequenceNum) htonl((((extId) &0xfu) << 28u) | (1u << 24u) | ((UINT32)(sequenceNum) << 8u))
+
 typedef STATUS (*DepayRtpPayloadFunc)(PBYTE, UINT32, PBYTE, PUINT32, PBOOL);
 
 /*

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -809,6 +809,52 @@ a=ice-options:trickle
     });
 }
 
+const auto sdpext = R"(v=0
+o=- 4936640868317839377 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0 1
+a=msid-semantic: WMS IorFnFnF3tBWrBDrWkOrWg3zowztGU0DXDCG
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 102 121 127 120 125 107 108 109 124 119 123 118 114 115 116
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:SNHT
+a=ice-pwd:aAU8vF42EO01/2WuVLJ+5kXU
+a=ice-options:trickle
+a=fingerprint:sha-256 07:A5:92:00:70:B3:51:ED:3E:F5:D4:D1:93:D4:3E:ED:69:5F:9E:81:03:6B:B2:AC:48:D7:35:E4:48:75:B5:91
+a=setup:actpass
+a=mid:0
+a=extmap:1 urn:ietf:params:rtp-hdrext:toffset
+a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+a=extmap:3 urn:3gpp:video-orientation
+a=extmap:4 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
+a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
+a=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing
+a=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space
+a=extmap:9 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:10 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
+a=extmap:11 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
+)";
+
+TEST_F(SdpApiTest, twccExtension)
+{
+    SessionDescription sd{};
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sd, const_cast<PCHAR>(sdpext)));
+    uint32_t extid = 0;
+    for (int i = 0; i < sd.mediaDescriptions[0].mediaAttributesCount; i++) {
+        if (!strncmp("extmap", sd.mediaDescriptions[0].sdpAttributes[i].attributeName, 6)) {
+            auto split = strchr(sd.mediaDescriptions[0].sdpAttributes[i].attributeValue, ' ');
+            if (split != nullptr) {
+                if (!strncmp(TWCC_EXT_URL, split + 1, strlen(TWCC_EXT_URL))) {
+                    EXPECT_EQ(STATUS_SUCCESS, strtoui32(sd.mediaDescriptions[0].sdpAttributes[i].attributeValue, split, 10, &extid));
+                }
+            }
+        }
+    }
+    EXPECT_EQ(4, extid);
+}
+
 TEST_F(SdpApiTest, populateSingleMediaSection_TestPayloadFmtp)
 {
     CHAR remoteSessionDescription[] = R"(v=0


### PR DESCRIPTION
*Description of changes:*

implements transport wide congestion control packet parsing and sending as described here https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01

- [x] SDP negotiation
- [x] parse twcc rtcp reports
- [x] conditionally send twcc extension in RTP packets
- [ ] implement congestion control (out of scope), will implement in upcoming PRs, most likely according to https://tools.ietf.org/html/draft-ietf-rmcat-gcc-02

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
