### PR TITLE
libwebsockets: add patch to fix pipe fd leak issue

### DIFF
--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 project(libwebsocket-download NONE)
 
-SET(PATCH_COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_LIST_DIR}/libwebsockets-old-gcc-fix-cast-cmakelists.patch)
+SET(PATCH_COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_LIST_DIR}/libwebsockets-old-gcc-fix-cast-cmakelists.patch ${CMAKE_CURRENT_LIST_DIR}/libwebsockets-leak-pipe-fix.patch)
 
 include(ExternalProject)
 

--- a/CMake/Dependencies/libwebsockets-leak-pipe-fix.patch
+++ b/CMake/Dependencies/libwebsockets-leak-pipe-fix.patch
@@ -1,0 +1,36 @@
+Author: Andy Green <andy@warmcat.com>
+Date: Wed Sep 08 12:25:47 2021 +0200
+
+cancel pipe: make sure we closed it on destroy with no EVENTFD case
+
+
+diff --git a/lib/core/context.c b/lib/core/context.c
+index 6194801..4f3bb45 100644
+--- a/lib/core/context.c
++++ b/lib/core/context.c
+@@ -1625,11 +1625,25 @@ lws_pt_destroy(struct lws_context_per_thread *pt)
+ 	vpt->foreign_pfd_list = NULL;
+ 
+ 	lws_pt_lock(pt, __func__);
++
+ 	if (pt->pipe_wsi) {
+ 		lws_destroy_event_pipe(pt->pipe_wsi);
+ 		pt->pipe_wsi = NULL;
+ 	}
+ 
++	if (pt->dummy_pipe_fds[0]
++#if !defined(WIN32)
++	    && (int)pt->dummy_pipe_fds[0] != -1
++#endif
++	) {
++		struct lws wsi;
++
++		memset(&wsi, 0, sizeof(wsi));
++		wsi.a.context = pt->context;
++		wsi.tsi = (char)pt->tid;
++		lws_plat_pipe_close(&wsi);
++	}
++
+ #if defined(LWS_WITH_SECURE_STREAMS)
+ 	lws_dll2_foreach_safe(&pt->ss_owner, NULL, lws_ss_destroy_dll);
+ 


### PR DESCRIPTION
Signed-off-by: Alex.Li <zhiqinli@amazon.com>

*Issue #, if available:*
#1263 

*Description of changes:*
This change will add a patch from libwebsockets to fix pipe fd leak issue when build libwebsockets with `DLWS_HAVE_EVENTFD=0`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
