### PR TITLE
Update createRtpPacketFromBytes(), fix double free

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -201,6 +201,9 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
             CHK(NULL != (pPayload = (PBYTE) MEMALLOC(bufferLen)), STATUS_NOT_ENOUGH_MEMORY);
             MEMCPY(pPayload, pBuffer, bufferLen);
             CHK_STATUS(createRtpPacketFromBytes(pPayload, bufferLen, &pRtpPacket));
+            // pRtpPacket took ownership of pPayload. Set pPayload to NULL to
+            // avoid possible double-free.
+            pPayload = NULL;
             pRtpPacket->receivedTime = now;
 
             // https://tools.ietf.org/html/rfc3550#section-6.4.1

--- a/src/source/Rtcp/RtpRollingBuffer.c
+++ b/src/source/Rtcp/RtpRollingBuffer.c
@@ -64,11 +64,14 @@ STATUS rtpRollingBufferAddRtpPacket(PRtpRollingBuffer pRollingBuffer, PRtpPacket
     CHK(pRawPacketCopy != NULL, STATUS_NOT_ENOUGH_MEMORY);
     MEMCPY(pRawPacketCopy, pRtpPacket->pRawPacket, pRtpPacket->rawPacketLength);
     CHK_STATUS(createRtpPacketFromBytes(pRawPacketCopy, pRtpPacket->rawPacketLength, &pRtpPacketCopy));
+    // pRtpPacketCopy took ownership of pRawPacketCopy
+    pRawPacketCopy = NULL;
 
     CHK_STATUS(rollingBufferAppendData(pRollingBuffer->pRollingBuffer, (UINT64) pRtpPacketCopy, &index));
     pRollingBuffer->lastIndex = index;
 
 CleanUp:
+    SAFE_MEMFREE(pRawPacketCopy);
     CHK_LOG_ERR(retStatus);
 
     LEAVES();

--- a/src/source/Rtp/RtpPacket.c
+++ b/src/source/Rtp/RtpPacket.c
@@ -97,6 +97,8 @@ STATUS createRtpPacketFromBytes(PBYTE rawPacket, UINT32 packetLength, PRtpPacket
 CleanUp:
 
     if (STATUS_FAILED(retStatus) && pRtpPacket != NULL) {
+        // Release ownership of rawPacket instead of freeing rawPacket
+        pRtpPacket->pRawPacket = NULL;
         freeRtpPacket(&pRtpPacket);
         pRtpPacket = NULL;
     }


### PR DESCRIPTION
*Description of changes:*

createRtpPacketFromBytes() now only moves ownership of the rawPacket
argument to the PRtpPacket object if the call to
createRtpPacketFromBytes() is successful. This allows the caller to
free rawPacket in a CleanUp section without having to check if
a call to createRtpPacketFromBytes() was the source of failure.

This commit also fixes two potential double frees in
sendPacketToRtpReceiver().

This first potential double free is that the call to
createRtpPacketFromBytes() in sendPacketToRtpReceiver() succeeds, but
then the call to jitterBufferPush() fails. When this happens, then
SAFE_MEMFREE() frees pPayload. However, the subsequent call to
freeRtpPacket() then also calls free on pPayload since
createRtpPacketFromBytes() transferred ownership of pPayload to
pRtpPacket.

This commit fixes the first potential double free by setting pPayload
to NULL after ownership of pPayload is transferred to pRtpPacket.

The second potential double free is that the call to
createRtpPacketFromBytes() in sendPacketToRtpReceiver() fails. When
this happens, the call to SAFE_MEMFREE() in the CleanUp section
performs a double free because createRtpPacketFromBytes() already
freed pPayload.

This commit fixes the second potential double free by changing
createRtpPacketFromBytes() only to transfer ownership when
createRtpPacketFromBytes() is successfully called, i.e.,
createRtpPacketFromBytes() won't free the rawPacket argument when the
call fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
