### PR TITLE
Check the TWCC manager before use

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1403,6 +1403,7 @@ STATUS twccManagerOnPacketSent(PKvsPeerConnection pc, PRtpPacket pRtpPacket)
     BOOL isEmpty = FALSE;
     INT64 firstTimeKvs, lastLocalTimeKvs, ageOfOldest;
     CHK(pc != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
+    CHK(pc->onSenderBandwidthEstimation != NULL && pc->pTwccManager != NULL, STATUS_SUCCESS);
     CHK(TWCC_EXT_PROFILE == pRtpPacket->header.extensionProfile, STATUS_SUCCESS);
 
     MUTEX_LOCK(pc->twccLock);


### PR DESCRIPTION
When disableSenderSideBandwidthEstimation is set to TRUE, it will cause Segmentation fault

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
