### PR TITLE
ICE configuration refresh functionality changes

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -699,7 +699,7 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
     pSampleConfiguration->channelInfo.channelRoleType = roleType;
     pSampleConfiguration->channelInfo.cachingPolicy = SIGNALING_API_CALL_CACHE_TYPE_FILE;
     pSampleConfiguration->channelInfo.cachingPeriod = SIGNALING_API_CALL_CACHE_TTL_SENTINEL_VALUE;
-    pSampleConfiguration->channelInfo.asyncIceServerConfig = TRUE;
+    pSampleConfiguration->channelInfo.asyncIceServerConfig = TRUE; // has no effect
     pSampleConfiguration->channelInfo.retry = TRUE;
     pSampleConfiguration->channelInfo.reconnect = TRUE;
     pSampleConfiguration->channelInfo.pCertPath = pSampleConfiguration->pCaCertPath;

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1202,8 +1202,10 @@ typedef struct {
 
     SIGNALING_API_CALL_CACHE_TYPE cachingPolicy; //!< Backend API call caching policy
 
-    BOOL asyncIceServerConfig; //!< When creating channel synchronously, do not await for the ICE
-                               //!< server configurations before returning from the call.
+    BOOL asyncIceServerConfig; //!< This parameter has no effect any longer. All ICE config retrieving
+                               //!< is done reactively when needed which will simplify the processing
+                               //!< and will help with issues on a small footprint platforms
+
 } ChannelInfo, *PChannelInfo;
 
 /**

--- a/src/source/Signaling/ChannelInfo.c
+++ b/src/source/Signaling/ChannelInfo.c
@@ -96,10 +96,8 @@ STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* pp
     // V1 handling
     if (pOrigChannelInfo->version > 0) {
         pChannelInfo->cachingPolicy = pOrigChannelInfo->cachingPolicy;
-        pChannelInfo->asyncIceServerConfig = pOrigChannelInfo->asyncIceServerConfig;
     } else {
         pChannelInfo->cachingPolicy = SIGNALING_API_CALL_CACHE_TYPE_NONE;
-        pChannelInfo->asyncIceServerConfig = FALSE;
     }
 
     // Set the current pointer to the end

--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -619,9 +619,6 @@ STATUS executeReadySignalingState(UINT64 customData, UINT64 time)
                                                                             SIGNALING_CLIENT_STATE_READY));
     }
 
-    // Ensure we won't async the GetIceConfig as we reach the ready state
-    ATOMIC_STORE_BOOL(&pSignalingClient->asyncGetIceConfig, FALSE);
-
     if (pSignalingClient->continueOnReady) {
         // Self-prime the connect
         CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -1610,7 +1610,7 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedAuthExpirat
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaultInjectionRevovered)
+TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaultInjectionRecovered)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -1724,7 +1724,7 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultInjectionRevovered)
+TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultInjectionRecovered)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -1840,7 +1840,7 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaultInjectionNotRevovered)
+TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaultInjectionNotRecovered)
 {
     if (!mAccessKeyIdSet) {
         return;
@@ -1952,7 +1952,7 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
 }
 
-TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultInjectionNotRevovered)
+TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultInjectionNot1669)
 {
     if (!mAccessKeyIdSet) {
         return;

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -528,8 +528,11 @@ race:getIceConfig
 race:PeerConnectionFunctionalityTest_freeTurnDueToP2PFoundBeforeTurnEstablished_Test
 race:PeerConnectionFunctionalityTest_freeTurnDueToP2PFoundAfterTurnEstablished
 race:DataChannelFunctionalityTest_createDataChannel_Disconnected_Test
-race:SignalingApiFunctionalityTest_iceRefreshEmulationWithFaultInjectionErrorDisconnect_Test
-race:SignalingApiFunctionalityTest_iceRefreshEmulationWithFaultInjectionErrorDisconnectNoRecovery_Test
+
+# in this case we are trying to mock a bad auth by directly modifying the internal buffer storing
+# the secret key which might in some cases be raced if the SDK detects a disconnect and the listener
+# thread is attempting to reconnect while we are emulating test.
+race:SignalingApiFunctionalityTest_iceServerConfigRefreshConnectedWithBadAuth_Test
 
 race:getDataChannelStats
 # WARNING: ThreadSanitizer: data race (pid=51832)


### PR DESCRIPTION
* Removing async ICE functionality to avoid issues with low footprint devices and parallel execution. This also has no benefits for "master" scenario. Embedded WebRTC based viewers might incur some latency hits as for the "viewer" the ICE configuration is on the "hot" path.
* Removing periodic ICE refresh. Now, it's done on access if the ICE hasn't been retrieved or whenever the ICE credentials have expired.
* Removing timer queue from the signaling client as it's no longer needed.
* The existing state machinery is unchanged and the change is very targeted and limited.
* Extra test coverage

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
