### PR TITLE
Cancel the thread once mediaThreadStarted flag is set to false

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -1025,6 +1025,12 @@ STATUS freeSampleConfiguration(PSampleConfiguration* ppSampleConfiguration)
         MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
         locked = TRUE;
     }
+    // Cancel the media thread
+    if(!(pSampleConfiguration->mediaThreadStarted)) {
+        DLOGD("Canceling media thread");
+        THREAD_CANCEL(pSampleConfiguration->mediaSenderTid);
+    }
+    
     for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
         retStatus = gatherIceServerStats(pSampleConfiguration->sampleStreamingSessionList[i]);
         if (STATUS_FAILED(retStatus)) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the samples, the `mediaSenderThread` flag is set to false after the audio and video threads join the main thread. However, we do not cancel the thread at cleanup leading to potential lingering threads. This PR fixes a potential clean up issue that could arise increasing the number of zombie threads in the system.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
