### PR TITLE
set correct peer connection state

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -396,6 +396,7 @@ VOID onIceConnectionStateChange(UINT64 customData, UINT64 connectionState)
             /* explicit fall-through */
         case ICE_AGENT_STATE_READY:
             /* start dtlsSession as soon as ice is connected */
+            newConnectionState = RTC_PEER_CONNECTION_STATE_CONNECTING;
             startDtlsSession = TRUE;
             break;
 

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -146,6 +146,9 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection, PBYTE, UINT32);
 STATUS changePeerConnectionState(PKvsPeerConnection, RTC_PEER_CONNECTION_STATE);
 STATUS twccManagerOnPacketSent(PKvsPeerConnection, PRtpPacket);
 
+// visible for testing only
+VOID onIceConnectionStateChange(UINT64, UINT64);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
*Description of changes:*

before:
`ICE_AGENT_STATE_READY` translated into `RTC_PEER_CONNECTION_STATE_NEW` if dtls is not connected  

now:
`ICE_AGENT_STATE_READY`  -> `RTC_PEER_CONNECTION_STATE_CONNECTING` if dtls is not connected   

both before and now:
`RTC_PEER_CONNECTION_STATE_CONNECTED` if dtls is connected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
