### PR TITLE
Fix scripts/pare_status.py for non-status #defines

### DIFF
--- a/scripts/parse_status.py
+++ b/scripts/parse_status.py
@@ -20,7 +20,7 @@ example_sums = hex_sums(operands_map)
 print(example_sums) # {'STATUS_CHILD': "0x5", 'STATUS_PARENT': "0x4"}
 '''
 
-pattern = re.compile("#define *([A-Z_]*) *(([A-Z_]*) *\+ *)?0x([0-9]*)")
+pattern = re.compile("#define *(STATUS\_[A-Z_]*) *(([A-Z_]*) *\+ *)?0x([0-9]*)")
 
 def operands_by_name(paragraph):
     matches = filter(None, [pattern.match(line) for line in paragraph.splitlines()])


### PR DESCRIPTION
*Description of changes:*
Update the regex in `scripts/pare_status.py` to only pick up on `#define` lines which begin with `STATUS_`, to exclude lines such as:

```
#define WINVER       0x0A00
```

Which involve a hex defined variable but should not be included in the ouput of this script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
