### PR TITLE
docs: fix simple typo, registeration -> registration

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1280,7 +1280,7 @@ typedef STATUS (*SignalingClientStateChangedFunc)(UINT64, SIGNALING_CLIENT_STATE
 typedef struct {
     UINT32 version;                                       //!< Current version of the structure
     UINT64 customData;                                    //!< Custom data passed by the caller
-    SignalingClientMessageReceivedFunc messageReceivedFn; //!< Callback registeration for received SDP
+    SignalingClientMessageReceivedFunc messageReceivedFn; //!< Callback registration for received SDP
     SignalingClientErrorReportFunc errorReportFn;         //!<  Error reporting function. This is an optional member
     SignalingClientStateChangedFunc stateChangeFn;        //!< Signaling client state change callback
 } SignalingClientCallbacks, *PSignalingClientCallbacks;


### PR DESCRIPTION
There is a small typo in src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h.

Should read `registration` rather than `registeration`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md