### PR TITLE
fix edge case try to unlock a mutex which is not locked in the case sample configuration is NULL

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -1228,7 +1228,7 @@ STATUS signalingMessageReceived(UINT64 customData, PReceivedSignalingMessage pRe
 {
     STATUS retStatus = STATUS_SUCCESS;
     PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) customData;
-    BOOL peerConnectionFound = FALSE, locked = TRUE, startStats = FALSE;
+    BOOL peerConnectionFound = FALSE, locked = FALSE, startStats = FALSE;
     UINT32 clientIdHash;
     UINT64 hashValue = 0;
     PPendingMessageQueue pPendingMessageQueue = NULL;


### PR DESCRIPTION
*Issue #, if available:*

We initialized locked to `TRUE` this results in an edge case bug where if the `pSampleConfiguration` is `NULL` we will try to unlocked.  Though we set the attribute for the mutex to `PTHREAD_MUTEX_RECURSIVE` which means the unlock will return an error I don't think we actually log that error anywhere.  This fixes that initial value for the `locked` boolean.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
