### PR TITLE
account for NACK resent packets in twcc

### DIFF
--- a/src/source/PeerConnection/Retransmitter.c
+++ b/src/source/PeerConnection/Retransmitter.c
@@ -95,9 +95,11 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
             }
             // resendPacket
             if (STATUS_SUCCEEDED(retStatus)) {
+                pRtpPacket->sentTime = GETTIME();
                 retransmittedPacketsSent++;
                 retransmittedBytesSent += pRtpPacket->rawPacketLength - RTP_HEADER_LEN(pRtpPacket);
                 DLOGV("Resent packet ssrc %lu seq %lu succeeded", pRtpPacket->header.ssrc, pRtpPacket->header.sequenceNumber);
+                twccManagerOnPacketSent(pKvsPeerConnection, pRtpPacket);
             } else {
                 DLOGV("Resent packet ssrc %lu seq %lu failed 0x%08x", pRtpPacket->header.ssrc, pRtpPacket->header.sequenceNumber, retStatus);
             }

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -306,7 +306,7 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
         // time not yet set (only happens for first rtp packet)
         localStartTimeKvs = twcc->twccPacketBySeqNum[(UINT16) sn].localTimeKvs;
     }
-    for (seqNum = sn; duration < TWCC_ESTIMATOR_TIME_WINDOW && seqNum != twcc->lastReportedSeqNum; seqNum++) {
+    for (seqNum = sn; seqNum != twcc->lastReportedSeqNum; seqNum++) {
         twccPacket = &twcc->twccPacketBySeqNum[seqNum];
         localEndTimeKvs = twccPacket->localTimeKvs;
         duration = localEndTimeKvs - localStartTimeKvs;


### PR DESCRIPTION
*Description of changes:*

Adds packets resent via NACK mechanism to twcc manager.
Previously the packets were not accounted for which caused bandwidth estimator to be overly optimistic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
