### PR TITLE
Log ice candidate protocol appropriately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: true
 branches:
   only:
   - master
+  - develop
 
 cache:
 - directories:

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -327,7 +327,7 @@ STATUS iceAgentAddRemoteCandidate(PIceAgent pIceAgent, PCHAR pIceCandidateString
     PDoubleListNode pCurNode = NULL;
     SDP_ICE_CANDIDATE_PARSER_STATE state;
     ICE_CANDIDATE_TYPE iceCandidateType = ICE_CANDIDATE_TYPE_HOST;
-    CHAR remoteProtocol[MAX_PROTOCOL_LENGTH];
+    CHAR remoteProtocol[MAX_PROTOCOL_LENGTH] = {'\0'};
 
     CHK(pIceAgent != NULL && pIceCandidateString != NULL, STATUS_NULL_ARG);
     CHK(!IS_EMPTY_STRING(pIceCandidateString), STATUS_INVALID_ARG);
@@ -355,7 +355,9 @@ STATUS iceAgentAddRemoteCandidate(PIceAgent pIceAgent, PCHAR pIceCandidateString
                 STRTOUI32(curr, next, 10, &priority);
                 break;
             case SDP_ICE_CANDIDATE_PARSER_STATE_PROTOCOL:
-                STRNCPY(remoteProtocol, curr, tokenLen);
+                if(tokenLen < MAX_PROTOCOL_LENGTH) {
+                    STRNCPY(remoteProtocol, curr, tokenLen);
+                }
                 CHK(STRNCMPI("tcp", curr, tokenLen) != 0, STATUS_ICE_CANDIDATE_STRING_IS_TCP);
                 break;
             case SDP_ICE_CANDIDATE_PARSER_STATE_IP:

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -160,6 +160,7 @@ typedef struct {
      * has been reported through IceNewLocalCandidateFunc */
     BOOL reported;
     CHAR id[ICE_CANDIDATE_ID_LEN + 1];
+    CHAR remoteProtocol[MAX_PROTOCOL_LENGTH];
 } IceCandidate, *PIceCandidate;
 
 typedef struct {


### PR DESCRIPTION
Issue #, if available:
#1174

Description of changes:
Previously, we never recorded remote candidate IP address. However, the SDP of remote candidate comprises of the protocol information. Since we did not record this information, all remote candidates being discovered would log protocol as N/A or UNKNOWN. This PR fixes this bug by storing the protocol for remote candidates.

Additionally, we also modify the logic for local candidate protocol logging by relying on pSocketConnection instead of pTurnConnection to log for all types of candidates. Although our SDK supports only UDP, it is important it is logged regardless based on SDP.

Resolves: #1174

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
