### PR TITLE
Fix broken clang in travis yml. Use v11.0.0

### DIFF
--- a/.travis-clang-format
+++ b/.travis-clang-format
@@ -1,0 +1,79 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Chromium
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  AfterNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: WebKit
+BreakBeforeTernaryOperators: true
+BreakStringLiterals: true
+ColumnLimit:     150
+CommentPragmas:  '^ IWYU pragma:'
+ContinuationIndentWidth: 4
+DerivePointerAlignment: false
+IncludeBlocks:   Preserve
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+CompactNamespaces: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+TabWidth:        4
+UseTab:          Never
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,14 +35,15 @@ matrix:
   include:
     #clang check
     - name: "clang-format Check"
-      os: linux
+      os: osx
       compiler: clang
       before_script:
-        - sudo apt-get -q update
-        - sudo apt-get install clang-format
+#        - sudo apt-get -q update
+#        - sudo apt-get install clang-format
+        - brew install clang-format
       script:
         - clang-format --version
-        - bash scripts/check-clang.sh .travis-clang-format
+        - bash scripts/check-clang.sh
 
 #    # MacOS Builds
 #    - name: "OSX GCC"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,199 +35,199 @@ matrix:
   include:
     #clang check
     - name: "clang-format Check"
-      os: osx
+      os: linux
       compiler: clang
       before_script:
-        - brew install clang-format
-        - mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE
+        - sudo apt-get -q update
+        - sudo apt-get -y install clang-format-11
       script:
-        - cd ..
+        - clang-format --version
         - bash scripts/check-clang.sh
 
-    # MacOS Builds
-    - name: "OSX GCC"
-      os: osx
-      compiler: gcc
-      before_script:
-        - mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-      script:
-        - make
-        - export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:`pwd`/../open-source/lib"
-        - ./tst/webrtc_client_test
-      after_failure: skip # timeout not available on MacOS
-
-    - name: "OSX Clang"
-      os: osx
-      compiler: clang
-      before_script:
-        - mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-      script:
-        - make
-        - export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:`pwd`/../open-source/lib"
-        - ./tst/webrtc_client_test || travis_terminate 1;
-        # Execute selected tests without auth integration
-        - unset AWS_ACCESS_KEY_ID
-        - unset AWS_SECRET_ACCESS_KEY
-        - ./tst/webrtc_client_test --gtest_break_on_failure --gtest_filter="SignalingApiFunctionalityTest.*:SignalingApiTest.*:TurnConnectionFunctionalityTest.*"
-      after_failure: skip # timeout not available on MacOS
-
-    # Code Coverage
-    - name: "Linux GCC Code Coverage"
-      os: linux
-      compiler: gcc
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-      before_script:
-        - mkdir build && cd build && cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
-      after_success:
-        - for test_file in $(find CMakeFiles/kvsWebrtcClient.dir CMakeFiles/kvsWebrtcSignalingClient.dir -name '*.gcno'); do gcov $test_file; done
-        - bash <(curl -s https://codecov.io/bash)
-
-    # AddressSanitizer
-    - name: "Linux Clang AddressSanitizer"
-      os: linux
-      compiler: clang
-      env:
-        - ASAN_OPTIONS=detect_odr_violation=0:detect_leaks=1
-        - LSAN_OPTIONS=suppressions=../tst/suppressions/LSAN.supp
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-      before_script: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
-
-    # UndefinedBehaviorSanitizer
-    - name: "Linux Clang UndefinedBehaviorSanitizer"
-      os: linux
-      compiler: clang
-      env: UBSAN_OPTIONS=halt_on_error=1
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-      before_script: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
-
-    # MemorySanitizer
-    - name: "Linux Clang MemorySanitizer"
-      env: allowTestFail=true
-      before_install:
-        # TODO: Remove the following 2 lines. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
-        - sudo service docker restart
-        - mkdir build
-        - docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -w /src/build -dit --name msan-tester -v $(pwd):/src seaduboi/kvs-msan-tester
-        - msan-tester() { docker exec -it msan-tester "$@"; }
-      script:
-        - msan-tester cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_DEPENDENCIES=FALSE -DBUILD_TEST=TRUE -DMEMORY_SANITIZER=TRUE -DCMAKE_CXX_FLAGS="-stdlib=libc++ -L/usr/src/libcxx_msan/lib -lc++abi -I/usr/src/libcxx_msan/include -I/usr/src/libcxx_msan/include/c++/v1 -fsanitize=memory -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize-memory-track-origins"
-        - msan-tester make
-        - msan-tester ./tst/webrtc_client_test
-      after_failure: skip # no coredumps in container
-
-    # ThreadSanitizer
-    - name: "Linux Clang ThreadSanitizer"
-      os: linux
-      compiler: clang
-      env: TSAN_OPTIONS=halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-      before_script: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
-
-    # Old Version GCC 4.4
-    - name: "Linux GCC 4.4 Build"
-      os: linux
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        - sudo apt-get -q update
-        - sudo apt-get -y install gcc-4.4
-        - sudo apt-get -y install gdb
-      compiler: gcc
-      before_script: export CC=gcc-4.4 && mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE
-
-    # Static Build
-    - name: "Static Build"
-      before_install:
-        # TODO: Remove the following 2 lines. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
-        - sudo service docker restart
-        - mkdir build
-        - docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -w /src/build -dit --security-opt=seccomp=.github/default.json --name alpine -v $(pwd):/src alpine:latest
-        - alpine() { docker exec -it alpine "$@"; }
-      install:
-        - alpine apk update
-        - alpine apk upgrade
-        - alpine apk add alpine-sdk cmake clang linux-headers perl bash openssl-dev
-      script:
-        - alpine cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
-        - alpine make
-        # ldd will return non-zero when there's no dynamic link. So, the positive value for static builds is non-zero
-        - alpine ../scripts/check-static-build.sh || travis_terminate 1
-        - alpine ./tst/webrtc_client_test
-      after_failure: skip # no coredumps in container
-
-    # Cross-compilation to ARM, no tests are run
-    - name: "ARM Cross-compilation"
-      os: linux
-      addons:
-        apt:
-          packages:
-            - gcc-arm-linux-gnueabi
-            - g++-arm-linux-gnueabi
-            - binutils-arm-linux-gnueabi
-      compiler: gcc
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-      before_script:
-        - export CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++
-        - mkdir build && cd build
-        - cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
-      script: make
-
-    - name: "mbedTLS - Linux GCC 4.4 Build"
-      os: linux
-      compiler: gcc
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        - sudo apt-get -q update
-        - sudo apt-get -y install gcc-4.4
-        - sudo apt-get -y install gdb
-      before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-
-    - name: "mbedTLS - Linux Clang"
-      os: linux
-      compiler: clang
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-      before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-
-    - name: "Windows MSVC"
-      os: windows
-      script:
-        - choco install nasm strawberryperl
-        - unset CC CC_FOR_BUILD CXX CXX_FOR_BUILD # We want to use MSVC
-        - export "PATH=/c/Strawberry/perl/site/bin:/c/Strawberry/perl/bin:/c/Strawberry/c/bin:/c/Program Files/NASM:`pwd`/open-source/lib:`pwd`/open-source/bin:$PATH"
-        - .github/build_windows.bat
-        - cd build/tst && ./webrtc_client_test.exe --gtest_filter="-DataChannelFunctionalityTest.*:IceApiTest.*:IceFunctionalityTest.*:PeerConnectionFunctionalityTest.*:SignalingApiFunctionalityTest.*:TurnConnectionFunctionalityTest.*:RtpFunctionalityTest.marshallUnmarshallH264Data:RtpFunctionalityTest.packingUnpackingVerifySameH264Frame:RtcpFunctionalityTest.onRtcpPacketCompound:RtcpFunctionalityTest.twcc3"
-
-    - name: "Sample check"
-      os: linux
-      compiler: gcc
-      before_install:
-        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        - sudo apt-get -q update
-        - sudo apt-get -y install gcc-4.4
-      before_script: mkdir build && cd build && cmake ..
-      script:
-        - make
-        - cd ..
-        - ./scripts/check-sample.sh
+#    # MacOS Builds
+#    - name: "OSX GCC"
+#      os: osx
+#      compiler: gcc
+#      before_script:
+#        - mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
+#      script:
+#        - make
+#        - export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:`pwd`/../open-source/lib"
+#        - ./tst/webrtc_client_test
+#      after_failure: skip # timeout not available on MacOS
+#
+#    - name: "OSX Clang"
+#      os: osx
+#      compiler: clang
+#      before_script:
+#        - mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
+#      script:
+#        - make
+#        - export DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:`pwd`/../open-source/lib"
+#        - ./tst/webrtc_client_test || travis_terminate 1;
+#        # Execute selected tests without auth integration
+#        - unset AWS_ACCESS_KEY_ID
+#        - unset AWS_SECRET_ACCESS_KEY
+#        - ./tst/webrtc_client_test --gtest_break_on_failure --gtest_filter="SignalingApiFunctionalityTest.*:SignalingApiTest.*:TurnConnectionFunctionalityTest.*"
+#      after_failure: skip # timeout not available on MacOS
+#
+#    # Code Coverage
+#    - name: "Linux GCC Code Coverage"
+#      os: linux
+#      compiler: gcc
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#      before_script:
+#        - mkdir build && cd build && cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
+#      after_success:
+#        - for test_file in $(find CMakeFiles/kvsWebrtcClient.dir CMakeFiles/kvsWebrtcSignalingClient.dir -name '*.gcno'); do gcov $test_file; done
+#        - bash <(curl -s https://codecov.io/bash)
+#
+#    # AddressSanitizer
+#    - name: "Linux Clang AddressSanitizer"
+#      os: linux
+#      compiler: clang
+#      env:
+#        - ASAN_OPTIONS=detect_odr_violation=0:detect_leaks=1
+#        - LSAN_OPTIONS=suppressions=../tst/suppressions/LSAN.supp
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#      before_script: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
+#
+#    # UndefinedBehaviorSanitizer
+#    - name: "Linux Clang UndefinedBehaviorSanitizer"
+#      os: linux
+#      compiler: clang
+#      env: UBSAN_OPTIONS=halt_on_error=1
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#      before_script: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
+#
+#    # MemorySanitizer
+#    - name: "Linux Clang MemorySanitizer"
+#      env: allowTestFail=true
+#      before_install:
+#        # TODO: Remove the following 2 lines. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+#        - sudo service docker restart
+#        - mkdir build
+#        - docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -w /src/build -dit --name msan-tester -v $(pwd):/src seaduboi/kvs-msan-tester
+#        - msan-tester() { docker exec -it msan-tester "$@"; }
+#      script:
+#        - msan-tester cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_DEPENDENCIES=FALSE -DBUILD_TEST=TRUE -DMEMORY_SANITIZER=TRUE -DCMAKE_CXX_FLAGS="-stdlib=libc++ -L/usr/src/libcxx_msan/lib -lc++abi -I/usr/src/libcxx_msan/include -I/usr/src/libcxx_msan/include/c++/v1 -fsanitize=memory -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize-memory-track-origins"
+#        - msan-tester make
+#        - msan-tester ./tst/webrtc_client_test
+#      after_failure: skip # no coredumps in container
+#
+#    # ThreadSanitizer
+#    - name: "Linux Clang ThreadSanitizer"
+#      os: linux
+#      compiler: clang
+#      env: TSAN_OPTIONS=halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#      before_script: mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
+#
+#    # Old Version GCC 4.4
+#    - name: "Linux GCC 4.4 Build"
+#      os: linux
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#        - sudo apt-get -q update
+#        - sudo apt-get -y install gcc-4.4
+#        - sudo apt-get -y install gdb
+#      compiler: gcc
+#      before_script: export CC=gcc-4.4 && mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE
+#
+#    # Static Build
+#    - name: "Static Build"
+#      before_install:
+#        # TODO: Remove the following 2 lines. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
+#        - sudo service docker restart
+#        - mkdir build
+#        - docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -w /src/build -dit --security-opt=seccomp=.github/default.json --name alpine -v $(pwd):/src alpine:latest
+#        - alpine() { docker exec -it alpine "$@"; }
+#      install:
+#        - alpine apk update
+#        - alpine apk upgrade
+#        - alpine apk add alpine-sdk cmake clang linux-headers perl bash openssl-dev
+#      script:
+#        - alpine cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
+#        - alpine make
+#        # ldd will return non-zero when there's no dynamic link. So, the positive value for static builds is non-zero
+#        - alpine ../scripts/check-static-build.sh || travis_terminate 1
+#        - alpine ./tst/webrtc_client_test
+#      after_failure: skip # no coredumps in container
+#
+#    # Cross-compilation to ARM, no tests are run
+#    - name: "ARM Cross-compilation"
+#      os: linux
+#      addons:
+#        apt:
+#          packages:
+#            - gcc-arm-linux-gnueabi
+#            - g++-arm-linux-gnueabi
+#            - binutils-arm-linux-gnueabi
+#      compiler: gcc
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#      before_script:
+#        - export CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++
+#        - mkdir build && cd build
+#        - cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+#      script: make
+#
+#    - name: "mbedTLS - Linux GCC 4.4 Build"
+#      os: linux
+#      compiler: gcc
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#        - sudo apt-get -q update
+#        - sudo apt-get -y install gcc-4.4
+#        - sudo apt-get -y install gdb
+#      before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+#
+#    - name: "mbedTLS - Linux Clang"
+#      os: linux
+#      compiler: clang
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#      before_script: mkdir build && cd build && cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+#
+#    - name: "Windows MSVC"
+#      os: windows
+#      script:
+#        - choco install nasm strawberryperl
+#        - unset CC CC_FOR_BUILD CXX CXX_FOR_BUILD # We want to use MSVC
+#        - export "PATH=/c/Strawberry/perl/site/bin:/c/Strawberry/perl/bin:/c/Strawberry/c/bin:/c/Program Files/NASM:`pwd`/open-source/lib:`pwd`/open-source/bin:$PATH"
+#        - .github/build_windows.bat
+#        - cd build/tst && ./webrtc_client_test.exe --gtest_filter="-DataChannelFunctionalityTest.*:IceApiTest.*:IceFunctionalityTest.*:PeerConnectionFunctionalityTest.*:SignalingApiFunctionalityTest.*:TurnConnectionFunctionalityTest.*:RtpFunctionalityTest.marshallUnmarshallH264Data:RtpFunctionalityTest.packingUnpackingVerifySameH264Frame:RtcpFunctionalityTest.onRtcpPacketCompound:RtcpFunctionalityTest.twcc3"
+#
+#    - name: "Sample check"
+#      os: linux
+#      compiler: gcc
+#      before_install:
+#        # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#        - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#        - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#        - sudo apt-get -q update
+#        - sudo apt-get -y install gcc-4.4
+#      before_script: mkdir build && cd build && cmake ..
+#      script:
+#        - make
+#        - cd ..
+#        - ./scripts/check-sample.sh
 
     # Generate Doxygen
     - name: "Generate Doxygen"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,10 @@ matrix:
   include:
     #clang check
     - name: "clang-format Check"
-      os: linux
+      os: osx
       compiler: clang
       before_script:
-        - sudo apt-get -q update
-        - sudo apt-get -y install clang-format
+        - brew install clang-format
         - mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=TRUE
       script:
         - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     packages:
       - gdb
       - docker-ce
+      - clang-format-11.0
 
 script:
   - export AWS_KVS_LOG_LEVEL=3
@@ -39,7 +40,6 @@ matrix:
       compiler: clang
       before_script:
         - sudo apt-get -q update
-        - sudo apt-get -y install clang-format-11
       script:
         - clang-format --version
         - bash scripts/check-clang.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,9 @@ services:
 
 addons:
   apt:
-    sources:
-      - sourceline: "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
-        key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
     packages:
       - gdb
       - docker-ce
-      - clang-11
 
 script:
   - export AWS_KVS_LOG_LEVEL=3
@@ -43,9 +39,10 @@ matrix:
       compiler: clang
       before_script:
         - sudo apt-get -q update
+        - sudo apt-get install clang-format
       script:
         - clang-format --version
-        - bash scripts/check-clang.sh
+        - bash scripts/check-clang.sh .travis-clang-format
 
 #    # MacOS Builds
 #    - name: "OSX GCC"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,13 @@ services:
 
 addons:
   apt:
+    sources:
+      - sourceline: "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main"
+        key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
     packages:
       - gdb
       - docker-ce
-      - clang-format-11.0
+      - clang-11
 
 script:
   - export AWS_KVS_LOG_LEVEL=3

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -734,13 +734,8 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
     SET_LOGGER_LOG_LEVEL(logLevel);
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_STATUS(createLwsIotCredentialProvider(pIotCoreCredentialEndPoint,
-                                              pIotCoreCert,
-                                              pIotCorePrivateKey,
-                                              pSampleConfiguration->pCaCertPath,
-                                              pIotCoreRoleAlias,
-                                              channelName,
-                                              &pSampleConfiguration->pCredentialProvider));
+    CHK_STATUS(createLwsIotCredentialProvider(pIotCoreCredentialEndPoint, pIotCoreCert, pIotCorePrivateKey, pSampleConfiguration->pCaCertPath,
+                                              pIotCoreRoleAlias, channelName, &pSampleConfiguration->pCredentialProvider));
 #else
     CHK_STATUS(
         createStaticCredentialProvider(pAccessKey, 0, pSecretKey, 0, pSessionToken, 0, MAX_UINT64, &pSampleConfiguration->pCredentialProvider));
@@ -1065,7 +1060,6 @@ STATUS freeSampleConfiguration(PSampleConfiguration* ppSampleConfiguration)
 #else
     freeStaticCredentialProvider(&pSampleConfiguration->pCredentialProvider);
 #endif
-
 
     if (IS_VALID_TIMER_QUEUE_HANDLE(pSampleConfiguration->timerQueueHandle)) {
         if (pSampleConfiguration->iceCandidatePairStatsTimerId != MAX_UINT32) {

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -272,7 +272,7 @@ CleanUp:
 
     CHK_LOG_ERR(retStatus);
 
-    return (PVOID) (ULONG_PTR) retStatus;
+    return (PVOID)(ULONG_PTR) retStatus;
 }
 
 PVOID sendAudioPackets(PVOID args)
@@ -340,7 +340,7 @@ PVOID sendAudioPackets(PVOID args)
 
 CleanUp:
 
-    return (PVOID) (ULONG_PTR) retStatus;
+    return (PVOID)(ULONG_PTR) retStatus;
 }
 
 PVOID sampleReceiveVideoFrame(PVOID args)
@@ -360,5 +360,5 @@ PVOID sampleReceiveVideoFrame(PVOID args)
 
 CleanUp:
 
-    return (PVOID) (ULONG_PTR) retStatus;
+    return (PVOID)(ULONG_PTR) retStatus;
 }

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -23,9 +23,9 @@ INT32 main(INT32 argc, CHAR* argv[])
     printf("[KVS Master] Using trickleICE by default\n");
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-        CHK_ERR((pChannelName = getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
+    CHK_ERR((pChannelName = getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
 #else
-        pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
+    pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
 #endif
 
     retStatus = createSampleConfiguration(pChannelName, SIGNALING_CHANNEL_ROLE_TYPE_VIEWER, TRUE, TRUE, &pSampleConfiguration);

--- a/scripts/check-clang.sh
+++ b/scripts/check-clang.sh
@@ -14,7 +14,7 @@ SOURCE_FILES=`find src samples tst -type f \( -name '*.h' -o -name '*.c' \) -not
 echo "Performing clang format compliance check...."
 for i in $SOURCE_FILES
 do
-    $CLANG_FORMAT -output-replacements-xml $i | grep -c "<replacement " > /dev/null
+    $CLANG_FORMAT -assume-filename=$1 -output-replacements-xml $i | grep -c "<replacement " > /dev/null
     if [ $? -ne 1 ]
     then
         echo "$i failed clang-format check."

--- a/scripts/check-clang.sh
+++ b/scripts/check-clang.sh
@@ -14,7 +14,7 @@ SOURCE_FILES=`find src samples tst -type f \( -name '*.h' -o -name '*.c' \) -not
 echo "Performing clang format compliance check...."
 for i in $SOURCE_FILES
 do
-    $CLANG_FORMAT -assume-filename=$1 -output-replacements-xml $i | grep -c "<replacement " > /dev/null
+    $CLANG_FORMAT -output-replacements-xml $i | grep -c "<replacement " > /dev/null
     if [ $? -ne 1 ]
     then
         echo "$i failed clang-format check."

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -26,12 +26,12 @@ extern "C" {
 #endif
 
 /*! \addtogroup StatusCodes
-* WEBRTC related status codes. Each value is an positive integer formed by adding
-* a base integer inticating the category to an index. Users may run scripts/parse_status.py
-* to print a list of all status codes and their hex value.
-*  @{
-*/
-#define STATUS_WEBRTC_BASE                                         0x55000000
+ * WEBRTC related status codes. Each value is an positive integer formed by adding
+ * a base integer inticating the category to an index. Users may run scripts/parse_status.py
+ * to print a list of all status codes and their hex value.
+ *  @{
+ */
+#define STATUS_WEBRTC_BASE 0x55000000
 
 /////////////////////////////////////////////////////
 /// Session description init related status codes
@@ -905,7 +905,7 @@ typedef VOID (*RtcOnPictureLoss)(UINT64);
  */
 typedef struct __RtcDataChannel {
     CHAR name[MAX_DATA_CHANNEL_NAME_LEN + 1]; //!< Define name of data channel. Max length is 256 characters
-    UINT32 id; //!< Read only field. Setting this in the application has no effect. This field is populated with the id
+    UINT32 id;                                //!< Read only field. Setting this in the application has no effect. This field is populated with the id
                //!< set by the peer connection's createDataChannel() call or the channel id is set in createDataChannel()
                //!< on embedded end.
 } RtcDataChannel, *PRtcDataChannel;
@@ -1053,16 +1053,16 @@ typedef struct {
     UINT32 iceConnectionCheckTimeout; //!< Maximum time allowed waiting for at least one ice candidate pair to receive
                                       //!< binding response from the peer. Use default value if 0.
 
-    UINT32 iceCandidateNominationTimeout; //!< If client is ice controlling, this is the timeout for receiving bind response of requests that has USE_CANDIDATE
-                                          //!< attribute. If client is ice controlled, this is the timeout for receiving binding request that has USE_CANDIDATE
-                                          //!< attribute after connection check is done. Use default value if 0.
+    UINT32 iceCandidateNominationTimeout; //!< If client is ice controlling, this is the timeout for receiving bind response of requests that has
+                                          //!< USE_CANDIDATE attribute. If client is ice controlled, this is the timeout for receiving binding request
+                                          //!< that has USE_CANDIDATE attribute after connection check is done. Use default value if 0.
 
     UINT32 iceConnectionCheckPollingInterval; //!< Ta in https://tools.ietf.org/html/rfc8445
                                               //!< rate at which binding request packets are sent during connection check. Use default interval if 0.
 
     INT32 generatedCertificateBits; //!< GeneratedCertificateBits controls the amount of bits the locally generated self-signed certificate uses
-                                    //!< A smaller amount of bits may result in less CPU usage on startup, but will cause a weaker certificate to be generated
-                                    //!< If set to 0 the default GENERATED_CERTIFICATE_BITS will be used
+                                    //!< A smaller amount of bits may result in less CPU usage on startup, but will cause a weaker certificate to be
+                                    //!< generated If set to 0 the default GENERATED_CERTIFICATE_BITS will be used
 
     BOOL generateRSACertificate; //!< GenerateRSACertificate controls if an ECDSA or RSA certificate is generated.
                                  //!< By default we generate an ECDSA certificate but some platforms may not support them.
@@ -1090,24 +1090,25 @@ typedef struct {
     RtcIceServer iceServers[MAX_ICE_SERVERS_COUNT]; //!< Servers available to be used by ICE, such as STUN and TURN servers.
     KvsRtcConfiguration kvsRtcConfiguration;        //!< Non-standard configuration options
 
-    RtcCertificate certificates[MAX_RTCCONFIGURATION_CERTIFICATES]; //!< Set of certificates that the RtcPeerConnection uses to authenticate.
-                                                                    //!< Although any given DTLS connection will use only one certificate, this
-                                                                    //!< attribute allows the caller to provide multiple certificates that support
-                                                                    //!< different algorithms.
-                                                                    //!<
-                                                                    //!< If this value is absent, then a default set of certificates is generated
-                                                                    //!< for each RtcPeerConnection.
-                                                                    //!<
-                                                                    //!< An absent value is determined by the certificate pointing to NULL
-                                                                    //!<
-                                                                    //!< Doc: https://www.w3.org/TR/webrtc/#dom-rtcconfiguration-certificates
-                                                                    //!<
-                                                                    //!< !!!!!!!!!! IMPORTANT !!!!!!!!!!
-                                                                    //!< It is recommended to rotate the certificates often - preferably for every peer connection
-                                                                    //!< to avoid a compromised client weakening the security of the new connections.
-                                                                    //!<
-                                                                    //!< NOTE: The certificates, if specified, can be freed after the peer connection create call
-                                                                    //!<
+    RtcCertificate
+        certificates[MAX_RTCCONFIGURATION_CERTIFICATES]; //!< Set of certificates that the RtcPeerConnection uses to authenticate.
+                                                         //!< Although any given DTLS connection will use only one certificate, this
+                                                         //!< attribute allows the caller to provide multiple certificates that support
+                                                         //!< different algorithms.
+                                                         //!<
+                                                         //!< If this value is absent, then a default set of certificates is generated
+                                                         //!< for each RtcPeerConnection.
+                                                         //!<
+                                                         //!< An absent value is determined by the certificate pointing to NULL
+                                                         //!<
+                                                         //!< Doc: https://www.w3.org/TR/webrtc/#dom-rtcconfiguration-certificates
+                                                         //!<
+                                                         //!< !!!!!!!!!! IMPORTANT !!!!!!!!!!
+                                                         //!< It is recommended to rotate the certificates often - preferably for every peer
+                                                         //!< connection to avoid a compromised client weakening the security of the new connections.
+                                                         //!<
+                                                         //!< NOTE: The certificates, if specified, can be freed after the peer connection create call
+                                                         //!<
 } RtcConfiguration, *PRtcConfiguration;
 
 /**
@@ -1443,8 +1444,8 @@ typedef struct {
 ////////////////////////////////////////////////////
 
 /*! \addtogroup PublicMemberFunctions
-* @{
-*/
+ * @{
+ */
 
 /**
  * @brief Initialize a RtcPeerConnection with the provided Configuration

--- a/src/source/PeerConnection/JitterBuffer.h
+++ b/src/source/PeerConnection/JitterBuffer.h
@@ -39,9 +39,9 @@ typedef struct {
     PHashTable pPkgBufferHashTable;
 } JitterBuffer, *PJitterBuffer;
 
-//constructor
+// constructor
 STATUS createJitterBuffer(FrameReadyFunc, FrameDroppedFunc, DepayRtpPayloadFunc, UINT32, UINT32, UINT64, PJitterBuffer*);
-//destructor
+// destructor
 STATUS freeJitterBuffer(PJitterBuffer*);
 STATUS jitterBufferPush(PJitterBuffer, PRtpPacket, PBOOL);
 STATUS jitterBufferDropBufferData(PJitterBuffer, UINT16, UINT16, UINT32);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Clang formatting in travis CI is broken, which lets CI pass for commits. Looks like the failure is recent. Updated Clang version to 11.0.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
