### PR TITLE
Adding a utility for exponential retries and consuming it for createSignalingClientSync API in sample code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,8 @@ file(
   "src/source/Srtp/*.c"
   "src/source/Stun/*.c"
   "src/source/Sctp/*.c"
-  "src/source/Metrics/*.c")
+  "src/source/Metrics/*.c"
+  "src/source/Utils/*.c")
 
 if (USE_OPENSSL)
   list(FILTER WEBRTC_CLIENT_SOURCE_FILES EXCLUDE REGEX ".*_mbedtls\\.c")

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -1493,3 +1493,20 @@ CleanUp:
 
     return retStatus;
 }
+
+STATUS createSignalingClientSyncWithWait(PSignalingClientInfo pClientInfo, PChannelInfo pChannelInfo, PSignalingClientCallbacks pCallbacks,
+                                         PAwsCredentialProvider pCredentialProvider, PSIGNALING_CLIENT_HANDLE pSignalingHandle,
+                                         PExponentialBackoffState pExponentialBackoffState) {
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    if (pExponentialBackoffState != NULL) {
+        CHK_STATUS(exponentialBackoffBlockingWait(pExponentialBackoffState));
+    }
+
+    CHK_STATUS(createSignalingClientSync(pClientInfo, pChannelInfo, pCallbacks, pCredentialProvider, pSignalingHandle));
+
+    CleanUp:
+    LEAVES();
+    return retStatus;
+}

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -188,6 +188,9 @@ STATUS submitPendingIceCandidate(PPendingMessageQueue, PSampleStreamingSession);
 STATUS removeExpiredMessageQueues(PStackQueue);
 STATUS getPendingMessageQueueForHash(PStackQueue, UINT64, BOOL, PPendingMessageQueue*);
 BOOL sampleFilterNetworkInterfaces(UINT64, PCHAR);
+STATUS createSignalingClientSyncWithWait(PSignalingClientInfo pClientInfo, PChannelInfo pChannelInfo,
+                                         PSignalingClientCallbacks pCallbacks, PAwsCredentialProvider pCredentialProvider,
+                                         PSIGNALING_CLIENT_HANDLE pSignalingHandle, PExponentialBackoffState pExponentialBackoffState);
 
 #ifdef __cplusplus
 }

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -82,21 +82,11 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     strcpy(pSampleConfiguration->clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 
-    retStatus = initializeExponentialBackoffStateWithDefaultConfig(&pExponentialBackoffState);
-    if (retStatus != STATUS_SUCCESS) {
-        printf("[KVS Master] initKvsWebRtc(): Unable to initialize exponential backoff state: \n", retStatus);
-        goto CleanUp;
-    }
 
-    retStatus = exponentialBackoffBlockingWait(pExponentialBackoffState);
-    if (retStatus != STATUS_SUCCESS) {
-        printf("[KVS Master] initKvsWebRtc(): Unexpected error while adding a wait time: \n", retStatus);
-        goto CleanUp;
-    }
-
-    retStatus = createSignalingClientSync(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
+    CHK_STATUS(initializeExponentialBackoffStateWithDefaultConfig(&pExponentialBackoffState));
+    retStatus = createSignalingClientSyncWithWait(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
                                           &pSampleConfiguration->signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,
-                                          &pSampleConfiguration->signalingClientHandle);
+                                          &pSampleConfiguration->signalingClientHandle, pExponentialBackoffState);
     if (retStatus != STATUS_SUCCESS) {
         printf("[KVS Master] createSignalingClientSync(): operation returned status code: 0x%08x \n", retStatus);
         goto CleanUp;
@@ -158,6 +148,9 @@ CleanUp:
             printf("[KVS Master] freeSampleConfiguration(): operation returned status code: 0x%08x", retStatus);
         }
     }
+
+    freeExponentialBackoffState(&pExponentialBackoffState);
+
     printf("[KVS Master] Cleanup done\n");
 
     RESET_INSTRUMENTED_ALLOCATORS();

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -11,6 +11,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     PSampleConfiguration pSampleConfiguration = NULL;
     SignalingClientMetrics signalingClientMetrics;
     PCHAR pChannelName;
+    PExponentialBackoffState pExponentialBackoffState = NULL;
     signalingClientMetrics.version = 0;
 
     SET_INSTRUMENTED_ALLOCATORS();
@@ -80,6 +81,18 @@ INT32 main(INT32 argc, CHAR* argv[])
     pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = signalingMessageReceived;
 
     strcpy(pSampleConfiguration->clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
+
+    retStatus = initializeExponentialBackoffStateWithDefaultConfig(&pExponentialBackoffState);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] initKvsWebRtc(): Unable to initialize exponential backoff state: \n", retStatus);
+        goto CleanUp;
+    }
+
+    retStatus = exponentialBackoffBlockingWait(pExponentialBackoffState);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] initKvsWebRtc(): Unexpected error while adding a wait time: \n", retStatus);
+        goto CleanUp;
+    }
 
     retStatus = createSignalingClientSync(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
                                           &pSampleConfiguration->signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -338,6 +338,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     STATUS retStatus = STATUS_SUCCESS;
     PSampleConfiguration pSampleConfiguration = NULL;
     PCHAR pChannelName;
+    PExponentialBackoffState pExponentialBackoffState = NULL;
 
     SET_INSTRUMENTED_ALLOCATORS();
 
@@ -420,6 +421,18 @@ INT32 main(INT32 argc, CHAR* argv[])
     pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = signalingMessageReceived;
 
     strcpy(pSampleConfiguration->clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
+
+    retStatus = initializeExponentialBackoffStateWithDefaultConfig(&pExponentialBackoffState);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] initKvsWebRtc(): Unable to initialize exponential backoff state: \n", retStatus);
+        goto CleanUp;
+    }
+
+    retStatus = exponentialBackoffBlockingWait(pExponentialBackoffState);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] initKvsWebRtc(): Unexpected error while adding a wait time: \n", retStatus);
+        goto CleanUp;
+    }
 
     retStatus = createSignalingClientSync(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
                                           &pSampleConfiguration->signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -422,21 +422,10 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     strcpy(pSampleConfiguration->clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
 
-    retStatus = initializeExponentialBackoffStateWithDefaultConfig(&pExponentialBackoffState);
-    if (retStatus != STATUS_SUCCESS) {
-        printf("[KVS Master] initKvsWebRtc(): Unable to initialize exponential backoff state: \n", retStatus);
-        goto CleanUp;
-    }
-
-    retStatus = exponentialBackoffBlockingWait(pExponentialBackoffState);
-    if (retStatus != STATUS_SUCCESS) {
-        printf("[KVS Master] initKvsWebRtc(): Unexpected error while adding a wait time: \n", retStatus);
-        goto CleanUp;
-    }
-
-    retStatus = createSignalingClientSync(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
+    CHK_STATUS(initializeExponentialBackoffStateWithDefaultConfig(&pExponentialBackoffState));
+    retStatus = createSignalingClientSyncWithWait(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
                                           &pSampleConfiguration->signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,
-                                          &pSampleConfiguration->signalingClientHandle);
+                                          &pSampleConfiguration->signalingClientHandle, pExponentialBackoffState);
     if (retStatus != STATUS_SUCCESS) {
         printf("[KVS GStreamer Master] createSignalingClientSync(): operation returned status code: 0x%08x \n", retStatus);
     }
@@ -492,6 +481,8 @@ CleanUp:
             printf("[KVS GStreamer Master] freeSampleConfiguration(): operation returned status code: 0x%08x \n", retStatus);
         }
     }
+    freeExponentialBackoffState(&pExponentialBackoffState);
+
     printf("[KVS Gstreamer Master] Cleanup done\n");
 
     RESET_INSTRUMENTED_ALLOCATORS();

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -12,6 +12,7 @@ VOID dataChannelOnMessageCallback(UINT64 customData, PRtcDataChannel pDataChanne
     } else {
         DLOGI("DataChannel String Message: %.*s\n", pMessageLen, pMessage);
     }
+    //exponentialBackoffBlockingWait(NULL);
 }
 
 // onOpen callback for the onOpen event of a viewer created data channel

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -21,6 +21,7 @@ extern "C" {
 #include <com/amazonaws/kinesis/video/common/Include.h>
 #include <com/amazonaws/kinesis/video/webrtcclient/NullableDefs.h>
 #include <com/amazonaws/kinesis/video/webrtcclient/Stats.h>
+#include "../source/Utils/ExponentialBackoffUtils.h"
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
@@ -360,6 +361,19 @@ extern "C" {
  */
 #define STATUS_ROLLING_BUFFER_BASE         STATUS_RTCP_BASE + 0x01000000
 #define STATUS_ROLLING_BUFFER_NOT_IN_RANGE STATUS_ROLLING_BUFFER_BASE + 0x00000001
+/*!@} */
+
+/////////////////////////////////////////////////////
+/// Exponential Backoff related status codes
+/////////////////////////////////////////////////////
+
+/*! \addtogroup Exponential back off retries status codes
+ * Values are derived from STATUS_EXPONENTIAL_BACKOFF_BASE
+ *  @{
+ */
+#define STATUS_EXPONENTIAL_BACKOFF_BASE                STATUS_ROLLING_BUFFER_BASE + 0x01000000
+#define STATUS_EXPONENTIAL_BACKOFF_RETRIES_EXHAUSTED   STATUS_EXPONENTIAL_BACKOFF_BASE + 0x00000001
+#define STATUS_EXPONENTIAL_INVALID_STATE               STATUS_EXPONENTIAL_BACKOFF_BASE + 0x00000002
 /*!@} */
 
 /////////////////////////////////////////////////////

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -155,7 +155,7 @@ STATUS generateJSONSafeString(PCHAR, UINT32);
 #include "Signaling/StateMachine.h"
 #include "Signaling/LwsApiCalls.h"
 #include "Metrics/Metrics.h"
-#include "Utils/ExponentialBackoffHelper.h"
+#include "Utils/ExponentialBackoffUtils.h"
 
 ////////////////////////////////////////////////////
 // Project internal defines

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -155,6 +155,7 @@ STATUS generateJSONSafeString(PCHAR, UINT32);
 #include "Signaling/StateMachine.h"
 #include "Signaling/LwsApiCalls.h"
 #include "Metrics/Metrics.h"
+#include "Utils/ExponentialBackoffHelper.h"
 
 ////////////////////////////////////////////////////
 // Project internal defines

--- a/src/source/Utils/ExponentialBackoffUtils.c
+++ b/src/source/Utils/ExponentialBackoffUtils.c
@@ -1,0 +1,214 @@
+#include <math.h>
+#include "ExponentialBackoffUtils.h"
+#include "../Include_i.h"
+
+STATUS getDefaultExponentialBackOffConfig(PExponentialBackoffConfig* ppPExponentialBackoffConfig) {
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PExponentialBackoffConfig pExponentialBackoffConfig = NULL;
+
+    CHK(ppPExponentialBackoffConfig != NULL, STATUS_NULL_ARG);
+
+    pExponentialBackoffConfig = (PExponentialBackoffConfig) MEMALLOC(SIZEOF(ExponentialBackoffConfig));
+    CHK(pExponentialBackoffConfig != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    pExponentialBackoffConfig->maxRetryCount = INFINITE_RETRY_COUNT_SENTINEL;
+    pExponentialBackoffConfig->maxWaitTime = HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_MAX_WAIT_TIME_MILLISECONDS;
+    pExponentialBackoffConfig->retryFactorTime = HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_RETRY_TIME_FACTOR_MILLISECONDS;
+    pExponentialBackoffConfig->minTimeToResetRetryState = HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS;
+    pExponentialBackoffConfig->jitterFactor = DEFAULT_JITTER_FACTOR_MILLISECONDS;
+
+    CleanUp:
+    (*ppPExponentialBackoffConfig) = pExponentialBackoffConfig;
+    LEAVES();
+    return retStatus;
+}
+
+STATUS resetRetryState(PExponentialBackoffState pExponentialBackoffState) {
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pExponentialBackoffState != NULL, STATUS_NULL_ARG);
+
+    pExponentialBackoffState->currentRetryCount = 0;
+    pExponentialBackoffState->lastRetryWaitTime = 0;
+    pExponentialBackoffState->status = BACKOFF_NOT_STARTED;
+    DLOGI("Resetting Exponential Backoff State");
+
+CleanUp:
+    LEAVES();
+    return retStatus;
+}
+
+STATUS initializeExponentialBackoffStateWithDefaultConfig(PExponentialBackoffState* ppExponentialBackoffState) {
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PExponentialBackoffState pExponentialBackoffState = NULL;
+    PExponentialBackoffConfig pExponentialBackoffConfig = NULL;
+
+    CHK(ppExponentialBackoffState != NULL, STATUS_NULL_ARG);
+
+    pExponentialBackoffState = (PExponentialBackoffState) MEMALLOC(SIZEOF(ExponentialBackoffState));
+    CHK(pExponentialBackoffState != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    CHK_STATUS(getDefaultExponentialBackOffConfig(&pExponentialBackoffConfig));
+
+    pExponentialBackoffState->pExponentialBackoffConfig = pExponentialBackoffConfig;
+    CHK_STATUS(resetRetryState(pExponentialBackoffState));
+
+CleanUp:
+    if (STATUS_SUCCEEDED(retStatus)) {
+        (*ppExponentialBackoffState) = pExponentialBackoffState;
+    } else {
+        if (pExponentialBackoffState != NULL) {
+            SAFE_MEMFREE(pExponentialBackoffState);
+            SAFE_MEMFREE(pExponentialBackoffState->pExponentialBackoffConfig);
+        }
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS initializeExponentialBackoffState(PExponentialBackoffState* ppBackoffState, PExponentialBackoffConfig pBackoffConfig) {
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PExponentialBackoffState pExponentialBackoffState = NULL;
+    PExponentialBackoffConfig pExponentialBackoffConfig = NULL;
+
+    CHK(ppBackoffState != NULL, STATUS_NULL_ARG);
+    CHK(pBackoffConfig != NULL, STATUS_NULL_ARG);
+
+    pExponentialBackoffState = (PExponentialBackoffState) MEMALLOC(SIZEOF(ExponentialBackoffState));
+    CHK(pExponentialBackoffState != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    pExponentialBackoffConfig = (PExponentialBackoffConfig) MEMALLOC(SIZEOF(ExponentialBackoffConfig));
+    CHK(pExponentialBackoffConfig != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    *pExponentialBackoffConfig = *pBackoffConfig;
+
+    pExponentialBackoffState->pExponentialBackoffConfig = pExponentialBackoffConfig;
+    CHK_STATUS(resetRetryState(pExponentialBackoffState));
+
+    CleanUp:
+    if (STATUS_SUCCEEDED(retStatus)) {
+        (*ppBackoffState) = pExponentialBackoffState;
+    } else {
+        SAFE_MEMFREE(pExponentialBackoffState);
+        SAFE_MEMFREE(pExponentialBackoffConfig);
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
+UINT64 getRandomJitter(UINT32 jitterFactor) {
+    return (RAND() % jitterFactor) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+}
+
+UINT64 calculateWaitTime(PExponentialBackoffState pRetryState, PExponentialBackoffConfig pRetryConfig) {
+    return pow(DEFAULT_EXPONENTIAL_FACTOR, pRetryState->currentRetryCount) * pRetryConfig->retryFactorTime;
+}
+
+STATUS validateAndUpdateExponentialBackoffStatus(PExponentialBackoffState pExponentialBackoffState) {
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    switch (pExponentialBackoffState->status) {
+        case BACKOFF_NOT_STARTED:
+            pExponentialBackoffState->status = BACKOFF_IN_PROGRESS;
+            DLOGI("Status changed from BACKOFF_NOT_STARTED to BACKOFF_IN_PROGRESS");
+            break;
+        case BACKOFF_IN_PROGRESS:
+            // Do nothing
+            DLOGI("Current status is BACKOFF_IN_PROGRESS");
+            break;
+        case BACKOFF_TERMINATED:
+            DLOGI("Cannot execute exponentialBackoffBlockingWait. Current status is BACKOFF_TERMINATED");
+            retStatus = STATUS_EXPONENTIAL_INVALID_STATE;
+            break;
+        default:
+            DLOGI("Cannot execute exponentialBackoffBlockingWait. Unexpected state [%d]", pExponentialBackoffState->status);
+            retStatus = STATUS_EXPONENTIAL_INVALID_STATE;
+    }
+
+    CleanUp:
+        LEAVES();
+        return retStatus;
+}
+
+STATUS exponentialBackoffBlockingWait(PExponentialBackoffState pRetryState) {
+    ENTERS();
+    PExponentialBackoffConfig pRetryConfig = NULL;
+    UINT64 currentTime = 0, waitTime = 0, jitter = 0;
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pRetryState != NULL, STATUS_NULL_ARG);
+    CHK(pRetryState->pExponentialBackoffConfig != NULL, STATUS_NULL_ARG);
+
+    CHK_STATUS(validateAndUpdateExponentialBackoffStatus(pRetryState));
+
+    pRetryConfig = pRetryState->pExponentialBackoffConfig;
+
+    // If retries is exhausted, return error to the application
+    if (pRetryConfig->maxRetryCount != INFINITE_RETRY_COUNT_SENTINEL) {
+        CHK(!(pRetryConfig->maxRetryCount == pRetryState->currentRetryCount),
+            STATUS_EXPONENTIAL_BACKOFF_RETRIES_EXHAUSTED);
+    }
+
+    // check the last retry time. If the difference between last retry and current time is greater than
+    // minTimeToResetRetryState, then reset the retry state
+    //
+    // Proceed if this is not the first retry
+    currentTime = GETTIME();
+    if (pRetryState->currentRetryCount != 0) {
+        if (currentTime - pRetryState->lastRetryWaitTime > pRetryConfig->minTimeToResetRetryState) {
+            CHK_STATUS(resetRetryState(pRetryState));
+            pRetryState->status = BACKOFF_IN_PROGRESS;
+        }
+    }
+
+    // Bound the exponential curve to maxWaitTime. Once we reach
+    // maxWaitTime, then we always wait for maxWaitTime time
+    // till the state is reset.
+    if (pRetryState->lastRetryWaitTime == pRetryConfig->maxWaitTime) {
+        waitTime = pRetryState->lastRetryWaitTime;
+    } else {
+        waitTime = calculateWaitTime(pRetryState, pRetryConfig);
+        if (waitTime > pRetryConfig->maxWaitTime) {
+            waitTime = pRetryConfig->maxWaitTime;
+        }
+    }
+
+    jitter = getRandomJitter(pRetryConfig->jitterFactor);
+    THREAD_SLEEP(waitTime + jitter);
+
+    pRetryState->lastRetryWaitTime = currentTime + waitTime + jitter;
+    pRetryState->currentRetryCount++;
+    DLOGI("Number of retries done [%"PRIu32"]. Last retry wait time [%"PRIu64"]",
+          pRetryState->currentRetryCount, pRetryState->lastRetryWaitTime);
+
+CleanUp:
+    if (retStatus == STATUS_EXPONENTIAL_BACKOFF_RETRIES_EXHAUSTED) {
+        DLOGI("Exhausted exponential retries");
+        resetRetryState(pRetryState);
+    }
+    LEAVES();
+    return retStatus;
+}
+
+VOID freeExponentialBackoffState(PExponentialBackoffState* ppExponentialBackoffState) {
+    ENTERS();
+    if (ppExponentialBackoffState == NULL) {
+        return;
+    }
+
+    if (*ppExponentialBackoffState != NULL) {
+        (*ppExponentialBackoffState)->status = BACKOFF_TERMINATED;
+        SAFE_MEMFREE((*ppExponentialBackoffState)->pExponentialBackoffConfig);
+        (*ppExponentialBackoffState)->pExponentialBackoffConfig = NULL;
+    }
+    SAFE_MEMFREE(*ppExponentialBackoffState);
+    *ppExponentialBackoffState = NULL;
+    LEAVES();
+}

--- a/src/source/Utils/ExponentialBackoffUtils.c
+++ b/src/source/Utils/ExponentialBackoffUtils.c
@@ -1,4 +1,3 @@
-#include <math.h>
 #include "ExponentialBackoffUtils.h"
 #include "../Include_i.h"
 
@@ -106,8 +105,16 @@ UINT64 getRandomJitter(UINT32 jitterFactor) {
     return (RAND() % jitterFactor) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
 }
 
+UINT64 power(UINT32 base, UINT32 exponent) {
+    UINT64 result = 1;
+    while (exponent-- > 0) {
+        result *= base;
+    }
+    return result;
+}
+
 UINT64 calculateWaitTime(PExponentialBackoffState pRetryState, PExponentialBackoffConfig pRetryConfig) {
-    return pow(DEFAULT_EXPONENTIAL_FACTOR, pRetryState->currentRetryCount) * pRetryConfig->retryFactorTime;
+    return power(DEFAULT_EXPONENTIAL_FACTOR, pRetryState->currentRetryCount) * pRetryConfig->retryFactorTime;
 }
 
 STATUS validateAndUpdateExponentialBackoffStatus(PExponentialBackoffState pExponentialBackoffState) {

--- a/src/source/Utils/ExponentialBackoffUtils.h
+++ b/src/source/Utils/ExponentialBackoffUtils.h
@@ -1,0 +1,139 @@
+/******************************************************
+A generic utility for exponential back off waits
+******************************************************/
+#ifndef __KINESIS_VIDEO_EXPONENTIAL_BACKOFF_HELPER_INCLUDE__
+#define __KINESIS_VIDEO_EXPONENTIAL_BACKOFF_HELPER_INCLUDE__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <com/amazonaws/kinesis/video/webrtcclient/Include.h>
+
+/************************************************************************
+ Following #define values are default configuration values for
+ exponential backoff retries.
+
+ With these values, the wait times will look like following -
+    ************************************
+    * Retry Count *      Wait time     *
+    * **********************************
+    *     1       *    300ms + jitter  *
+    *     2       *    600ms + jitter  *
+    *     3       *   1200ms + jitter  *
+    *     4       *   2400ms + jitter  *
+    *     5       *   4800ms + jitter  *
+    *     6       *   9600ms + jitter  *
+    *     7       *  10000ms + jitter  *
+    *     8       *  10000ms + jitter  *
+    *     9       *  10000ms + jitter  *
+    ************************************
+ jitter = random number between [0, 300)ms.
+************************************************************************/
+/**
+ * Factor for computing the exponential backoff wait time
+ */
+#define DEFAULT_RETRY_TIME_FACTOR_MILLISECONDS                  300
+
+/**
+ * Factor determining the curve of exponential wait time
+ */
+#define DEFAULT_EXPONENTIAL_FACTOR                              2
+
+/**
+ * Maximum exponential wait time. Once the exponential wait time
+ * curve reaches this value, it stays at this value. This is
+ * required to put a reasonable upper bound on wait time.
+ */
+#define DEFAULT_MAX_WAIT_TIME_MILLISECONDS                      15000
+
+/**
+ * Maximum time between two consecutive calls to exponentialBackoffBlockingWait
+ * after which the retry count will be reset to initial state.
+ */
+#define DEFAULT_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS      25000
+
+/**
+ * Factor to get a random jitter. Jitter values [0, 300).
+ */
+#define DEFAULT_JITTER_FACTOR_MILLISECONDS                      300
+
+typedef enum {
+    BACKOFF_NOT_STARTED     = (UINT16) 0x01,
+    BACKOFF_IN_PROGRESS     = (UINT16) 0x02,
+    BACKOFF_TERMINATED      = (UINT16) 0x03
+} ExponentialBackoffStatus;
+
+typedef struct __ExponentialBackoffConfig {
+    UINT32  maxRetryCount;
+    UINT64  maxWaitTime;
+    UINT32  retryFactorTime;
+    UINT64  minTimeToResetRetryState;
+    UINT32  jitterFactor;
+} ExponentialBackoffConfig;
+typedef ExponentialBackoffConfig* PExponentialBackoffConfig;
+
+typedef struct __ExponentialBackoffState {
+    PExponentialBackoffConfig pExponentialBackoffConfig;
+    ExponentialBackoffStatus status;
+    UINT32 currentRetryCount;
+    UINT64 lastRetryWaitTime;
+} ExponentialBackoffState;
+typedef ExponentialBackoffState* PExponentialBackoffState;
+
+/**************************************************************************************************
+API usage:
+
+ PExponentialBackoffState pExponentialBackoffState = NULL;
+ CHK_STATUS(initializeExponentialBackoffStateWithDefaultConfig(&pExponentialBackoffState));
+
+ while (...) {
+     CHK_STATUS(exponentialBackoffBlockingWait(pExponentialBackoffState));
+    // some business logic which includes service API call(s)
+ }
+
+ CHK_STATUS(freeExponentialBackoffState(&pExponentialBackoffState));
+
+**************************************************************************************************/
+
+/**
+ * @brief Initializes exponential backoff state with default configuration
+ * This should be called once before calling exponentialBackoffBlockingWait.
+ *
+ * NOT THREAD SAFE.
+ */
+PUBLIC_API STATUS initializeExponentialBackoffStateWithDefaultConfig(PExponentialBackoffState*);
+
+/**
+ * @brief Initializes exponential backoff state with provided configuration
+ * This should be called once before calling exponentialBackoffBlockingWait.
+ * If unsure about the configuration parameters, it is recommended to initialize
+ * the state using initializeExponentialBackoffStateWithDefaultConfig API
+ *
+ * NOT THREAD SAFE.
+ */
+PUBLIC_API STATUS initializeExponentialBackoffState(PExponentialBackoffState*, PExponentialBackoffConfig);
+
+/**
+ * @brief
+ * Computes next exponential backoff wait time and blocks the thread for that
+ * much time
+ *
+ * NOT THREAD SAFE.
+ */
+PUBLIC_API STATUS exponentialBackoffBlockingWait(PExponentialBackoffState pExponentialBackoffState);
+
+/**
+ * @brief Frees ExponentialBackoffState and its corresponding ExponentialBackoffConfig struct
+ *
+ * NOT THREAD SAFE.
+ */
+PUBLIC_API VOID freeExponentialBackoffState(PExponentialBackoffState*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // __KINESIS_VIDEO_EXPONENTIAL_BACKOFF_HELPER_INCLUDE__

--- a/tst/ExponentialBackoffUtilsTest.cpp
+++ b/tst/ExponentialBackoffUtilsTest.cpp
@@ -1,0 +1,232 @@
+#include "WebRTCClientTestFixture.h"
+#include <vector>
+#include <chrono>
+#include <thread>
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+typedef struct __Range {
+    double low;
+    double high;
+} Range;
+class ExponentialBackoffUtilsTest : public WebRtcClientTestBase {
+public:
+    bool inRange(double number, Range& range) {
+        return (range.low <= number && number <= range.high);
+    }
+
+    void getTestRetryConfiguration(PExponentialBackoffConfig pExponentialBackoffConfig) {
+        // Set time to reset state to 5 seconds
+        pExponentialBackoffConfig->minTimeToResetRetryState = 5000 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        // If testing bounded retries, set max retry count to 5
+        pExponentialBackoffConfig->maxRetryCount = INFINITE_RETRY_COUNT_SENTINEL;
+        // Set max exponential wait time to 3 seconds
+        pExponentialBackoffConfig->maxWaitTime = 3000 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        // Set retry factor to 100 milliseconds.
+        // With this value, the exponential curve will be -
+        // ((2^1)*X + jitter), ((2^1)*X + jitter), ((2^2)*X + jitter), ((2^3)*X + jitter) ...
+        // where X = 100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND
+        pExponentialBackoffConfig->retryFactorTime = 200 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        // Set random jitter between [0, 4] * HUNDREDS_OF_NANOS_IN_A_MILLISECOND
+        pExponentialBackoffConfig->jitterFactor = 50;
+    }
+
+    void validateExponentialBackoffWaitTime(
+            PExponentialBackoffState pExponentialBackoffState,
+            double currentTimeMilliSec,
+            int expectedRetryCount,
+            ExponentialBackoffStatus expectedExponentialBackoffStatus,
+            Range& acceptableWaitTimeRange) {
+        // Validate retry count is correctly incremented in ExponentialBackoffState
+        EXPECT_EQ(expectedRetryCount, pExponentialBackoffState->currentRetryCount);
+        // validate that the status is still "In Progress"
+        EXPECT_EQ(expectedExponentialBackoffStatus, pExponentialBackoffState->status);
+        // Record the actual wait time for validation
+        double lastWaitTimeMilliSec = (pExponentialBackoffState->lastRetryWaitTime)/(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 1.0);
+        double actualWaitTimeMilliSec = lastWaitTimeMilliSec - currentTimeMilliSec;
+        EXPECT_TRUE(inRange(actualWaitTimeMilliSec, acceptableWaitTimeRange));
+    }
+};
+
+TEST_F(ExponentialBackoffUtilsTest, testInitializeExponentialBackoffStateWithDefaultConfig)
+{
+    EXPECT_EQ(STATUS_NULL_ARG, initializeExponentialBackoffStateWithDefaultConfig(NULL));
+
+    PExponentialBackoffState pExponentialBackoffState = NULL;
+    EXPECT_EQ(STATUS_SUCCESS, initializeExponentialBackoffStateWithDefaultConfig(&pExponentialBackoffState));
+
+    EXPECT_TRUE(pExponentialBackoffState != NULL);
+    EXPECT_EQ(0, pExponentialBackoffState->currentRetryCount);
+    EXPECT_EQ(0, pExponentialBackoffState->lastRetryWaitTime);
+    EXPECT_EQ(BACKOFF_NOT_STARTED, pExponentialBackoffState->status);
+
+    EXPECT_TRUE(pExponentialBackoffState->pExponentialBackoffConfig != NULL);
+    EXPECT_EQ(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_RETRY_TIME_FACTOR_MILLISECONDS,
+                pExponentialBackoffState->pExponentialBackoffConfig->retryFactorTime);
+    EXPECT_EQ(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_MAX_WAIT_TIME_MILLISECONDS,
+                pExponentialBackoffState->pExponentialBackoffConfig->maxWaitTime);
+    EXPECT_EQ(INFINITE_RETRY_COUNT_SENTINEL, pExponentialBackoffState->pExponentialBackoffConfig->maxRetryCount);
+    EXPECT_EQ(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS,
+                pExponentialBackoffState->pExponentialBackoffConfig->minTimeToResetRetryState);
+
+    freeExponentialBackoffState(&pExponentialBackoffState);
+    EXPECT_TRUE(pExponentialBackoffState == NULL);
+}
+
+TEST_F(ExponentialBackoffUtilsTest, testInitializeExponentialBackoffState)
+{
+    PExponentialBackoffState pExponentialBackoffState = NULL;
+    PExponentialBackoffConfig pExponentialBackoffConfig = NULL;
+
+    EXPECT_EQ(STATUS_NULL_ARG, initializeExponentialBackoffState(NULL, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, initializeExponentialBackoffState(&pExponentialBackoffState, NULL));
+
+    pExponentialBackoffConfig = (PExponentialBackoffConfig) MEMALLOC(SIZEOF(ExponentialBackoffConfig));
+    EXPECT_TRUE(pExponentialBackoffConfig != NULL);
+
+    EXPECT_EQ(STATUS_NULL_ARG, initializeExponentialBackoffState(NULL, pExponentialBackoffConfig));
+
+    pExponentialBackoffConfig->minTimeToResetRetryState = 25;
+    pExponentialBackoffConfig->maxRetryCount = 5;
+    pExponentialBackoffConfig->maxWaitTime = 10;
+    pExponentialBackoffConfig->retryFactorTime = 20;
+    pExponentialBackoffConfig->jitterFactor = 1;
+    EXPECT_EQ(STATUS_SUCCESS, initializeExponentialBackoffState(&pExponentialBackoffState, pExponentialBackoffConfig));
+
+    EXPECT_TRUE(pExponentialBackoffState != NULL);
+    EXPECT_TRUE(pExponentialBackoffState->pExponentialBackoffConfig != NULL);
+    EXPECT_EQ(25, pExponentialBackoffState->pExponentialBackoffConfig->minTimeToResetRetryState);
+    EXPECT_EQ(5, pExponentialBackoffState->pExponentialBackoffConfig->maxRetryCount);
+    EXPECT_EQ(10, pExponentialBackoffState->pExponentialBackoffConfig->maxWaitTime);
+    EXPECT_EQ(20, pExponentialBackoffState->pExponentialBackoffConfig->retryFactorTime);
+    EXPECT_EQ(1, pExponentialBackoffState->pExponentialBackoffConfig->jitterFactor);
+
+    freeExponentialBackoffState(&pExponentialBackoffState);
+    EXPECT_TRUE(pExponentialBackoffState == NULL);
+    SAFE_MEMFREE(pExponentialBackoffConfig);
+}
+
+/**
+ * This test validates un-bounded exponentially backed-off retries with an upper
+ * bound on the actual retry wait time.
+ * The test performs 7 consecutive and validates the wait time for each retry.
+ * The retry config has an upper limit on
+ * The test verifies reception of error upon calling exponentialBackoffBlockingWait after
+ * configured retries are exhausted.
+ *
+ * This test takes roughly 15 seconds to execute
+ */
+TEST_F(ExponentialBackoffUtilsTest, testExponentialBackoffBlockingWait_Unbounded)
+{
+    PExponentialBackoffState pExponentialBackoffState = NULL;
+    PExponentialBackoffConfig pExponentialBackoffConfig = NULL;
+    pExponentialBackoffConfig = (PExponentialBackoffConfig) MEMALLOC(SIZEOF(ExponentialBackoffConfig));
+    EXPECT_TRUE(pExponentialBackoffConfig != NULL);
+
+    getTestRetryConfiguration(pExponentialBackoffConfig);
+
+    EXPECT_EQ(STATUS_SUCCESS, initializeExponentialBackoffState(&pExponentialBackoffState, pExponentialBackoffConfig));
+    EXPECT_TRUE(pExponentialBackoffState != NULL);
+    EXPECT_TRUE(pExponentialBackoffState->pExponentialBackoffConfig != NULL);
+
+    std::vector<double> actualRetryWaitTime;
+    std::vector<Range> acceptableRetryWaitTimeRangeMilliSec {
+        {200.0, 300.0},     // 1st retry 200ms + jitter
+        {400.0, 500.0},     // 2st retry 400ms + jitter
+        {800.0, 900.0},     // 3st retry 800ms + jitter
+        {1600.0, 1700.0},   // 4st retry 1600ms + jitter
+        {3000.0, 3100.0},   // 5st retry 3000ms + jitter
+        {3000.0, 3100.0},   // 6st retry 3000ms + jitter
+        {3000.0, 3100.0}    // 7st retry 3000ms + jitter
+    };
+
+    for (int retryCount = 0; retryCount < 7; retryCount++) {
+        double currentTimeMilliSec = GETTIME()/(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 1.0);
+        EXPECT_EQ(STATUS_SUCCESS, exponentialBackoffBlockingWait(pExponentialBackoffState));
+        validateExponentialBackoffWaitTime(
+                pExponentialBackoffState,
+                currentTimeMilliSec,
+                retryCount+1,
+                BACKOFF_IN_PROGRESS,
+                acceptableRetryWaitTimeRangeMilliSec.at(retryCount));
+    }
+
+    // We have configured minTimeToResetRetryState as 5 seconds. So sleep for just over 5 seconds
+    // and then verify the next retry has retry count as 1
+    std::this_thread::sleep_for(std::chrono::milliseconds(5100));
+    double currentTimeMilliSec = GETTIME()/(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 1.0);
+    EXPECT_EQ(STATUS_SUCCESS, exponentialBackoffBlockingWait(pExponentialBackoffState));
+    validateExponentialBackoffWaitTime(
+            pExponentialBackoffState,
+            currentTimeMilliSec,
+            1, // expected current retry count (1st retry)
+            BACKOFF_IN_PROGRESS, // expected retry state
+            acceptableRetryWaitTimeRangeMilliSec.at(0));
+
+    freeExponentialBackoffState(&pExponentialBackoffState);
+    EXPECT_TRUE(pExponentialBackoffState == NULL);
+    SAFE_MEMFREE(pExponentialBackoffConfig);
+}
+
+/**
+ * Test to validate bounded exponentially backed-off retries.
+ * The test performs 5 consecutive and validates the wait time for each retry.
+ * The test verifies reception of error upon calling exponentialBackoffBlockingWait after
+ * configured retries are exhausted.
+ *
+ * This test takes roughly 6 seconds to execute
+ */
+TEST_F(ExponentialBackoffUtilsTest, testExponentialBackoffBlockingWait_Bounded)
+{
+    PExponentialBackoffState pExponentialBackoffState = NULL;
+    PExponentialBackoffConfig pExponentialBackoffConfig = NULL;
+    pExponentialBackoffConfig = (PExponentialBackoffConfig) MEMALLOC(SIZEOF(ExponentialBackoffConfig));
+    EXPECT_TRUE(pExponentialBackoffConfig != NULL);
+
+    getTestRetryConfiguration(pExponentialBackoffConfig);
+    pExponentialBackoffConfig->maxRetryCount = 5;
+
+    EXPECT_EQ(STATUS_SUCCESS, initializeExponentialBackoffState(&pExponentialBackoffState, pExponentialBackoffConfig));
+    EXPECT_TRUE(pExponentialBackoffState != NULL);
+    EXPECT_TRUE(pExponentialBackoffState->pExponentialBackoffConfig != NULL);
+
+    std::vector<double> actualRetryWaitTime;
+    std::vector<Range> acceptableRetryWaitTimeRangeMilliSec {
+        {200.0, 300.0},     // 1st retry 200ms + jitter
+        {400.0, 500.0},     // 2st retry 400ms + jitter
+        {800.0, 900.0},     // 3st retry 800ms + jitter
+        {1600.0, 1700.0},   // 4st retry 1600ms + jitter
+        {3000.0, 3100.0},   // 5st retry 3000ms + jitter
+    };
+
+    for (int retryCount = 0; retryCount < pExponentialBackoffConfig->maxRetryCount; retryCount++) {
+        double currentTimeMilliSec = GETTIME()/(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 1.0);
+        EXPECT_EQ(STATUS_SUCCESS, exponentialBackoffBlockingWait(pExponentialBackoffState));
+        validateExponentialBackoffWaitTime(
+                pExponentialBackoffState,
+                currentTimeMilliSec,
+                retryCount+1,
+                BACKOFF_IN_PROGRESS,
+                acceptableRetryWaitTimeRangeMilliSec.at(retryCount));
+    }
+
+    // After the retries are exhausted, subsequent call to exponentialBackoffBlockingWait should return an error
+    EXPECT_EQ(STATUS_EXPONENTIAL_BACKOFF_RETRIES_EXHAUSTED, exponentialBackoffBlockingWait(pExponentialBackoffState));
+    EXPECT_EQ(0, pExponentialBackoffState->currentRetryCount);
+    EXPECT_EQ(0, pExponentialBackoffState->lastRetryWaitTime);
+    EXPECT_EQ(BACKOFF_NOT_STARTED, pExponentialBackoffState->status);
+
+    freeExponentialBackoffState(&pExponentialBackoffState);
+    EXPECT_TRUE(pExponentialBackoffState == NULL);
+    SAFE_MEMFREE(pExponentialBackoffConfig);
+}
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
PR consists of two changes - 
(1) Adding a generic utility for exponential backoff retries
(2) Wrapping createSignalingClientSync API with exponentially backed-off retries

*Testing:*
- Added new unit tests
- All other test are passing
- Attempted to run samples on my AWS account but I could not see the stream on KVS WebRTC Test Page. Most likely some configuration issue (unrelated to the change in this PR).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
