### PR TITLE
log response, particularly in case of failure

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -111,7 +111,7 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
             lwsl_hexdump_debug(pDataIn, dataSize);
 
             if (dataSize != 0) {
-                CHK(NULL != (pLwsCallInfo->callInfo.responseData = (PCHAR) MEMALLOC(dataSize)), STATUS_NOT_ENOUGH_MEMORY);
+                CHK(NULL != (pLwsCallInfo->callInfo.responseData = (PCHAR) MEMALLOC(dataSize+1)), STATUS_NOT_ENOUGH_MEMORY);
                 MEMCPY(pLwsCallInfo->callInfo.responseData, pDataIn, dataSize);
                 pLwsCallInfo->callInfo.responseDataLen = (UINT32) dataSize;
                 pLwsCallInfo->callInfo.responseData[dataSize] = '\0';

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -114,6 +114,7 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
                 CHK(NULL != (pLwsCallInfo->callInfo.responseData = (PCHAR) MEMALLOC(dataSize)), STATUS_NOT_ENOUGH_MEMORY);
                 MEMCPY(pLwsCallInfo->callInfo.responseData, pDataIn, dataSize);
                 pLwsCallInfo->callInfo.responseDataLen = (UINT32) dataSize;
+                DLOGV("Received client http read response:  %s", pLwsCallInfo->callInfo.responseData);
             }
 
             break;

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -114,6 +114,7 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
                 CHK(NULL != (pLwsCallInfo->callInfo.responseData = (PCHAR) MEMALLOC(dataSize)), STATUS_NOT_ENOUGH_MEMORY);
                 MEMCPY(pLwsCallInfo->callInfo.responseData, pDataIn, dataSize);
                 pLwsCallInfo->callInfo.responseDataLen = (UINT32) dataSize;
+                pLwsCallInfo->callInfo.responseData[dataSize] = '\0';
                 if (pLwsCallInfo->callInfo.callResult != SERVICE_CALL_RESULT_OK) {
                     DLOGW("Received client http read response:  %s", pLwsCallInfo->callInfo.responseData);
                 } else {
@@ -891,7 +892,7 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
                                  SSL_CERTIFICATE_TYPE_NOT_SPECIFIED, pSignalingClient->pChannelInfo->pUserAgent,
                                  SIGNALING_SERVICE_API_CALL_CONNECTION_TIMEOUT, SIGNALING_SERVICE_API_CALL_COMPLETION_TIMEOUT,
                                  DEFAULT_LOW_SPEED_LIMIT, DEFAULT_LOW_SPEED_TIME_LIMIT, pSignalingClient->pAwsCredentials, &pRequestInfo));
-    
+
     CHK_STATUS(createLwsCallInfo(pSignalingClient, pRequestInfo, PROTOCOL_INDEX_HTTPS, &pLwsCallInfo));
 
     // Make a blocking call

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -114,7 +114,11 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
                 CHK(NULL != (pLwsCallInfo->callInfo.responseData = (PCHAR) MEMALLOC(dataSize)), STATUS_NOT_ENOUGH_MEMORY);
                 MEMCPY(pLwsCallInfo->callInfo.responseData, pDataIn, dataSize);
                 pLwsCallInfo->callInfo.responseDataLen = (UINT32) dataSize;
-                DLOGV("Received client http read response:  %s", pLwsCallInfo->callInfo.responseData);
+                if (pLwsCallInfo->callInfo.callResult != SERVICE_CALL_RESULT_OK) {
+                    DLOGW("Received client http read response:  %s", pLwsCallInfo->callInfo.responseData);
+                } else {
+                    DLOGV("Received client http read response:  %s", pLwsCallInfo->callInfo.responseData);
+                }
             }
 
             break;
@@ -887,7 +891,7 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
                                  SSL_CERTIFICATE_TYPE_NOT_SPECIFIED, pSignalingClient->pChannelInfo->pUserAgent,
                                  SIGNALING_SERVICE_API_CALL_CONNECTION_TIMEOUT, SIGNALING_SERVICE_API_CALL_COMPLETION_TIMEOUT,
                                  DEFAULT_LOW_SPEED_LIMIT, DEFAULT_LOW_SPEED_TIME_LIMIT, pSignalingClient->pAwsCredentials, &pRequestInfo));
-
+    
     CHK_STATUS(createLwsCallInfo(pSignalingClient, pRequestInfo, PROTOCOL_INDEX_HTTPS, &pLwsCallInfo));
 
     // Make a blocking call


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For example before if the request signature was too old we should just swallow that error and manifest as a timeout 0x0000000f in the sync call.  Now we have logging to indicate what the error is, for example:

```
2021-10-29 14:50:08 WARN    lwsHttpCallbackRoutine(): Received client http read response:  {"message":"Signature expired: 20211029T144008Z is now earlier than 20211029T144508Z (20211029T145008Z - 5 min.)"}
```

In this instance I tried to submit the API call 10 minutes after the time was set in the request header.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
