### PR TITLE
Return appropriate error code on non-success result from getChannelEndpoint call

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -898,7 +898,8 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
     resultLen = pLwsCallInfo->callInfo.responseDataLen;
 
     // Early return if we have a non-success result
-    CHK((SERVICE_CALL_RESULT) ATOMIC_LOAD(&pSignalingClient->result) == SERVICE_CALL_RESULT_OK && resultLen != 0 && pResponseStr != NULL, retStatus);
+    CHK((SERVICE_CALL_RESULT) ATOMIC_LOAD(&pSignalingClient->result) == SERVICE_CALL_RESULT_OK && resultLen != 0 && pResponseStr != NULL,
+        STATUS_INVALID_API_CALL_RETURN_JSON);
 
     // Parse and extract the endpoints
     jsmn_init(&parser);


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Currently if we get a non-successful HTTP response from call to `/getSignalingChannelEndpoint` (for example, a 403), a `STATUS_SUCCESS` is returned from this function. This makes it hard to debug errors since we will have assumed that the channel endpoint was successfully retrieved and stored into `pSignalingClient`.

I am not 100% on whether or not this is the right return code, please let me know if it isn't and I will update accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
