### PR TITLE
[FIX] When protocol in DCEP header of data channel open command is no…

### DIFF
--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -305,14 +305,17 @@ STATUS handleDcepPacket(PSctpSession pSctpSession, UINT32 streamId, PBYTE data, 
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     UINT16 labelLength = 0;
+    UINT16 protocolLength = 0;
 
     // Assert that is DCEP of type DataChannelOpen
     CHK(length > SCTP_DCEP_HEADER_LENGTH && data[0] == DCEP_DATA_CHANNEL_OPEN, STATUS_SUCCESS);
 
-    MEMCPY(&labelLength, data + 8, SIZEOF(UINT16));
-    putInt16((PINT16) &labelLength, labelLength);
+	MEMCPY(&labelLength, data + 8, SIZEOF(UINT16));
+	MEMCPY(&protocolLength, data + 10, SIZEOF(UINT16));
+	putInt16((PINT16) &labelLength, labelLength);
+	putInt16((PINT16) &protocolLength, protocolLength);
 
-    CHK((labelLength + SCTP_DCEP_HEADER_LENGTH) >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
+	CHK((labelLength + protocolLength + SCTP_DCEP_HEADER_LENGTH) >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
 
     pSctpSession->sctpSessionCallbacks.dataChannelOpenFunc(pSctpSession->sctpSessionCallbacks.customData, streamId, data + SCTP_DCEP_HEADER_LENGTH,
                                                            labelLength);


### PR DESCRIPTION
…t empty, there is a check preventing the data channel to be opened. Now protocol length is correctly handled to avoid check failing.

In this PR the value of the protocol string (if not empty) is not checked. May be it should be checked against the default value "stcp" and if not matching the data channel creation should fail. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
