### PR TITLE
[Request For Comments] Using Exponential Backoff APIs while creating signaling client in samples

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           99c1a8cd8cec88f99c9c4ce3944b53ae341d1491
+    GIT_TAG           b5019aa2de359d64a8202e757eb171874bb44da4
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -85,7 +85,11 @@ INT32 main(INT32 argc, CHAR* argv[])
     // Note:
     // If creating signaling client in a direct or some sort of indirect loop, then create exponentialBackoffState just once
     // and pass the same object to all the createSignalingClientSyncWithBackoff calls.
-    CHK_STATUS(exponentialBackoffStateWithDefaultConfigCreate(&pExponentialBackoffState));
+    retStatus = exponentialBackoffStateWithDefaultConfigCreate(&pExponentialBackoffState);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Viewer] exponentialBackoffStateWithDefaultConfigCreate(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
 
     retStatus = createSignalingClientSyncWithBackoff(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
                                           &pSampleConfiguration->signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -87,7 +87,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     // and pass the same object to all the createSignalingClientSyncWithBackoff calls.
     retStatus = exponentialBackoffStateWithDefaultConfigCreate(&pExponentialBackoffState);
     if (retStatus != STATUS_SUCCESS) {
-        printf("[KVS Viewer] exponentialBackoffStateWithDefaultConfigCreate(): operation returned status code: 0x%08x \n", retStatus);
+        printf("[KVS Master] exponentialBackoffStateWithDefaultConfigCreate(): operation returned status code: 0x%08x \n", retStatus);
         goto CleanUp;
     }
 

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -425,7 +425,11 @@ INT32 main(INT32 argc, CHAR* argv[])
     // Note:
     // If creating signaling client in a direct or some sort of indirect loop, then create exponentialBackoffState just once
     // and pass the same object to all the createSignalingClientSyncWithBackoff calls.
-    CHK_STATUS(exponentialBackoffStateWithDefaultConfigCreate(&pExponentialBackoffState));
+    retStatus = exponentialBackoffStateWithDefaultConfigCreate(&pExponentialBackoffState);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Viewer] exponentialBackoffStateWithDefaultConfigCreate(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
 
     retStatus = createSignalingClientSyncWithBackoff(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
                                           &pSampleConfiguration->signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -427,7 +427,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     // and pass the same object to all the createSignalingClientSyncWithBackoff calls.
     retStatus = exponentialBackoffStateWithDefaultConfigCreate(&pExponentialBackoffState);
     if (retStatus != STATUS_SUCCESS) {
-        printf("[KVS Viewer] exponentialBackoffStateWithDefaultConfigCreate(): operation returned status code: 0x%08x \n", retStatus);
+        printf("[KVS GStreamer Master] exponentialBackoffStateWithDefaultConfigCreate(): operation returned status code: 0x%08x \n", retStatus);
         goto CleanUp;
     }
 

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -88,7 +88,11 @@ INT32 main(INT32 argc, CHAR* argv[])
     // Note:
     // If creating signaling client in a direct or some sort of indirect loop, then create exponentialBackoffState just once
     // and pass the same object to all the createSignalingClientSyncWithBackoff calls.
-    CHK_STATUS(exponentialBackoffStateWithDefaultConfigCreate(&pExponentialBackoffState));
+    retStatus = exponentialBackoffStateWithDefaultConfigCreate(&pExponentialBackoffState);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Viewer] exponentialBackoffStateWithDefaultConfigCreate(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
 
     retStatus = createSignalingClientSyncWithBackoff(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
                                           &pSampleConfiguration->signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1868,6 +1868,23 @@ PUBLIC_API STATUS createSignalingClientSync(PSignalingClientInfo, PChannelInfo, 
                                             PSIGNALING_CLIENT_HANDLE);
 
 /**
+ * @brief Creates a Signaling client and returns a handle to it.
+ * Calls to this API in quick succession could result in blocking the thread
+ * for the wait time computed within PExponentialBackoffState.
+ *
+ * @param[in] PSignalingClientInfo Signaling client info
+ * @param[in] PChannelInfo Signaling channel info to use/create a channel
+ * @param[in] PSignalingClientCallbacks Signaling callbacks for event notifications
+ * @param[in] PAwsCredentialProvider Credential provider for auth integration
+ * @param[in] PExponentialBackoffState Exponential backoff state
+ * @param[out] PSIGNALING_CLIENT_HANDLE Returned signaling client handle
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS createSignalingClientSyncWithBackoff(PSignalingClientInfo, PChannelInfo, PSignalingClientCallbacks, PAwsCredentialProvider,
+                                                       PSIGNALING_CLIENT_HANDLE, PExponentialBackoffState);
+
+/**
  * @brief Frees the Signaling client object
  *
  * NOTE: The call is idempotent.

--- a/src/source/Signaling/Client.c
+++ b/src/source/Signaling/Client.c
@@ -1,6 +1,5 @@
 #define LOG_CLASS "SignalingClient"
 #include "../Include_i.h"
-#include "com/amazonaws/kinesis/video/utils/Include.h"
 
 STATUS createSignalingClientSyncWithBackoff(
         PSignalingClientInfo pClientInfo, PChannelInfo pChannelInfo, PSignalingClientCallbacks pCallbacks,

--- a/src/source/Signaling/Client.c
+++ b/src/source/Signaling/Client.c
@@ -1,8 +1,10 @@
 #define LOG_CLASS "SignalingClient"
 #include "../Include_i.h"
+#include "com/amazonaws/kinesis/video/utils/Include.h"
 
-STATUS createSignalingClientSync(PSignalingClientInfo pClientInfo, PChannelInfo pChannelInfo, PSignalingClientCallbacks pCallbacks,
-                                 PAwsCredentialProvider pCredentialProvider, PSIGNALING_CLIENT_HANDLE pSignalingHandle)
+STATUS createSignalingClientSyncWithBackoff(
+        PSignalingClientInfo pClientInfo, PChannelInfo pChannelInfo, PSignalingClientCallbacks pCallbacks,
+        PAwsCredentialProvider pCredentialProvider, PSIGNALING_CLIENT_HANDLE pSignalingHandle, PExponentialBackoffState pExponentialBackoffState)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -16,18 +18,29 @@ STATUS createSignalingClientSync(PSignalingClientInfo pClientInfo, PChannelInfo 
     MEMSET(&signalingClientInfoInternal, 0x00, SIZEOF(signalingClientInfoInternal));
     signalingClientInfoInternal.signalingClientInfo = *pClientInfo;
 
+    if (pExponentialBackoffState != NULL) {
+        DLOGI("Exponential backoff state is not NULL. Attempting to back off before creating signaling client.");
+        CHK_STATUS(exponentialBackoffBlockingWait(pExponentialBackoffState));
+    }
+
     CHK_STATUS(createSignalingSync(&signalingClientInfoInternal, pChannelInfo, pCallbacks, pCredentialProvider, &pSignalingClient));
 
     *pSignalingHandle = TO_SIGNALING_CLIENT_HANDLE(pSignalingClient);
 
 CleanUp:
 
-    if (STATUS_FAILED(retStatus)) {
-        freeSignaling(&pSignalingClient);
-    }
+     if (STATUS_FAILED(retStatus)) {
+         freeSignaling(&pSignalingClient);
+     }
 
-    LEAVES();
-    return retStatus;
+     LEAVES();
+     return retStatus;
+}
+
+STATUS createSignalingClientSync(PSignalingClientInfo pClientInfo, PChannelInfo pChannelInfo, PSignalingClientCallbacks pCallbacks,
+                                 PAwsCredentialProvider pCredentialProvider, PSIGNALING_CLIENT_HANDLE pSignalingHandle)
+{
+    return createSignalingClientSyncWithBackoff(pClientInfo, pChannelInfo, pCallbacks, pCredentialProvider, pSignalingHandle, NULL);
 }
 
 STATUS freeSignalingClient(PSIGNALING_CLIENT_HANDLE pSignalingHandle)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The PR contains changes to 
- Consume latest Producer (and PIC)
- Use Exponential Backoff APIs while creating signaling client in samples

I've created a separate API to create signaling client with exponential backoff. This technically should be the only API and we should remove the existing one. But this would be a breaking change for existing customers so I've just kept both APIs there for the time being. I'll send a separate CR if we decide to deprecate the older one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
