### PR TITLE
README: Fix incorrect profiler option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ complies, use the `scripts/check-clang.sh` to check for compliance and `scripts/
 
 ## Tracing high memory and/or cpu usage
 If you would like to specifically find the code path that causes high memory and/or cpu usage, you need to recompile the SDK with this command:
-`cmake .. -DENABLE_PROFILE=ON`
+`cmake .. -DLINK_PROFILER=ON`
 
 The flag will link the SDK with [gperftools](https://github.com/gperftools/gperftools) profiler.
 


### PR DESCRIPTION
Signed-off-by: Alex.Li <zhiqinli@amazon.com>

*Issue #, if available:*

*Description of changes:*
In CMakeLists:

https://github.com/codingspirit/amazon-kinesis-video-streams-webrtc-sdk-c/blob/42c249e0be61840e607c8c7666c8f8eb9f18003d/CMakeLists.txt#L30

So in readme should be `LINK_PROFILER`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
