### PR TITLE
Fixing the SocketConnection teardown path to not use CHK_STATUS and s…

### DIFF
--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -74,7 +74,9 @@ STATUS freeSocketConnection(PSocketConnection* ppSocketConnection)
         freeTlsSession(&pSocketConnection->pTlsSession);
     }
 
-    CHK_STATUS(closeSocket(pSocketConnection->localSocket));
+    if (STATUS_FAILED(retStatus = closeSocket(pSocketConnection->localSocket))) {
+        DLOGW("Failed to close the local socket with 0x%08x", retStatus);
+    }
 
     MEMFREE(pSocketConnection);
 


### PR DESCRIPTION
…kip over further destruction of the object

Issue #https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/996

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
