### PR TITLE
Generating pseudo-random SN for the self-signed cert as FireFox fails…

### DIFF
--- a/src/source/Crypto/Dtls.c
+++ b/src/source/Crypto/Dtls.c
@@ -78,3 +78,22 @@ CleanUp:
     LEAVES();
     return retStatus;
 }
+
+STATUS dtlsFillPseudoRandomBits(PBYTE pBuf, UINT32 bufSize)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 i;
+
+    CHK(pBuf != NULL, STATUS_NULL_ARG);
+    CHK(bufSize >= DTLS_CERT_MIN_SERIAL_NUM_SIZE && bufSize <= DTLS_CERT_MAX_SERIAL_NUM_SIZE, retStatus);
+
+    for (i = 0; i < bufSize; i++) {
+        *pBuf++ = (BYTE)(RAND() & 0xFF);
+    }
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}

--- a/src/source/Crypto/Dtls.h
+++ b/src/source/Crypto/Dtls.h
@@ -18,7 +18,8 @@ extern "C" {
 
 #define GENERATED_CERTIFICATE_MAX_SIZE 4096
 #define GENERATED_CERTIFICATE_BITS     2048
-#define GENERATED_CERTIFICATE_SERIAL   1
+#define DTLS_CERT_MIN_SERIAL_NUM_SIZE  8
+#define DTLS_CERT_MAX_SERIAL_NUM_SIZE  20
 #define GENERATED_CERTIFICATE_DAYS     365
 #define GENERATED_CERTIFICATE_NAME     "KVS-WebRTC-Client"
 #define KEYING_EXTRACTOR_LABEL         "EXTRACTOR-dtls_srtp"
@@ -170,6 +171,8 @@ STATUS dtlsSessionOnStateChange(PDtlsSession, UINT64, DtlsSessionOnStateChange);
 /******** Internal Functions **********/
 STATUS dtlsValidateRtcCertificates(PRtcCertificate, PUINT32);
 STATUS dtlsSessionChangeState(PDtlsSession, RTC_DTLS_TRANSPORT_STATE);
+
+STATUS dtlsFillPseudoRandomBits(PBYTE, UINT32);
 
 #ifdef KVS_USE_OPENSSL
 STATUS dtlsCheckOutgoingDataBuffer(PDtlsSession);

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -611,6 +611,7 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     mbedtls_ctr_drbg_context* pCtrDrbg = NULL;
     mbedtls_mpi serial;
     mbedtls_x509write_cert* pWriteCert = NULL;
+    BYTE certSn[DTLS_CERT_MAX_SERIAL_NUM_SIZE];
 
     CHK(pCert != NULL && pKey != NULL, STATUS_NULL_ARG);
 
@@ -618,6 +619,7 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     CHK(NULL != (pEntropy = (mbedtls_entropy_context*) MEMALLOC(SIZEOF(mbedtls_entropy_context))), STATUS_NOT_ENOUGH_MEMORY);
     CHK(NULL != (pCtrDrbg = (mbedtls_ctr_drbg_context*) MEMALLOC(SIZEOF(mbedtls_ctr_drbg_context))), STATUS_NOT_ENOUGH_MEMORY);
     CHK(NULL != (pWriteCert = (mbedtls_x509write_cert*) MEMALLOC(SIZEOF(mbedtls_x509write_cert))), STATUS_NOT_ENOUGH_MEMORY);
+    CHK_STATUS(dtlsFillPseudoRandomBits(certSn, SIZEOF(certSn)));
 
     // initialize to sane values
     mbedtls_entropy_init(pEntropy);
@@ -641,7 +643,7 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     }
 
     // generate a new certificate
-    CHK(mbedtls_mpi_read_string(&serial, 10, STR(GENERATED_CERTIFICATE_SERIAL)) == 0, STATUS_CERTIFICATE_GENERATION_FAILED);
+    CHK(mbedtls_mpi_read_binary(&serial, certSn, SIZEOF(certSn)) == 0, STATUS_CERTIFICATE_GENERATION_FAILED);
 
     now = GETTIME();
     CHK(generateTimestampStr(now, "%Y%m%d%H%M%S", notBeforeBuf, SIZEOF(notBeforeBuf), &written) == STATUS_SUCCESS,

--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -94,9 +94,11 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     X509_NAME* pX509Name = NULL;
     UINT32 eccGroup = 0;
     EC_KEY* eccKey = NULL;
+    UINT64 certSn;
 
     CHK(ppCert != NULL && ppPkey != NULL, STATUS_NULL_ARG);
     CHK((*ppPkey = EVP_PKEY_new()) != NULL, STATUS_CERTIFICATE_GENERATION_FAILED);
+    CHK_STATUS(dtlsFillPseudoRandomBits((PBYTE) &certSn, SIZEOF(UINT64)));
 
     if (generateRSACertificate) {
         CHK((pBne = BN_new()) != NULL, STATUS_CERTIFICATE_GENERATION_FAILED);
@@ -119,7 +121,7 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
 
     CHK((*ppCert = X509_new()) != NULL, STATUS_CERTIFICATE_GENERATION_FAILED);
     X509_set_version(*ppCert, 2);
-    ASN1_INTEGER_set(X509_get_serialNumber(*ppCert), GENERATED_CERTIFICATE_SERIAL);
+    ASN1_INTEGER_set_uint64(X509_get_serialNumber(*ppCert), certSn);
     X509_gmtime_adj(X509_get_notBefore(*ppCert), -1 * GENERATED_CERTIFICATE_DAYS * SECONDS_IN_A_DAY);
     X509_gmtime_adj(X509_get_notAfter(*ppCert), GENERATED_CERTIFICATE_DAYS * SECONDS_IN_A_DAY);
     CHK(X509_set_pubkey(*ppCert, *ppPkey) != 0, STATUS_CERTIFICATE_GENERATION_FAILED);

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -41,6 +41,7 @@ extern "C" {
 #include <mbedtls/error.h>
 #include <mbedtls/certs.h>
 #include <mbedtls/sha256.h>
+#include <mbedtls/md5.h>
 #endif
 
 #include <srtp2/srtp.h>


### PR DESCRIPTION
… to host two DTLS session with the same CA and SN. This is open for interpretation as the two certificates with the same CA and SN for DTLS session will be self-signed and will have different actual public/private key pairs so no security implications and the fingerprints will be different. However, to make this work with FireFox, we will be generating pseudo-random SNs. NOTE: This doesn't need to have a crypto-strength.

Issue #1050 1050

Generating pseudo-random SN for the self-signed cert.


NOTE: This has been tested on Chrome and on FireFox hosting two peer connections in parallel on the same page.
NOTE: This has been tested with OpenSSL and with mbedTLS.
NOTE: In order to make the API easy to use, I opted for 64bit randomness for OpenSSL. This is still plenty of entropy for this purpose.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
