### PR TITLE
socketConnectionClosed: Check mutex before lock/unlock

### DIFF
--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -236,13 +236,17 @@ STATUS socketConnectionClosed(PSocketConnection pSocketConnection)
 
     CHK(pSocketConnection != NULL, STATUS_NULL_ARG);
     CHK(!ATOMIC_LOAD_BOOL(&pSocketConnection->connectionClosed), retStatus);
-    MUTEX_LOCK(pSocketConnection->lock);
+    if (IS_VALID_MUTEX_VALUE(pSocketConnection->lock)) {
+        MUTEX_LOCK(pSocketConnection->lock);
+    }
     DLOGD("Close socket %d", pSocketConnection->localSocket);
     ATOMIC_STORE_BOOL(&pSocketConnection->connectionClosed, TRUE);
     if (pSocketConnection->pTlsSession != NULL) {
         tlsSessionShutdown(pSocketConnection->pTlsSession);
     }
-    MUTEX_UNLOCK(pSocketConnection->lock);
+    if (IS_VALID_MUTEX_VALUE(pSocketConnection->lock)) {
+        MUTEX_UNLOCK(pSocketConnection->lock);
+    }
 
 CleanUp:
 


### PR DESCRIPTION
Signed-off-by: Alex.Li <zhiqinli@amazon.com>

*Issue #, if available:*
#995 
*Description of changes:*
socketConnectionClosed: Check mutex before lock/unlock

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
