### PR TITLE
Move to linux from osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,11 @@ matrix:
   include:
     #clang check
     - name: "clang-format Check"
-      os: osx
+      os: linux
       compiler: clang
       before_script:
-        - brew install clang-format
+        - sudo apt-get -q update
+        - sudo apt-get -y install clang-format
         - mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE
       script:
         - cd ..


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- It looks like there are some issues with clang-format install on MacOS Sierra hosts that travisCI uses. Since, all we need to do is check formatting, the type of host does not matter. Linux is more stable and hence this PR moves clang-format check from OSX to Linux.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
