### PR TITLE
prevent deadlock when calling onSenderBandwidthEstimation callback

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -319,6 +319,8 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
     }
 
     if (duration > 0) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+        locked = FALSE;
         pKvsPeerConnection->onSenderBandwidthEstimation(pKvsPeerConnection->onSenderBandwidthEstimationCustomData, sentBytes, receivedBytes,
                                                         sentPackets, receivedPackets, duration);
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1115

*Description of changes:*
call sender estimation callback with twcclock unlocked to prevent potential deadlock


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
