### PR TITLE
Refactor peer certificate verification out of srtp allocation

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -13,7 +13,6 @@ STATUS allocateSrtp(PKvsPeerConnection pKvsPeerConnection)
     MEMSET(&dtlsKeyingMaterial, 0, SIZEOF(DtlsKeyingMaterial));
 
     CHK(pKvsPeerConnection != NULL, STATUS_SUCCESS);
-    CHK_STATUS(dtlsSessionVerifyRemoteCertificateFingerprint(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->remoteCertificateFingerprint));
     CHK_STATUS(dtlsSessionPopulateKeyingMaterial(pKvsPeerConnection->pDtlsSession, &dtlsKeyingMaterial));
 
     MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
@@ -136,6 +135,7 @@ VOID onInboundPacket(UINT64 customData, PBYTE buff, UINT32 buffLen)
 
         CHK_STATUS(dtlsSessionIsInitFinished(pKvsPeerConnection->pDtlsSession, &isDtlsConnected));
         if (isDtlsConnected) {
+            CHK_STATUS(dtlsSessionVerifyRemoteCertificateFingerprint(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->remoteCertificateFingerprint));
             if (pKvsPeerConnection->pSrtpSession == NULL) {
                 CHK_STATUS(allocateSrtp(pKvsPeerConnection));
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, our DTLS implementation only verifies peer certificates using the fingerprint from the offer/answer SDP. But, if the users only use data channels, the peer certificates will pass without any verification.

Update: It turns out that we'll always allocate SRTP, so the peer certificate will always get verified. So, to avoid confusion, the PR has been updated to move out the verification out of SRTP allocation.

https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/536

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
