### PR TITLE
added implementation and a test to use remote sdp to construct local sdp

### DIFF
--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -671,7 +671,7 @@ a=group:BUNDLE audio video data
 
         EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendonly", answerSdp.sdp);
         EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendrecv", answerSdp.sdp);
-        EXPECT_PRED_FORMAT2(testing::IsSubstring, "group:BUNDLE audio video dtmf", answerSdp.sdp);
+        EXPECT_PRED_FORMAT2(testing::IsSubstring, "group:BUNDLE audio video data", answerSdp.sdp);
 
         closePeerConnection(pRtcPeerConnection);
         EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -1088,41 +1088,6 @@ TEST_P(SdpApiTest_SdpMatch, populateSingleMediaSection_TestH264Fmtp)
     freePeerConnection(&pRtcPeerConnection);
 }
 
-TEST_F(SdpApiTest, populateSessionDescriptionBundle_TestTxSendRecv)
-{
-    PRtcPeerConnection offerPc = NULL;
-    RtcConfiguration configuration;
-    RtcSessionDescriptionInit sessionDescriptionInit;
-
-    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
-
-    // Create peer connection
-    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
-
-    RtcMediaStreamTrack track;
-    PRtcRtpTransceiver pTransceiver;
-    RtcRtpTransceiverInit rtcRtpTransceiverInit;
-    rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
-
-    MEMSET(&track, 0x00, SIZEOF(RtcMediaStreamTrack));
-
-    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
-    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
-    STRCPY(track.streamId, "myKvsVideoStream");
-    STRCPY(track.trackId, "myTrack");
-
-    // PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) offerPc;
-    printf("\n\nFROM REMOTE DESC:%s\n\n", (&(((PKvsPeerConnection) offerPc)->remoteSessionDescription))->sdpAttributes[0].attributeValue);
-    STRCPY((&(((PKvsPeerConnection) offerPc)->remoteSessionDescription))->sdpAttributes[0].attributeValue, "BUNDLE audio video data dtmf");
-
-    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
-    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
-    EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendrecv", sessionDescriptionInit.sdp);
-
-    closePeerConnection(offerPc);
-    freePeerConnection(&offerPc);
-}
-
 SdpMatch offer_1v1a1d_Chrome_Android = SdpMatch{
     R"(v=0
 o=- 2383219383355379692 2 IN IP4 127.0.0.1


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1224
*Description of changes:*
Modified the logic for populating SDP attributes in a local session description to use remote session description SDP attributes if present. 
Added a test which uses an offer with SDP attributes "BUNDLE audio video data" and checks if the answer responds with the same in its SDP attributes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
