### PR TITLE
set protocol value following the spec

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -99,10 +99,10 @@ STATUS createIceAgent(PCHAR username, PCHAR password, PIceAgentCallbacks pIceAge
             pIceAgent->rtcIceServerDiagnostics[i].port = (INT32) getInt16(pIceAgent->iceServers[i].ipAddress.port);
             switch (pIceAgent->iceServers[pIceAgent->iceServersCount].transport) {
                 case KVS_SOCKET_PROTOCOL_UDP:
-                    STRCPY(pIceAgent->rtcIceServerDiagnostics[i].protocol, ICE_URL_TRANSPORT_UDP);
+                    STRCPY(pIceAgent->rtcIceServerDiagnostics[i].protocol, ICE_TRANSPORT_TYPE_UDP);
                     break;
                 case KVS_SOCKET_PROTOCOL_TCP:
-                    STRCPY(pIceAgent->rtcIceServerDiagnostics[i].protocol, ICE_URL_TRANSPORT_TCP);
+                    STRCPY(pIceAgent->rtcIceServerDiagnostics[i].protocol, ICE_TRANSPORT_TYPE_TCP);
                     break;
                 default:
                     MEMSET(pIceAgent->rtcIceServerDiagnostics[i].protocol, 0, SIZEOF(pIceAgent->rtcIceServerDiagnostics[i].protocol));
@@ -1909,11 +1909,11 @@ STATUS updateCandidateStats(PIceAgent pIceAgent, BOOL isRemote)
         if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_RELAYED && pIceCandidate->pTurnConnection != NULL) {
             switch (pIceCandidate->pTurnConnection->protocol) {
                 case KVS_SOCKET_PROTOCOL_UDP:
-                    STRNCPY(pRtcIceCandidateDiagnostics->relayProtocol, ICE_URL_TRANSPORT_UDP,
+                    STRNCPY(pRtcIceCandidateDiagnostics->relayProtocol, ICE_TRANSPORT_TYPE_UDP,
                             ARRAY_SIZE(pRtcIceCandidateDiagnostics->relayProtocol));
                     break;
                 case KVS_SOCKET_PROTOCOL_TCP:
-                    STRNCPY(pRtcIceCandidateDiagnostics->relayProtocol, ICE_URL_TRANSPORT_TCP,
+                    STRNCPY(pRtcIceCandidateDiagnostics->relayProtocol, ICE_TRANSPORT_TYPE_TCP,
                             ARRAY_SIZE(pIceAgent->rtcSelectedLocalIceCandidateDiagnostics.relayProtocol));
                     break;
                 default:
@@ -1927,7 +1927,7 @@ STATUS updateCandidateStats(PIceAgent pIceAgent, BOOL isRemote)
     STRNCPY(pRtcIceCandidateDiagnostics->candidateType, iceAgentGetCandidateTypeStr(pIceCandidate->iceCandidateType),
             ARRAY_SIZE(pRtcIceCandidateDiagnostics->candidateType));
 
-    STRNCPY(pRtcIceCandidateDiagnostics->protocol, ICE_URL_TRANSPORT_UDP, ARRAY_SIZE(pRtcIceCandidateDiagnostics->protocol));
+    STRNCPY(pRtcIceCandidateDiagnostics->protocol, ICE_TRANSPORT_TYPE_UDP, ARRAY_SIZE(pRtcIceCandidateDiagnostics->protocol));
     if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_RELAYED) {
         STRNCPY(pRtcIceCandidateDiagnostics->protocol, pIceAgent->rtcIceServerDiagnostics[pIceCandidate->iceServerIndex].protocol,
                 ARRAY_SIZE(pRtcIceCandidateDiagnostics->protocol));

--- a/src/source/Ice/IceUtils.h
+++ b/src/source/Ice/IceUtils.h
@@ -21,6 +21,10 @@ extern "C" {
 #define ICE_URL_TRANSPORT_UDP      "transport=udp"
 #define ICE_URL_TRANSPORT_TCP      "transport=tcp"
 
+#define ICE_TRANSPORT_TYPE_UDP "udp"
+#define ICE_TRANSPORT_TYPE_TCP "tcp"
+#define ICE_TRANSPORT_TYPE_TLS "tls"
+
 /**
  * Ring buffer storing transactionIds
  */

--- a/src/source/Rtcp/RtpRollingBuffer.c
+++ b/src/source/Rtcp/RtpRollingBuffer.c
@@ -119,7 +119,7 @@ STATUS rtpRollingBufferGetValidSeqIndexList(PRtpRollingBuffer pRollingBuffer, PU
             pCurSeqIndexListPtr++;
             // Return if filled up given valid sequence number array
             CHK(++returnPacketCount < *pValidIndexListLen, retStatus);
-            *pCurSeqIndexListPtr = (UINT32) NULL;
+            *pCurSeqIndexListPtr = (UINT64) NULL;
         }
     }
 

--- a/tst/MetricsApiTest.cpp
+++ b/tst/MetricsApiTest.cpp
@@ -72,7 +72,7 @@ TEST_F(MetricsApiTest, webRtcIceServerGetMetrics)
     EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(pRtcPeerConnection, NULL, &rtcIceMetrics));
     EXPECT_EQ(443, rtcIceMetrics.rtcStatsObject.iceServerStats.port);
     EXPECT_PRED_FORMAT2(testing::IsSubstring, configuration.iceServers[1].urls, rtcIceMetrics.rtcStatsObject.iceServerStats.url);
-    EXPECT_PRED_FORMAT2(testing::IsSubstring, "transport=tcp", rtcIceMetrics.rtcStatsObject.iceServerStats.protocol);
+    EXPECT_PRED_FORMAT2(testing::IsSubstring, "tcp", rtcIceMetrics.rtcStatsObject.iceServerStats.protocol);
 
     EXPECT_EQ(STATUS_SUCCESS, closePeerConnection(pRtcPeerConnection));
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));


### PR DESCRIPTION
*Issue #1255 #1256 , if available:*

*Description of changes:*
Set protocol/relayProtocol of RtcIceCandidateStats following the [specification](https://www.w3.org/TR/webrtc-stats/#icecandidate-dict*).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
