### PR TITLE
libwebsockets: update libwebsockets to v4.2-stable

### DIFF
--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 ExternalProject_Add(project_libwebsockets
     GIT_REPOSITORY    https://github.com/warmcat/libwebsockets.git
-    GIT_TAG           v3.2.3
+    GIT_TAG           v4.2-stable
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -13,6 +13,9 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     PCHAR userLogLevelStr = NULL;
     UINT32 userLogLevel;
     struct lws_context_creation_info creationInfo;
+    const lws_retry_bo_t retryPolicy = {
+        .secs_since_valid_ping = SIGNALING_SERVICE_WSS_PING_PONG_INTERVAL_IN_SECONDS,
+    };
     PStateMachineState pStateMachineState;
     BOOL cacheFound = FALSE;
     PSignalingFileCacheEntry pFileCacheEntry = NULL;
@@ -95,7 +98,7 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     creationInfo.ka_time = SIGNALING_SERVICE_TCP_KEEPALIVE_IN_SECONDS;
     creationInfo.ka_probes = SIGNALING_SERVICE_TCP_KEEPALIVE_PROBE_COUNT;
     creationInfo.ka_interval = SIGNALING_SERVICE_TCP_KEEPALIVE_PROBE_INTERVAL_IN_SECONDS;
-    creationInfo.ws_ping_pong_interval = SIGNALING_SERVICE_WSS_PING_PONG_INTERVAL_IN_SECONDS;
+    creationInfo.retry_and_idle_policy = &retryPolicy;
 
     ATOMIC_STORE_BOOL(&pSignalingClient->clientReady, FALSE);
     ATOMIC_STORE_BOOL(&pSignalingClient->shutdown, FALSE);


### PR DESCRIPTION
Signed-off-by: zhiqinli@amazon.com <zhiqinli@amazon.com>

*Issue #, if available:*
#1147 
In libwebsockets v3.2.3, there is a memory access violation issue when use mbedtls with certificates, @ycyang1229 managed to fix this via:
https://github.com/warmcat/libwebsockets/pull/2304
this PR has been merged into libwebsockets main and v4.2-stable branch. Without this patch, using mbedtls with iot certificates will always failed.
*Description of changes:*
Similar to #1152 , this changes will update libwebsockets to v4.2-stable. This update will fix #1147, and replace old `ws_ping_pong_interval` with new `lws_retry_bo_t ` to manage ping behaviors, which was introduced since libwebsockets v4.+.

ref: https://libwebsockets.org/git/libwebsockets/tree/READMEs/README.lws_retry.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
