### PR TITLE
Display only messsage type and recipient client ID

### DIFF
--- a/src/source/Signaling/LwsApiCalls.h
+++ b/src/source/Signaling/LwsApiCalls.h
@@ -87,6 +87,7 @@ extern "C" {
 #define SIGNALING_GO_AWAY              "GO_AWAY"
 #define SIGNALING_RECONNECT_ICE_SERVER "RECONNECT_ICE_SERVER"
 #define SIGNALING_STATUS_RESPONSE      "STATUS_RESPONSE"
+#define SIGNALING_MESSAGE_UNKNOWN      "UNKNOWN"
 
 // Max length of the signaling message type string length
 #define MAX_SIGNALING_MESSAGE_TYPE_LEN ARRAY_SIZE(SIGNALING_RECONNECT_ICE_SERVER)
@@ -249,6 +250,7 @@ STATUS writeLwsData(PSignalingClient, BOOL);
 STATUS terminateLwsListenerLoop(PSignalingClient);
 STATUS receiveLwsMessage(PSignalingClient, PCHAR, UINT32);
 STATUS getMessageTypeFromString(PCHAR, UINT32, SIGNALING_MESSAGE_TYPE*);
+PCHAR getMessageTypeInString(SIGNALING_MESSAGE_TYPE);
 STATUS wakeLwsServiceEventLoop(PSignalingClient, UINT32);
 STATUS terminateConnectionWithStatus(PSignalingClient, SERVICE_CALL_RESULT);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While logging the payload that is sent from the embedded SDK, in case of sending an offer, we end up logging the credentials for the ICE Servers which is part of the OFFER payload. This PR fixes it by just logging necessary information (type of message being sent and recipient ID) to keep the information to a minimum.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
