### PR TITLE
use poll instead of select

### DIFF
--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -117,6 +117,12 @@ INT32 getErrorCode(VOID);
  */
 PCHAR getErrorString(INT32);
 
+#ifdef _WIN32
+#define POLL WSAPoll
+#else
+#define POLL poll
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/source/Ice/SocketConnection.h
+++ b/src/source/Ice/SocketConnection.h
@@ -10,7 +10,7 @@ Socket Connection internal include file
 extern "C" {
 #endif
 
-#define SOCKET_SEND_RETRY_TIMEOUT_MICRO_SECOND 500000
+#define SOCKET_SEND_RETRY_TIMEOUT_MILLI_SECOND 500
 #define MAX_SOCKET_WRITE_RETRY                 3
 
 #define CLOSE_SOCKET_IF_CANT_RETRY(e, ps)                                                                                                            \


### PR DESCRIPTION
*Description of changes:*

Use `poll` system call instead of `select`.
Select fails when socket fd value is larger than 1024. This happens when running as part of a process which has already opened a lot of descriptors.
This is caused by a design bug in glibc `select` implementation.

```
BUGS
       POSIX allows an implementation to define an upper limit, advertised via the constant FD_SETSIZE, on the  range  of  file  de‐
       scriptors that can be specified in a file descriptor set.  The Linux kernel imposes no fixed limit, but the glibc implementa‐
       tion makes fd_set a fixed-size type, with FD_SETSIZE defined as 1024, and the  FD_*()  macros  operating  according  to  that
       limit.  To monitor file descriptors greater than 1023, use poll(2) instead.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
