### PR TITLE
Modifying relay candidate will change to prflx candidate in a specifi…

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2574,7 +2574,9 @@ STATUS iceAgentCheckPeerReflexiveCandidate(PIceAgent pIceAgent, PKvsIpAddress pI
         CHK(pIceCandidate == NULL, retStatus); // return early if duplicated
 
         findCandidateWithSocketConnection(pSocketConnection, pIceAgent->localCandidates, &pLocalIceCandidate);
-        pLocalIceCandidate->iceCandidateType = ICE_CANDIDATE_TYPE_PEER_REFLEXIVE;
+		if (pLocalIceCandidate->iceCandidateType != ICE_CANDIDATE_TYPE_RELAYED) {
+			pLocalIceCandidate->iceCandidateType = ICE_CANDIDATE_TYPE_PEER_REFLEXIVE;	
+		}
         pLocalIceCandidate->ipAddress = *pIpAddress;
         iceAgentLogNewCandidate(pLocalIceCandidate);
         CHK(FALSE, retStatus);

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -759,7 +759,7 @@ STATUS iceAgentShutdown(PIceAgent pIceAgent)
             /* close socket so ice doesnt receive any more data */
             CHK_STATUS(socketConnectionClosed(pLocalCandidate->pSocketConnection));
         } else {
-            CHK_STATUS(turnConnectionShutdown(pLocalCandidate->pTurnConnection, 0));
+            CHK_STATUS(turnConnectionShutdown(pLocalCandidate->pTurnConnection, 5 * HUNDREDS_OF_NANOS_IN_A_SECOND));
             turnConnections[turnConnectionCount++] = pLocalCandidate->pTurnConnection;
         }
     }


### PR DESCRIPTION
…c network environment, resulting in the problem of being unable to connect

*Issue #, if available:*

Modifying relay candidate will change to prflx candidate in a specific network environment, resulting in the problem of being unable to connect.

*Description of changes:*
The simplest way is to modify only non relay candidate to the prflx type .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
