### PR TITLE
Update mbedTLS

### DIFF
--- a/CMake/Dependencies/libmbedtls-CMakeLists.txt
+++ b/CMake/Dependencies/libmbedtls-CMakeLists.txt
@@ -18,9 +18,8 @@ endif()
 
 ExternalProject_Add(
   project_libmbedtls
-  # TODO: needs to replace this with official mbedTLS release version
   GIT_REPOSITORY  https://github.com/ARMmbed/mbedtls.git
-  GIT_TAG         868906cd0658ce91ca841af6f09d76846ef86d1b
+  GIT_TAG         v2.25.0
   PREFIX          ${CMAKE_CURRENT_BINARY_DIR}/build
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/README.md
+++ b/README.md
@@ -225,6 +225,14 @@ where, `configuration` is of type `RtcConfiguration` in the function that calls 
 Doing this will make sure that `createCertificateAndKey() would not execute since a certificate is already available.`
 ```
 
+## Provide Hardware Entropy Source
+
+In the mbedTLS version, the SDK uses /dev/urandom on Unix and CryptGenRandom API on Windows to get a strong entropy source. On some systems, these APIs might not be available. So, it's **strongly suggested** that you bring your own hardware entropy source. To do this, you need to follow these steps:
+
+1. Uncomment `MBEDTLS_ENTROPY_HARDWARE_ALT` in configs/config_mbedtls.h
+2. Write your own entropy source implementation by following this function signature: https://github.com/ARMmbed/mbedtls/blob/v2.25.0/include/mbedtls/entropy_poll.h#L81-L92
+3. Include your implementation source code in the linking process
+
 ## DEBUG
 ### Getting the SDPs
 If you would like to print out the SDPs, run this command:

--- a/configs/config_mbedtls.h
+++ b/configs/config_mbedtls.h
@@ -10,6 +10,28 @@ extern "C" {
 // enable DTLS-SRTP extension
 #define MBEDTLS_SSL_DTLS_SRTP
 
+// disable TLS 1.0 and 1.1 as they should be deprecated in major browser vendors
+#undef MBEDTLS_SSL_CBC_RECORD_SPLITTING
+#undef MBEDTLS_SSL_PROTO_TLS1
+#undef MBEDTLS_SSL_PROTO_TLS1_1
+
+// disable because they don't comply with AWS security standard
+#undef MBEDTLS_ECP_DP_SECP224K1_ENABLED
+#undef MBEDTLS_ECP_DP_SECP256K1_ENABLED
+
+/**
+ * \def MBEDTLS_ENTROPY_HARDWARE_ALT
+ *
+ * Uncomment this macro to let mbed TLS use your own implementation of a
+ * hardware entropy collector.
+ *
+ * Your function must be called \c mbedtls_hardware_poll(), have the same
+ * prototype as declared in entropy_poll.h, and accept NULL as first argument.
+ *
+ * Uncomment to use your own hardware entropy collector.
+ */
+//#define MBEDTLS_ENTROPY_HARDWARE_ALT
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -28,6 +28,7 @@ STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEU
     mbedtls_ctr_drbg_init(&pDtlsSession->ctrDrbg);
     mbedtls_ssl_config_init(&pDtlsSession->sslCtxConfig);
     mbedtls_ssl_init(&pDtlsSession->sslCtx);
+    mbedtls_ctr_drbg_set_prediction_resistance(&pDtlsSession->ctrDrbg, MBEDTLS_CTR_DRBG_PR_ON);
     CHK(mbedtls_ctr_drbg_seed(&pDtlsSession->ctrDrbg, mbedtls_entropy_func, &pDtlsSession->entropy, NULL, 0) == 0, STATUS_CREATE_SSL_FAILED);
 
     CHK_STATUS(createIOBuffer(DEFAULT_MTU_SIZE, &pDtlsSession->pReadBuffer));


### PR DESCRIPTION
Changes:
  * Update mbedTLS config to comply to AWS security standard
  * Enable drbg prediction resistance
  * Update mbedTLS to the official v2.25.0
  * Add hardware entropy source documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
