### PR TITLE
Signaling state machine rework

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -574,6 +574,11 @@ extern "C" {
 #define SIGNALING_CONNECT_STATE_TIMEOUT (15 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
 /**
+ * Default disconnect sync API timeout
+ */
+#define SIGNALING_DISCONNECT_STATE_TIMEOUT (15 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
+/**
  * Default refresh ICE server config API timeout
  */
 #define SIGNALING_REFRESH_ICE_CONFIG_STATE_TIMEOUT (15 * HUNDREDS_OF_NANOS_IN_A_SECOND)

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -495,7 +495,7 @@ extern "C" {
 /**
  * Version of signaling client
  */
-#define SIGNALING_CLIENT_CURRENT_VERSION 0
+#define SIGNALING_CLIENT_CURRENT_VERSION 1
 
 /**
  * Version of SignalingChannelDescription structure

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -37,7 +37,7 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     CHK_STATUS(validateSignalingCallbacks(pSignalingClient, pCallbacks));
     CHK_STATUS(validateSignalingClientInfo(pSignalingClient, pClientInfo));
 
-    pSignalingClient->version = 1;
+    pSignalingClient->version = SIGNALING_CLIENT_CURRENT_VERSION;
 
     // Set invalid call times
     pSignalingClient->describeTime = INVALID_TIMESTAMP_VALUE;
@@ -626,7 +626,7 @@ STATUS signalingStoreOngoingMessage(PSignalingClient pSignalingClient, PSignalin
     CHK(pSignalingClient != NULL && pSignalingMessage != NULL, STATUS_NULL_ARG);
     MUTEX_LOCK(pSignalingClient->messageQueueLock);
     locked = TRUE;
-    // pOngoingCallInfo already null here
+
     CHK_STATUS(signalingGetOngoingMessage(pSignalingClient, pSignalingMessage->correlationId, pSignalingMessage->peerClientId, &pExistingMessage));
     CHK(pExistingMessage == NULL, STATUS_SIGNALING_DUPLICATE_MESSAGE_BEING_SENT);
     CHK_STATUS(stackQueueEnqueue(pSignalingClient->pMessageQueue, (UINT64) pSignalingMessage));

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -37,6 +37,8 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     CHK_STATUS(validateSignalingCallbacks(pSignalingClient, pCallbacks));
     CHK_STATUS(validateSignalingClientInfo(pSignalingClient, pClientInfo));
 
+    pSignalingClient->version = 1;
+
     // Set invalid call times
     pSignalingClient->describeTime = INVALID_TIMESTAMP_VALUE;
     pSignalingClient->createTime = INVALID_TIMESTAMP_VALUE;
@@ -151,9 +153,6 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     // At this point we have constructed the main object and we can assign to the returned pointer
     *ppSignalingClient = pSignalingClient;
 
-    // Set the time out before execution
-    pSignalingClient->stepUntil = pSignalingClient->diagnostics.createTime + SIGNALING_CREATE_TIMEOUT;
-
     // Notify of the state change initially as the state machinery is already in the NEW state
     if (pSignalingClient->signalingClientCallbacks.stateChangeFn != NULL) {
         CHK_STATUS(getStateMachineCurrentState(pSignalingClient->pStateMachine, &pStateMachineState));
@@ -165,8 +164,8 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     ATOMIC_STORE_BOOL(&pSignalingClient->refreshIceConfig, FALSE);
 
     // Prime the state machine
-    CHK_STATUS(signalingStateMachineIterator(pSignalingClient, pSignalingClient->stepUntil,
-                                             SIGNALING_STATE_READY, STATUS_SUCCESS));
+    CHK_STATUS(signalingStateMachineIterator(pSignalingClient, pSignalingClient->diagnostics.createTime + SIGNALING_CREATE_TIMEOUT,
+                                             SIGNALING_STATE_READY));
 
 CleanUp:
 
@@ -380,17 +379,11 @@ STATUS signalingConnectSync(PSignalingClient pSignalingClient)
     // Check if we are already connected
     CHK(!ATOMIC_LOAD_BOOL(&pSignalingClient->connected), retStatus);
 
-    // Self-prime through the ready state
-    pSignalingClient->continueOnReady = TRUE;
-
     // Store the signaling state in case we error/timeout so we can re-set it on exit
     CHK_STATUS(getStateMachineCurrentState(pSignalingClient->pStateMachine, &pState));
 
-    // Set the time out before execution
-    pSignalingClient->stepUntil = GETTIME() + SIGNALING_CONNECT_STATE_TIMEOUT;
-
-    CHK_STATUS(signalingStateMachineIterator(pSignalingClient, pSignalingClient->stepUntil,
-                                             SIGNALING_STATE_CONNECTED, retStatus));
+    CHK_STATUS(signalingStateMachineIterator(pSignalingClient, GETTIME() + SIGNALING_CONNECT_STATE_TIMEOUT,
+                                             SIGNALING_STATE_CONNECTED));
 
 CleanUp:
 
@@ -410,12 +403,8 @@ STATUS signalingDisconnectSync(PSignalingClient pSignalingClient)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT64 disconnectExpiration = GETTIME() + SIGNALING_CONNECT_STATE_TIMEOUT;
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
-
-    // Do not self-prime through the ready state
-    pSignalingClient->continueOnReady = FALSE;
 
     // Check if we are already not connected
     CHK(ATOMIC_LOAD_BOOL(&pSignalingClient->connected), retStatus);
@@ -424,7 +413,7 @@ STATUS signalingDisconnectSync(PSignalingClient pSignalingClient)
 
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) SERVICE_CALL_RESULT_OK);
 
-    CHK_STATUS(signalingStateMachineIterator(pSignalingClient, disconnectExpiration, SIGNALING_STATE_DISCONNECTED, retStatus));
+    CHK_STATUS(signalingStateMachineIterator(pSignalingClient, GETTIME() + SIGNALING_DISCONNECT_STATE_TIMEOUT, SIGNALING_STATE_READY));
 
 CleanUp:
 
@@ -438,7 +427,6 @@ STATUS signalingDeleteSync(PSignalingClient pSignalingClient)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT64 deleteExpiration = GETTIME() + SIGNALING_DELETE_TIMEOUT;
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
 
@@ -453,10 +441,7 @@ STATUS signalingDeleteSync(PSignalingClient pSignalingClient)
     // Set the state directly
     setStateMachineCurrentState(pSignalingClient->pStateMachine, SIGNALING_STATE_DELETE);
 
-    // Set the time out before execution
-    pSignalingClient->stepUntil = GETTIME() + SIGNALING_DELETE_TIMEOUT;
-
-    CHK_STATUS(signalingStateMachineIterator(pSignalingClient, deleteExpiration, SIGNALING_STATE_DELETED, retStatus));
+    CHK_STATUS(signalingStateMachineIterator(pSignalingClient, GETTIME() + SIGNALING_DELETE_TIMEOUT, SIGNALING_STATE_DELETED));
 
 CleanUp:
 
@@ -571,6 +556,7 @@ STATUS refreshIceConfiguration(PSignalingClient pSignalingClient)
     CHAR iceRefreshErrMsg[SIGNALING_MAX_ERROR_MESSAGE_LEN + 1];
     UINT32 iceRefreshErrLen;
     UINT64 curTime;
+    BOOL locked = FALSE;
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
 
@@ -584,6 +570,8 @@ STATUS refreshIceConfiguration(PSignalingClient pSignalingClient)
     CHK_STATUS(acceptStateMachineState(pSignalingClient->pStateMachine,
                                        SIGNALING_STATE_READY | SIGNALING_STATE_CONNECT | SIGNALING_STATE_CONNECTED | SIGNALING_STATE_DISCONNECTED));
 
+    MUTEX_LOCK(pSignalingClient->stateLock);
+    locked = TRUE;
     // Get and store the current state to re-set to if we fail
     CHK_STATUS(getStateMachineCurrentState(pSignalingClient->pStateMachine, &pStateMachineState));
 
@@ -593,14 +581,15 @@ STATUS refreshIceConfiguration(PSignalingClient pSignalingClient)
 
     // Iterate the state machinery in steady states only - ready or connected
     if (pStateMachineState->state == SIGNALING_STATE_READY || pStateMachineState->state == SIGNALING_STATE_CONNECTED) {
-        // Set the time out before execution
-        pSignalingClient->stepUntil = curTime + SIGNALING_REFRESH_ICE_CONFIG_STATE_TIMEOUT;
-
-        CHK_STATUS(signalingStateMachineIterator(pSignalingClient, pSignalingClient->stepUntil,
-                                                 pStateMachineState->state, retStatus));
+        CHK_STATUS(signalingStateMachineIterator(pSignalingClient, curTime + SIGNALING_REFRESH_ICE_CONFIG_STATE_TIMEOUT,
+                                                 pStateMachineState->state));
     }
 
 CleanUp:
+
+    if (locked) {
+        MUTEX_UNLOCK(pSignalingClient->stateLock);
+    }
 
     CHK_LOG_ERR(retStatus);
 

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -44,6 +44,9 @@ extern "C" {
 // Error reconnecting to the signaling service
 #define SIGNALING_RECONNECT_ERROR_MSG "Failed to reconnect with status code 0x%08x."
 
+// Signaling client structure version
+#define SIGNALING_CLIENT_CURRENT_VERSION 1
+
 // Max error string length
 #define SIGNALING_MAX_ERROR_MESSAGE_LEN 512
 

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -44,9 +44,6 @@ extern "C" {
 // Error reconnecting to the signaling service
 #define SIGNALING_RECONNECT_ERROR_MSG "Failed to reconnect with status code 0x%08x."
 
-// Signaling client structure version
-#define SIGNALING_CLIENT_CURRENT_VERSION 1
-
 // Max error string length
 #define SIGNALING_MAX_ERROR_MESSAGE_LEN 512
 

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -139,6 +139,9 @@ typedef struct {
  * Internal representation of the Signaling client.
  */
 typedef struct {
+    // Current version of the structure
+    UINT32 version;
+
     // Current service call result
     volatile SIZE_T result;
 
@@ -169,9 +172,6 @@ typedef struct {
 
     // Indicates that there is another thread attempting to grab the service lock
     volatile ATOMIC_BOOL serviceLockContention;
-
-    // Current version of the structure
-    UINT32 version;
 
     // Stored Client info
     SignalingClientInfoInternal clientInfo;
@@ -209,9 +209,6 @@ typedef struct {
     // Service call context
     ServiceCallContext serviceCallContext;
 
-    // Indicates whether to self-prime on Ready or not
-    BOOL continueOnReady;
-
     // Interlocking the state transitions
     MUTEX stateLock;
 
@@ -232,9 +229,6 @@ typedef struct {
 
     // Conditional variable for receiving response to the sent message
     CVAR receiveCvar;
-
-    // Execute the state machine until this time
-    UINT64 stepUntil;
 
     // Indicates when the ICE configuration has been retrieved
     UINT64 iceConfigTime;

--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -64,21 +64,7 @@ STATUS stepSignalingStateMachine(PSignalingClient pSignalingClient, STATUS statu
     MUTEX_LOCK(pSignalingClient->stateLock);
     locked = TRUE;
 
-//    // Check if an error and the retry is OK
-//    if (!pSignalingClient->pChannelInfo->retry && STATUS_FAILED(status)) {
-//        CHK(FALSE, status);
-//    }
-//
     currentTime = GETTIME();
-//
-//    CHK(pSignalingClient->stepUntil == 0 || currentTime <= pSignalingClient->stepUntil, STATUS_OPERATION_TIMED_OUT);
-//
-//    // Check if the status is any of the retry/failed statuses
-//    if (STATUS_FAILED(status)) {
-//        for (i = 0; i < SIGNALING_STATE_MACHINE_STATE_COUNT; i++) {
-//            CHK(status != SIGNALING_STATE_MACHINE_STATES[i].status, SIGNALING_STATE_MACHINE_STATES[i].status);
-//        }
-//    }
 
     // Fix-up the expired credentials transition
     // NOTE: Api Gateway might not return an error that can be interpreted as unauthorized to
@@ -287,12 +273,6 @@ STATUS executeGetTokenSignalingState(UINT64 customData, UINT64 time)
 
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) serviceCallResult);
 
-//    // Self-prime the next state
-//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-//
-//    // Reset the ret status
-//    retStatus = STATUS_SUCCESS;
-
 CleanUp:
 
     LEAVES();
@@ -361,11 +341,6 @@ STATUS executeDescribeSignalingState(UINT64 customData, UINT64 time)
     // Call the aggregate function
     retStatus = describeChannel(pSignalingClient, time);
 
-//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-//
-//    // Reset the ret status
-//    retStatus = STATUS_SUCCESS;
-
 CleanUp:
 
     LEAVES();
@@ -423,11 +398,6 @@ STATUS executeCreateSignalingState(UINT64 customData, UINT64 time)
 
     // Call the aggregate function
     retStatus = createChannel(pSignalingClient, time);
-
-//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-//
-//    // Reset the ret status
-//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -487,11 +457,6 @@ STATUS executeGetEndpointSignalingState(UINT64 customData, UINT64 time)
     // Call the aggregate function
     retStatus = getChannelEndpoint(pSignalingClient, time);
 
-//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-//
-//    // Reset the ret status
-//    retStatus = STATUS_SUCCESS;
-
 CleanUp:
 
     LEAVES();
@@ -549,11 +514,6 @@ STATUS executeGetIceConfigSignalingState(UINT64 customData, UINT64 time)
 
     // Call the aggregate function
     retStatus = getIceConfig(pSignalingClient, time);
-
-//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-//
-//    // Reset the ret status
-//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -619,16 +579,6 @@ STATUS executeReadySignalingState(UINT64 customData, UINT64 time)
                                                                             SIGNALING_CLIENT_STATE_READY));
     }
 
-//    if (pSignalingClient->continueOnReady) {
-//        // Self-prime the connect
-//        CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-//    } else {
-//        // Reset the timeout for the state machine
-//        pSignalingClient->stepUntil = 0;
-//    }
-//
-//    // Reset the ret status
-//    retStatus = STATUS_SUCCESS;
 CleanUp:
 
     LEAVES();
@@ -718,11 +668,6 @@ STATUS executeConnectSignalingState(UINT64 customData, UINT64 time)
     }
 
     retStatus = connectSignalingChannel(pSignalingClient, time);
-
-//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-//
-//    // Reset the ret status
-//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -870,9 +815,6 @@ STATUS executeDisconnectedSignalingState(UINT64 customData, UINT64 time)
                                                                             SIGNALING_CLIENT_STATE_DISCONNECTED));
     }
 
-    // Self-prime the next state
-//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-
 CleanUp:
 
     LEAVES();
@@ -939,11 +881,6 @@ STATUS executeDeleteSignalingState(UINT64 customData, UINT64 time)
 
     // Call the aggregate function
     retStatus = deleteChannel(pSignalingClient, time);
-
-//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-//
-//    // Reset the ret status
-//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 

--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -64,21 +64,21 @@ STATUS stepSignalingStateMachine(PSignalingClient pSignalingClient, STATUS statu
     MUTEX_LOCK(pSignalingClient->stateLock);
     locked = TRUE;
 
-    // Check if an error and the retry is OK
-    if (!pSignalingClient->pChannelInfo->retry && STATUS_FAILED(status)) {
-        CHK(FALSE, status);
-    }
-
+//    // Check if an error and the retry is OK
+//    if (!pSignalingClient->pChannelInfo->retry && STATUS_FAILED(status)) {
+//        CHK(FALSE, status);
+//    }
+//
     currentTime = GETTIME();
-
-    CHK(pSignalingClient->stepUntil == 0 || currentTime <= pSignalingClient->stepUntil, STATUS_OPERATION_TIMED_OUT);
-
-    // Check if the status is any of the retry/failed statuses
-    if (STATUS_FAILED(status)) {
-        for (i = 0; i < SIGNALING_STATE_MACHINE_STATE_COUNT; i++) {
-            CHK(status != SIGNALING_STATE_MACHINE_STATES[i].status, SIGNALING_STATE_MACHINE_STATES[i].status);
-        }
-    }
+//
+//    CHK(pSignalingClient->stepUntil == 0 || currentTime <= pSignalingClient->stepUntil, STATUS_OPERATION_TIMED_OUT);
+//
+//    // Check if the status is any of the retry/failed statuses
+//    if (STATUS_FAILED(status)) {
+//        for (i = 0; i < SIGNALING_STATE_MACHINE_STATE_COUNT; i++) {
+//            CHK(status != SIGNALING_STATE_MACHINE_STATES[i].status, SIGNALING_STATE_MACHINE_STATES[i].status);
+//        }
+//    }
 
     // Fix-up the expired credentials transition
     // NOTE: Api Gateway might not return an error that can be interpreted as unauthorized to
@@ -287,11 +287,11 @@ STATUS executeGetTokenSignalingState(UINT64 customData, UINT64 time)
 
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) serviceCallResult);
 
-    // Self-prime the next state
-    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-
-    // Reset the ret status
-    retStatus = STATUS_SUCCESS;
+//    // Self-prime the next state
+//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//
+//    // Reset the ret status
+//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -361,10 +361,10 @@ STATUS executeDescribeSignalingState(UINT64 customData, UINT64 time)
     // Call the aggregate function
     retStatus = describeChannel(pSignalingClient, time);
 
-    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-
-    // Reset the ret status
-    retStatus = STATUS_SUCCESS;
+//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//
+//    // Reset the ret status
+//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -424,10 +424,10 @@ STATUS executeCreateSignalingState(UINT64 customData, UINT64 time)
     // Call the aggregate function
     retStatus = createChannel(pSignalingClient, time);
 
-    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-
-    // Reset the ret status
-    retStatus = STATUS_SUCCESS;
+//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//
+//    // Reset the ret status
+//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -487,10 +487,10 @@ STATUS executeGetEndpointSignalingState(UINT64 customData, UINT64 time)
     // Call the aggregate function
     retStatus = getChannelEndpoint(pSignalingClient, time);
 
-    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-
-    // Reset the ret status
-    retStatus = STATUS_SUCCESS;
+//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//
+//    // Reset the ret status
+//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -550,10 +550,10 @@ STATUS executeGetIceConfigSignalingState(UINT64 customData, UINT64 time)
     // Call the aggregate function
     retStatus = getIceConfig(pSignalingClient, time);
 
-    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-
-    // Reset the ret status
-    retStatus = STATUS_SUCCESS;
+//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//
+//    // Reset the ret status
+//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -619,16 +619,16 @@ STATUS executeReadySignalingState(UINT64 customData, UINT64 time)
                                                                             SIGNALING_CLIENT_STATE_READY));
     }
 
-    if (pSignalingClient->continueOnReady) {
-        // Self-prime the connect
-        CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-    } else {
-        // Reset the timeout for the state machine
-        pSignalingClient->stepUntil = 0;
-    }
-
-    // Reset the ret status
-    retStatus = STATUS_SUCCESS;
+//    if (pSignalingClient->continueOnReady) {
+//        // Self-prime the connect
+//        CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//    } else {
+//        // Reset the timeout for the state machine
+//        pSignalingClient->stepUntil = 0;
+//    }
+//
+//    // Reset the ret status
+//    retStatus = STATUS_SUCCESS;
 CleanUp:
 
     LEAVES();
@@ -719,10 +719,10 @@ STATUS executeConnectSignalingState(UINT64 customData, UINT64 time)
 
     retStatus = connectSignalingChannel(pSignalingClient, time);
 
-    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-
-    // Reset the ret status
-    retStatus = STATUS_SUCCESS;
+//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//
+//    // Reset the ret status
+//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 
@@ -871,7 +871,7 @@ STATUS executeDisconnectedSignalingState(UINT64 customData, UINT64 time)
     }
 
     // Self-prime the next state
-    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
 
 CleanUp:
 
@@ -940,10 +940,10 @@ STATUS executeDeleteSignalingState(UINT64 customData, UINT64 time)
     // Call the aggregate function
     retStatus = deleteChannel(pSignalingClient, time);
 
-    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
-
-    // Reset the ret status
-    retStatus = STATUS_SUCCESS;
+//    CHK_STATUS(stepSignalingStateMachine(pSignalingClient, retStatus));
+//
+//    // Reset the ret status
+//    retStatus = STATUS_SUCCESS;
 
 CleanUp:
 

--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -52,7 +52,7 @@ STATUS signalingStateMachineIterator(PSignalingClient pSignalingClient, UINT64 e
 {
     ENTERS();
     UINT64 currentTime;
-    int i;
+    UINT32 i;
     STATUS retStatus = STATUS_SUCCESS;
     PStateMachineState pState = NULL;
     BOOL locked = FALSE;

--- a/src/source/Signaling/StateMachine.h
+++ b/src/source/Signaling/StateMachine.h
@@ -31,7 +31,7 @@ extern "C" {
 #define INFINITE_RETRY_COUNT_SENTINEL 0
 
 // Whether to step the state machine
-STATUS stepSignalingStateMachine(PSignalingClient, STATUS);
+STATUS signalingStateMachineIterator(PSignalingClient, UINT64, UINT64, STATUS);
 
 STATUS acceptSignalingStateMachineState(PSignalingClient, UINT64);
 SIGNALING_CLIENT_STATE getSignalingStateFromStateMachineState(UINT64);

--- a/src/source/Signaling/StateMachine.h
+++ b/src/source/Signaling/StateMachine.h
@@ -31,7 +31,7 @@ extern "C" {
 #define INFINITE_RETRY_COUNT_SENTINEL 0
 
 // Whether to step the state machine
-STATUS signalingStateMachineIterator(PSignalingClient, UINT64, UINT64, STATUS);
+STATUS signalingStateMachineIterator(PSignalingClient, UINT64, UINT64);
 
 STATUS acceptSignalingStateMachineState(PSignalingClient, UINT64);
 SIGNALING_CLIENT_STATE getSignalingStateFromStateMachineState(UINT64);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There are calls to `stepSignalingStateMachine` from `executeStateFn` and `getNextStateFn` functions for a lot of states in the signaling state machine. `stepSignalingStateMachine` calls `stepStateMachine` which also contains calls to `executeStateFn` and `getNextStateFn` functions. This causes recursion and could cause the stack to overflow.

- the `stepSignalingStateMachine` is replaced with `signalingStateMachineIterator`
- calls to the `stepSignalingStateMachine` from _Signaling.c_ and _LwsApiCalls.c_ have been replaced with calls to `signalingStateMachineIterator` with their respective final states
- the `stepUntil` and `continueOnReady` attributes have been removed from the signaling client since they are no longer needed to break out of or track the states. This is instead handled by having an `expiration` and a `final state` for the iterator

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
