### PR TITLE
Log ice candidate protocol appropriately

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -1025,6 +1025,12 @@ STATUS freeSampleConfiguration(PSampleConfiguration* ppSampleConfiguration)
         MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
         locked = TRUE;
     }
+    // Cancel the media thread
+    if(!(pSampleConfiguration->mediaThreadStarted)) {
+        DLOGD("Canceling media thread");
+        THREAD_CANCEL(pSampleConfiguration->mediaSenderTid);
+    }
+    
     for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
         retStatus = gatherIceServerStats(pSampleConfiguration->sampleStreamingSessionList[i]);
         if (STATUS_FAILED(retStatus)) {

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -21,6 +21,12 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
     } else {
         DLOGI("DataChannel String Message: %.*s\n", pMessageLen, pMessage);
     }
+    // Send a response to the message sent by the viewer
+    STATUS retStatus = STATUS_SUCCESS;
+    retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) MASTER_DATA_CHANNEL_MESSAGE, STRLEN(MASTER_DATA_CHANNEL_MESSAGE));
+    if(retStatus != STATUS_SUCCESS) {
+        DLOGI("[KVS Master] dataChannelSend(): operation returned status code: 0x%08x \n", retStatus);
+    }
 }
 
 VOID onDataChannel(UINT64 customData, PRtcDataChannel pRtcDataChannel)

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -46,6 +46,9 @@ extern "C" {
 #define IOT_CORE_ROLE_ALIAS          ((PCHAR) "AWS_IOT_CORE_ROLE_ALIAS")
 #define IOT_CORE_THING_NAME          ((PCHAR) "AWS_IOT_CORE_THING_NAME")
 
+#define MASTER_DATA_CHANNEL_MESSAGE "This message is from the KVS Master"
+#define VIEWER_DATA_CHANNEL_MESSAGE "This message is from the KVS Viewer"
+
 /* Uncomment the following line in order to enable IoT credentials checks in the provided samples */
 //#define IOT_CORE_ENABLE_CREDENTIALS  1
 

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -160,6 +160,7 @@ typedef struct {
      * has been reported through IceNewLocalCandidateFunc */
     BOOL reported;
     CHAR id[ICE_CANDIDATE_ID_LEN + 1];
+    CHAR remoteProtocol[MAX_PROTOCOL_LENGTH];
 } IceCandidate, *PIceCandidate;
 
 typedef struct {


### PR DESCRIPTION
*Issue #, if available:*
#1174 

*Description of changes:*
Previously, we never recorded remote candidate IP address. However, the SDP of remote candidate comprises of the protocol information. Since we did not record this information, all remote candidates being discovered would log protocol as N/A or UNKNOWN. This PR fixes this bug by storing the protocol for remote candidates. 

Additionally, we also modify the logic for local candidate protocol logging by relying on pSocketConnection instead of pTurnConnection to log for all types of candidates. Although our SDK supports only UDP, it is important it is logged regardless based on SDP.

Resolves: #1174 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
