### PR TITLE
Signaling: Fix possible null access in freeSignaling

### DIFF
--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -97,8 +97,6 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     creationInfo.ka_interval = SIGNALING_SERVICE_TCP_KEEPALIVE_PROBE_INTERVAL_IN_SECONDS;
     creationInfo.ws_ping_pong_interval = SIGNALING_SERVICE_WSS_PING_PONG_INTERVAL_IN_SECONDS;
 
-    CHK(NULL != (pSignalingClient->pLwsContext = lws_create_context(&creationInfo)), STATUS_SIGNALING_LWS_CREATE_CONTEXT_FAILED);
-
     ATOMIC_STORE_BOOL(&pSignalingClient->clientReady, FALSE);
     ATOMIC_STORE_BOOL(&pSignalingClient->shutdown, FALSE);
     ATOMIC_STORE_BOOL(&pSignalingClient->connected, FALSE);
@@ -140,6 +138,9 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
 
     // Create the ongoing message list
     CHK_STATUS(stackQueueCreate(&pSignalingClient->pMessageQueue));
+
+    pSignalingClient->pLwsContext = lws_create_context(&creationInfo);
+    CHK(pSignalingClient->pLwsContext != NULL, STATUS_SIGNALING_LWS_CREATE_CONTEXT_FAILED);
 
     // Initializing the diagnostics mostly is taken care of by zero-mem in MEMCALLOC
     pSignalingClient->diagnostics.createTime = GETTIME();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Possible null access when:

1. https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/b9e41d1c114acd50da3e72b05d486ebb1a0d2ff7/src/source/Signaling/Signaling.c#L132 failed, `pSignalingClient->lwsServiceLock` is invalid, goto CleanUp and call `freeSignaling`
2. https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/b9e41d1c114acd50da3e72b05d486ebb1a0d2ff7/src/source/Signaling/Signaling.c#L198


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
