### PR TITLE
#1300 fix compile errors cause by not including "poll.h"

### DIFF
--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -65,6 +65,7 @@ extern "C" {
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #endif
 
 // Max uFrag and uPwd length as documented in https://tools.ietf.org/html/rfc5245#section-15.4


### PR DESCRIPTION
*Issue #1300 

*Description of changes:*

add #include <poll.h> to Include_i.h

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
