### PR TITLE
Add option to build aws dependencies while using system 3rd party deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project(KinesisVideoWebRTCClient LANGUAGES C)
 # User Flags
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
 option(BUILD_DEPENDENCIES "Whether or not to build depending libraries from source" ON)
+option(BUILD_AWS_DEPENDENCIES "Whether or not to build depending AWS libraries from source" ON)
 option(USE_OPENSSL "Use openssl as crypto library" ON)
 option(USE_MBEDTLS "Use mbedtls as crypto library" OFF)
 option(BUILD_STATIC_LIBS "Build all libraries statically. (This includes third-party libraries.)" OFF)
@@ -142,18 +143,27 @@ if(BUILD_DEPENDENCIES)
   if (LINK_PROFILER)
     build_dependency(gperftools)
   endif()
+endif()
+
+if(BUILD_AWS_DEPENDENCIES OR BUILD_DEPENDENCIES)
+  set(OPEN_SRC_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/open-source)
+  if(NOT EXISTS ${OPEN_SRC_INSTALL_PREFIX})
+    file(MAKE_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX})
+  endif()
+
+  set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${OPEN_SRC_INSTALL_PREFIX}/lib/pkgconfig")
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${OPEN_SRC_INSTALL_PREFIX})
 
   # building kvsCommonLws also builds kvspic
   set(BUILD_ARGS
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-      -DUSE_OPENSSL=${USE_OPENSSL}
-      -DUSE_MBEDTLS=${USE_MBEDTLS}
-      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+  -DUSE_OPENSSL=${USE_OPENSSL}
+  -DUSE_MBEDTLS=${USE_MBEDTLS}
+  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
   build_dependency(kvsCommonLws ${BUILD_ARGS})
 
   message(STATUS "Finished building dependencies.")
 endif()
-
 ############# find dependent libraries ############
 
 find_package(Threads)

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -453,7 +453,7 @@ extern "C" {
 /**
  * Maximum length of signaling message
  */
-#define MAX_SIGNALING_MESSAGE_LEN (10 * 1024)
+#define MAX_SIGNALING_MESSAGE_LEN (10 * 4096)
 /*!@} */
 
 /////////////////////////////////////////////////////

--- a/src/source/Sdp/Sdp.h
+++ b/src/source/Sdp/Sdp.h
@@ -64,16 +64,16 @@ extern "C" {
 #define MAX_SDP_TOKEN_LENGTH 128
 #define MAX_SDP_FMTP_VALUES  64
 
-#define MAX_SDP_SESSION_BANDWIDTH_COUNT        2
-#define MAX_SDP_SESSION_TIME_DESCRIPTION_COUNT 2
-#define MAX_SDP_SESSION_TIMEZONE_COUNT         2
+#define MAX_SDP_SESSION_BANDWIDTH_COUNT        16
+#define MAX_SDP_SESSION_TIME_DESCRIPTION_COUNT 16
+#define MAX_SDP_SESSION_TIMEZONE_COUNT         16
 /**
  * https://tools.ietf.org/html/rfc4566#section-5.14
  *
  * reserving enough for audio, video, text, application and message for now
  */
-#define MAX_SDP_SESSION_MEDIA_COUNT   5
-#define MAX_SDP_MEDIA_BANDWIDTH_COUNT 2
+#define MAX_SDP_SESSION_MEDIA_COUNT   16
+#define MAX_SDP_MEDIA_BANDWIDTH_COUNT 16
 
 #define MAX_SDP_ATTRIBUTES_COUNT 128
 


### PR DESCRIPTION
On Ubuntu 20.04, all necessary 3rd party dependencies are available from the package manager, while AWS common libs are not. This PR adds a separate option to build the AWS dependencies even if system dependencies are not built from source