### PR TITLE
Without LWS_WITH_NETWORK then private-lib-core-net.h is not included …

### DIFF
--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -35,6 +35,7 @@ ExternalProject_Add(project_libwebsockets
         -DLWS_WITHOUT_SERVER=1
         -DLWS_WITHOUT_TESTAPPS=1
         -DLWS_WITH_THREADPOOL=1
+        -DLWS_WITH_NETWORK=1
         -DLWS_WITHOUT_TEST_SERVER_EXTPOLL=1
         -DLWS_WITHOUT_TEST_PING=1
         -DLWS_WITHOUT_TEST_CLIENT=1


### PR DESCRIPTION
…in private-lib-core.h, which

links to the threadpool APIs currently failing to be linked: lws_threadpool_wsi_closing & lws_threadpool_tsi_context

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
