### PR TITLE
Added targets for cmake clean

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,3 +342,8 @@ endif()
 if(BUILD_BENCHMARK)
   add_subdirectory(bench)
 endif()
+
+get_directory_property(clean_files ADDITIONAL_CLEAN_FILES)
+list(APPEND clean_files "${OPEN_SRC_INSTALL_PREFIX}")
+list(APPEND clean_files "${CMAKE_CURRENT_SOURCE_DIR}/build")
+set_directory_properties(PROPERTIES ADDITIONAL_CLEAN_FILES "${clean_files}")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added targets for cmake to clean before building the project
- `cmake --build . --target clean` can be used to clean the added targets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
