### PR TITLE
Retry metric

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           9a995a5793b4024f19912be9a319993b1e16005c
+    GIT_TAG           706e65eefa6e218eaae7e0a9715f58c8b113d2bd
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           706e65eefa6e218eaae7e0a9715f58c8b113d2bd
+    GIT_TAG           0bf73ab8690be82fa7e63ba34a11916f902e4377
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -863,6 +863,7 @@ STATUS logSignalingClientStats(PSignalingClientMetrics pSignalingClientMetrics)
     // This gives the EMA of the getIceConfig() call.
     DLOGD("Data Plane API call latency: %" PRIu64 " ms",
           (pSignalingClientMetrics->signalingClientStats.dpApiCallLatency / HUNDREDS_OF_NANOS_IN_A_MILLISECOND));
+    DLOGD("API call retry count: %d", pSignalingClientMetrics->signalingClientStats.apiCallRetryCount);
 CleanUp:
     LEAVES();
     return retStatus;

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -707,6 +707,7 @@ STATUS setupDefaultSignalingClientRetryStrategy(PSignalingClientInfo pSignalingC
 
     pSignalingClientInfo->signalingClientRetryStrategy.retryStrategyType = KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT;
     pSignalingClientInfo->signalingClientRetryStrategy.createRetryStrategyFn = exponentialBackoffRetryStrategyCreate;
+    pSignalingClientInfo->signalingClientRetryStrategy.getCurrentRetryAttemptNumberFn = getExponentialBackoffRetryCount;
     pSignalingClientInfo->signalingClientRetryStrategy.freeRetryStrategyFn = exponentialBackoffRetryStrategyFree;
     pSignalingClientInfo->signalingClientRetryStrategy.executeRetryStrategyFn = getExponentialBackoffRetryStrategyWaitTime;
 

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -11,7 +11,6 @@ INT32 main(INT32 argc, CHAR* argv[])
     PSampleConfiguration pSampleConfiguration = NULL;
     SignalingClientMetrics signalingClientMetrics;
     PCHAR pChannelName;
-    signalingClientMetrics.version = 0;
 
     SET_INSTRUMENTED_ALLOCATORS();
 
@@ -114,7 +113,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 CleanUp:
 
     if (retStatus != STATUS_SUCCESS) {
-        printf("[KVS Master] Terminated with status code 0x%08x", retStatus);
+        printf("[KVS Master] Terminated with status code 0x%08x\n", retStatus);
     }
 
     printf("[KVS Master] Cleaning up....\n");
@@ -147,7 +146,7 @@ CleanUp:
         if (retStatus == STATUS_SUCCESS) {
             logSignalingClientStats(&signalingClientMetrics);
         } else {
-            printf("[KVS Master] signalingClientGetMetrics() operation returned status code: 0x%08x", retStatus);
+            printf("[KVS Master] signalingClientGetMetrics() operation returned status code: 0x%08x\n", retStatus);
         }
         retStatus = freeSignalingClient(&pSampleConfiguration->signalingClientHandle);
         if (retStatus != STATUS_SUCCESS) {

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1192,6 +1192,7 @@ typedef struct {
                                                                     //!< being used this value can be NULL or point to an EMPTY_STRING.
     SignalingClientRetryStrategy signalingClientRetryStrategy;      //!< Retry strategy used while creating signaling client
     UINT32 signalingClientCreationMaxRetryCount;                    //!< Maximum attempts which createSignalingClientSync API will make on failures to create signaling client
+    UINT32 stateMachineRetryCount;                                  //!< Retry count of state machine. Note that this **MUST NOT** be modified by the user. It is a read only field
 } SignalingClientInfo, *PSignalingClientInfo;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -172,8 +172,7 @@ typedef enum {
 typedef struct {
     UINT64 durationInSeconds;                              //!< Time (seconds) spent in each state
     RTC_QUALITY_LIMITATION_REASON qualityLimitationReason; //!< Quality limitation reason
-} QualityLimitationDurationsRecord;
-typedef QualityLimitationDurationsRecord* PQualityLimitationDurationsRecord;
+} QualityLimitationDurationsRecord, *PQualityLimitationDurationsRecord;
 
 /**
  * @brief Record of total number of packets sent per DSCP. Used by RTCOutboundRtpStreamStats
@@ -182,8 +181,7 @@ typedef QualityLimitationDurationsRecord* PQualityLimitationDurationsRecord;
 typedef struct {
     DOMString dscp;                  //!< DSCP String
     UINT64 totalNumberOfPacketsSent; //!< Number of packets sent
-} DscpPacketsSentRecord;
-typedef DscpPacketsSentRecord* PDscpPacketsSentRecord;
+} DscpPacketsSentRecord, *PDscpPacketsSentRecord;
 
 /**
  * @brief RtcIceCandidatePairStats Stats related to the local-remote ICE candidate pair
@@ -227,8 +225,7 @@ typedef struct {
     UINT64 responsesReceived;        //!< The total number of connectivity check responses received.
     UINT64 responsesSent;            //!< The total number of connectivity check responses sent.
     UINT64 bytesDiscardedOnSend;     //!< Total number of bytes for this candidate pair discarded due to socket errors
-} RtcIceCandidatePairStats;
-typedef RtcIceCandidatePairStats* PRtcIceCandidatePairStats;
+} RtcIceCandidatePairStats, *PRtcIceCandidatePairStats;
 
 /**
  * @brief: RtcIceServerStats Stats related to the ICE Server
@@ -244,8 +241,7 @@ typedef struct {
     UINT64 totalRequestsSent;      //!< Total amount of requests that have been sent to the server
     UINT64 totalResponsesReceived; //!< Total number of responses received from the server
     UINT64 totalRoundTripTime;     //!< Sum of RTTs of all the requests for which response has been received
-} RtcIceServerStats;
-typedef RtcIceServerStats* PRtcIceServerStats;
+} RtcIceServerStats, *PRtcIceServerStats;
 
 /**
  * @brief: RtcIceCandidateStats Stats related to a specific candidate in a pair
@@ -263,8 +259,7 @@ typedef struct {
     INT32 priority;                       //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
     INT32 port;                           //!< Port number of the candidate
     DOMString candidateType;              //!< Type of local/remote ICE candidate
-} RtcIceCandidateStats;
-typedef RtcIceCandidateStats* PRtcIceCandidateStats;
+} RtcIceCandidateStats, *PRtcIceCandidateStats;
 
 /**
  * @brief RtcTransportStats Represents the stats corresponding to an RTCDtlsTransport and
@@ -293,8 +288,7 @@ typedef struct {
     UINT64 bytesSent;                         //!< The total number of payload bytes sent on this PeerConnection (excluding header and padding)
     UINT64 bytesReceived;                     //!< The total number of payload bytes received on this PeerConnection (excluding header and padding)
     UINT32 selectedCandidatePairChanges;      //!< The number of times that the selected candidate pair of this transport has changed
-} RtcTransportStats;
-typedef RtcTransportStats* PRtcTransportStats;
+} RtcTransportStats, *PRtcTransportStats;
 
 /**
  * @brief RTCRtpStreamStats captures stream stats that will be used as part of RTCSentRtpStreamStats report
@@ -312,8 +306,7 @@ typedef struct {
     // TODO: codecId not yet populated
     DOMString codecId; //!< It is a unique identifier that is associated to the object that was inspected to produce the RTCCodecStats associated with
                        //!< this RTP stream.
-} RTCRtpStreamStats;
-typedef RTCRtpStreamStats* PRTCRtpStreamStats;
+} RTCRtpStreamStats, *PRTCRtpStreamStats;
 
 /**
  * @brief RTCSentRtpStreamStats will be used as part of outbound Rtp stats
@@ -326,8 +319,7 @@ typedef struct {
                       //!< section 6.4.1.
                       //!< The total number of payload octets (i.e., not including header or padding)
                       //!< transmitted in RTP data packets by the sender since starting transmission
-} RTCSentRtpStreamStats;
-typedef RTCSentRtpStreamStats* PRTCSentRtpStreamStats;
+} RTCSentRtpStreamStats, *PRTCSentRtpStreamStats;
 
 /**
  * @brief RtcOutboundRtpStreamStats Gathers stats for media stream from the embedded device
@@ -380,8 +372,7 @@ typedef struct {
     QualityLimitationDurationsRecord qualityLimitationDurations; //!< Total time (seconds) spent in each reason state
     DscpPacketsSentRecord perDscpPacketsSent;                    //!< Total number of packets sent for this SSRC, per DSCP
     RTC_QUALITY_LIMITATION_REASON qualityLimitationReason;       //!< Only valid for video.
-} RtcOutboundRtpStreamStats;
-typedef RtcOutboundRtpStreamStats* PRtcOutboundRtpStreamStats;
+} RtcOutboundRtpStreamStats, *PRtcOutboundRtpStreamStats;
 
 /**
  * @brief RTCRemoteInboundRtpStreamStats Represents the remote endpoint's measurement metrics for a particular incoming RTP stream
@@ -395,8 +386,7 @@ typedef struct {
     DOUBLE fractionLost;              //!< The fraction packet loss reported for this SSRC
     UINT64 reportsReceived;           //!< Total number of RTCP RR blocks received for this SSRC
     UINT64 roundTripTimeMeasurements; //!< Total number of RTCP RR blocks received for this SSRC that contain a valid round trip time
-} RtcRemoteInboundRtpStreamStats;
-typedef RtcRemoteInboundRtpStreamStats* PRtcRemoteInboundRtpStreamStats;
+} RtcRemoteInboundRtpStreamStats, *PRtcRemoteInboundRtpStreamStats;
 
 typedef struct {
     RTCRtpStreamStats rtpStream;
@@ -430,8 +420,7 @@ typedef struct {
                               //!< decoding, the framesReceived counter is incremented.
     UINT32 fullFramesLost; //!< Only valid for video. The cumulative number of full frames lost. The measurement begins when the receiver is created
                            //!< and is a cumulative metric as defined in Appendix A (i) of [RFC7004].
-} RtcReceivedRtpStreamStats;
-typedef RtcReceivedRtpStreamStats* PRtcReceivedRtpStreamStats;
+} RtcReceivedRtpStreamStats, *PRtcReceivedRtpStreamStats;
 
 /**
  * @brief The RTCInboundRtpStreamStats dictionary represents the measurement metrics for the incoming RTP media stream. The timestamp reported in the
@@ -536,8 +525,7 @@ typedef struct {
     UINT32 framesReceived;       //!< Only valid for video. Represents the total number of complete frames received on this RTP stream. This metric is
                                  //!< incremented when the complete frame is received.
     DOMString decoderImplementation; //!<  TODO Identifies the decoder implementation used. This is useful for diagnosing interoperability issues.
-} RtcInboundRtpStreamStats;
-typedef RtcInboundRtpStreamStats* PRtcInboundRtpStreamStats;
+} RtcInboundRtpStreamStats, *PRtcInboundRtpStreamStats;
 
 /**
  * Reference: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelstate
@@ -562,8 +550,7 @@ typedef struct {
     UINT64 bytesSent;        //!< Represents the total number of payload bytes sent on this RTCDatachannel, i.e., not including headers or padding.
     UINT32 messagesReceived; //!< Represents the total number of API "message" events received.
     UINT64 bytesReceived;    //!< Represents the total number of bytes received on this RTCDatachannel, i.e., not including headers or padding.
-} RtcDataChannelStats;
-typedef RtcDataChannelStats* PRtcDataChannelStats;
+} RtcDataChannelStats, *PRtcDataChannelStats;
 
 /**
  * @brief SignalingClientMetrics Represent the stats related to the KVS WebRTC SDK signaling client
@@ -591,8 +578,7 @@ typedef struct {
                                      //!< In all of these cases the error callback (if specified) will be called.
     UINT32 numberOfReconnects;       //!< Number of reconnects in the session
     UINT32 apiCallRetryCount;        //!< Number of retries due to API call failures in the state machine
-} SignalingClientStats;
-typedef SignalingClientStats* PSignalingClientStats;
+} SignalingClientStats, *PSignalingClientStats;
 
 /**
  * @brief RTCStatsObject Represents an object passed in by the application developer which will
@@ -608,8 +594,7 @@ typedef struct {
     RtcRemoteInboundRtpStreamStats remoteInboundRtpStreamStats; //!< Remote Inbound RTP Stream stats object
     RtcInboundRtpStreamStats inboundRtpStreamStats;             //!< Inbound RTP Stream stats object
     RtcDataChannelStats rtcDataChannelStats;
-} RtcStatsObject;
-typedef RtcStatsObject* PRtcStatsObject;
+} RtcStatsObject, *PRtcStatsObject;
 /*!@} */
 
 #ifdef __cplusplus

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -172,7 +172,8 @@ typedef enum {
 typedef struct {
     UINT64 durationInSeconds;                              //!< Time (seconds) spent in each state
     RTC_QUALITY_LIMITATION_REASON qualityLimitationReason; //!< Quality limitation reason
-} QualityLimitationDurationsRecord, PQualityLimitationDurationsRecord;
+} QualityLimitationDurationsRecord;
+typedef QualityLimitationDurationsRecord* PQualityLimitationDurationsRecord;
 
 /**
  * @brief Record of total number of packets sent per DSCP. Used by RTCOutboundRtpStreamStats
@@ -181,7 +182,8 @@ typedef struct {
 typedef struct {
     DOMString dscp;                  //!< DSCP String
     UINT64 totalNumberOfPacketsSent; //!< Number of packets sent
-} DscpPacketsSentRecord, *PDscpPacketsSentRecord;
+} DscpPacketsSentRecord;
+typedef DscpPacketsSentRecord* PDscpPacketsSentRecord;
 
 /**
  * @brief RtcIceCandidatePairStats Stats related to the local-remote ICE candidate pair
@@ -225,7 +227,8 @@ typedef struct {
     UINT64 responsesReceived;        //!< The total number of connectivity check responses received.
     UINT64 responsesSent;            //!< The total number of connectivity check responses sent.
     UINT64 bytesDiscardedOnSend;     //!< Total number of bytes for this candidate pair discarded due to socket errors
-} RtcIceCandidatePairStats, *PRtcIceCandidatePairStats;
+} RtcIceCandidatePairStats;
+typedef RtcIceCandidatePairStats* PRtcIceCandidatePairStats;
 
 /**
  * @brief: RtcIceServerStats Stats related to the ICE Server
@@ -241,7 +244,8 @@ typedef struct {
     UINT64 totalRequestsSent;      //!< Total amount of requests that have been sent to the server
     UINT64 totalResponsesReceived; //!< Total number of responses received from the server
     UINT64 totalRoundTripTime;     //!< Sum of RTTs of all the requests for which response has been received
-} RtcIceServerStats, *PRtcIceServerStats;
+} RtcIceServerStats;
+typedef RtcIceServerStats* PRtcIceServerStats;
 
 /**
  * @brief: RtcIceCandidateStats Stats related to a specific candidate in a pair
@@ -259,7 +263,8 @@ typedef struct {
     INT32 priority;                       //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
     INT32 port;                           //!< Port number of the candidate
     DOMString candidateType;              //!< Type of local/remote ICE candidate
-} RtcIceCandidateStats, *PRtcIceCandidateStats;
+} RtcIceCandidateStats;
+typedef RtcIceCandidateStats* PRtcIceCandidateStats;
 
 /**
  * @brief RtcTransportStats Represents the stats corresponding to an RTCDtlsTransport and
@@ -288,7 +293,8 @@ typedef struct {
     UINT64 bytesSent;                         //!< The total number of payload bytes sent on this PeerConnection (excluding header and padding)
     UINT64 bytesReceived;                     //!< The total number of payload bytes received on this PeerConnection (excluding header and padding)
     UINT32 selectedCandidatePairChanges;      //!< The number of times that the selected candidate pair of this transport has changed
-} RtcTransportStats, *PRtcTransportStats;
+} RtcTransportStats;
+typedef RtcTransportStats* PRtcTransportStats;
 
 /**
  * @brief RTCRtpStreamStats captures stream stats that will be used as part of RTCSentRtpStreamStats report
@@ -306,7 +312,8 @@ typedef struct {
     // TODO: codecId not yet populated
     DOMString codecId; //!< It is a unique identifier that is associated to the object that was inspected to produce the RTCCodecStats associated with
                        //!< this RTP stream.
-} RTCRtpStreamStats, *PRTCRtpStreamStats;
+} RTCRtpStreamStats;
+typedef RTCRtpStreamStats* PRTCRtpStreamStats;
 
 /**
  * @brief RTCSentRtpStreamStats will be used as part of outbound Rtp stats
@@ -319,7 +326,8 @@ typedef struct {
                       //!< section 6.4.1.
                       //!< The total number of payload octets (i.e., not including header or padding)
                       //!< transmitted in RTP data packets by the sender since starting transmission
-} RTCSentRtpStreamStats, *PRTCSentRtpStreamStats;
+} RTCSentRtpStreamStats;
+typedef RTCSentRtpStreamStats* PRTCSentRtpStreamStats;
 
 /**
  * @brief RtcOutboundRtpStreamStats Gathers stats for media stream from the embedded device
@@ -372,7 +380,8 @@ typedef struct {
     QualityLimitationDurationsRecord qualityLimitationDurations; //!< Total time (seconds) spent in each reason state
     DscpPacketsSentRecord perDscpPacketsSent;                    //!< Total number of packets sent for this SSRC, per DSCP
     RTC_QUALITY_LIMITATION_REASON qualityLimitationReason;       //!< Only valid for video.
-} RtcOutboundRtpStreamStats, *PRtcOutboundRtpStreamStats;
+} RtcOutboundRtpStreamStats;
+typedef RtcOutboundRtpStreamStats* PRtcOutboundRtpStreamStats;
 
 /**
  * @brief RTCRemoteInboundRtpStreamStats Represents the remote endpoint's measurement metrics for a particular incoming RTP stream
@@ -386,7 +395,8 @@ typedef struct {
     DOUBLE fractionLost;              //!< The fraction packet loss reported for this SSRC
     UINT64 reportsReceived;           //!< Total number of RTCP RR blocks received for this SSRC
     UINT64 roundTripTimeMeasurements; //!< Total number of RTCP RR blocks received for this SSRC that contain a valid round trip time
-} RtcRemoteInboundRtpStreamStats, *PRtcRemoteInboundRtpStreamStats;
+} RtcRemoteInboundRtpStreamStats;
+typedef RtcRemoteInboundRtpStreamStats* PRtcRemoteInboundRtpStreamStats;
 
 typedef struct {
     RTCRtpStreamStats rtpStream;
@@ -420,7 +430,8 @@ typedef struct {
                               //!< decoding, the framesReceived counter is incremented.
     UINT32 fullFramesLost; //!< Only valid for video. The cumulative number of full frames lost. The measurement begins when the receiver is created
                            //!< and is a cumulative metric as defined in Appendix A (i) of [RFC7004].
-} RtcReceivedRtpStreamStats, *PRtcReceivedRtpStreamStats;
+} RtcReceivedRtpStreamStats;
+typedef RtcReceivedRtpStreamStats* PRtcReceivedRtpStreamStats;
 
 /**
  * @brief The RTCInboundRtpStreamStats dictionary represents the measurement metrics for the incoming RTP media stream. The timestamp reported in the
@@ -525,7 +536,8 @@ typedef struct {
     UINT32 framesReceived;       //!< Only valid for video. Represents the total number of complete frames received on this RTP stream. This metric is
                                  //!< incremented when the complete frame is received.
     DOMString decoderImplementation; //!<  TODO Identifies the decoder implementation used. This is useful for diagnosing interoperability issues.
-} RtcInboundRtpStreamStats, *PRtcInboundRtpStreamStats;
+} RtcInboundRtpStreamStats;
+typedef RtcInboundRtpStreamStats* PRtcInboundRtpStreamStats;
 
 /**
  * Reference: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelstate
@@ -550,7 +562,8 @@ typedef struct {
     UINT64 bytesSent;        //!< Represents the total number of payload bytes sent on this RTCDatachannel, i.e., not including headers or padding.
     UINT32 messagesReceived; //!< Represents the total number of API "message" events received.
     UINT64 bytesReceived;    //!< Represents the total number of bytes received on this RTCDatachannel, i.e., not including headers or padding.
-} RtcDataChannelStats, *PRtcDataChannelStats;
+} RtcDataChannelStats;
+typedef RtcDataChannelStats* PRtcDataChannelStats;
 
 /**
  * @brief SignalingClientMetrics Represent the stats related to the KVS WebRTC SDK signaling client
@@ -577,7 +590,9 @@ typedef struct {
                                      //!< * When refreshing ICE server configuration fails after pre-configured retries
                                      //!< In all of these cases the error callback (if specified) will be called.
     UINT32 numberOfReconnects;       //!< Number of reconnects in the session
-} SignalingClientStats, PSignalingClientStats;
+    UINT32 apiCallRetryCount;        //!< Number of retries due to API call failures in the state machine
+} SignalingClientStats;
+typedef SignalingClientStats* PSignalingClientStats;
 
 /**
  * @brief RTCStatsObject Represents an object passed in by the application developer which will
@@ -593,7 +608,8 @@ typedef struct {
     RtcRemoteInboundRtpStreamStats remoteInboundRtpStreamStats; //!< Remote Inbound RTP Stream stats object
     RtcInboundRtpStreamStats inboundRtpStreamStats;             //!< Inbound RTP Stream stats object
     RtcDataChannelStats rtcDataChannelStats;
-} RtcStatsObject, *PRtcStatsObject;
+} RtcStatsObject;
+typedef RtcStatsObject* PRtcStatsObject;
 /*!@} */
 
 #ifdef __cplusplus

--- a/src/source/Signaling/Client.c
+++ b/src/source/Signaling/Client.c
@@ -54,13 +54,14 @@ STATUS createSignalingClientSync(PSignalingClientInfo pClientInfo, PChannelInfo 
         THREAD_SLEEP(signalingClientCreationWaitTime);
 
         retStatus = createSignalingSync(&signalingClientInfoInternal, pChannelInfo, pCallbacks, pCredentialProvider, &pSignalingClient);
+        pClientInfo->stateMachineRetryCount = signalingClientInfoInternal.signalingClientInfo.stateMachineRetryCount;
         if (retStatus == STATUS_SUCCESS) {
             break;
         }
         signalingClientCreationMaxRetryCount--;
     }
 
-    DLOGV("Create signaling client returned [%" PRId64 "].", retStatus);
+    DLOGV("Create signaling client returned 0x%08x.", retStatus);
     CHK_STATUS(retStatus);
 
     *pSignalingHandle = TO_SIGNALING_CLIENT_HANDLE(pSignalingClient);
@@ -301,6 +302,7 @@ STATUS signalingClientGetMetrics(SIGNALING_CLIENT_HANDLE signalingClientHandle, 
     STATUS retStatus = STATUS_SUCCESS;
     PSignalingClient pSignalingClient = FROM_SIGNALING_CLIENT_HANDLE(signalingClientHandle);
 
+    pSignalingClientMetrics->version = SIGNALING_CLIENT_METRICS_CURRENT_VERSION;
     DLOGV("Signaling Client Get Metrics");
 
     CHK_STATUS(signalingGetMetrics(pSignalingClient, pSignalingClientMetrics));

--- a/src/source/Signaling/Client.c
+++ b/src/source/Signaling/Client.c
@@ -55,6 +55,7 @@ STATUS createSignalingClientSync(PSignalingClientInfo pClientInfo, PChannelInfo 
 
         retStatus = createSignalingSync(&signalingClientInfoInternal, pChannelInfo, pCallbacks, pCredentialProvider, &pSignalingClient);
         pClientInfo->stateMachineRetryCount = signalingClientInfoInternal.signalingClientInfo.stateMachineRetryCount;
+        
         if (retStatus == STATUS_SUCCESS) {
             break;
         }

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -170,7 +170,7 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
                                              SIGNALING_STATE_READY));
 
 CleanUp:
-
+    pClientInfo->signalingClientInfo.stateMachineRetryCount = pSignalingClient->diagnostics.stateMachineRetryCount;
     CHK_LOG_ERR(retStatus);
 
     if (STATUS_FAILED(retStatus)) {
@@ -529,6 +529,7 @@ STATUS configureRetryStrategyForSignalingStateMachine(PSignalingClient pSignalin
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     pSignalingClient->clientInfo.signalingStateMachineRetryStrategy.retryStrategyType = KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT;
     pSignalingClient->clientInfo.signalingStateMachineRetryStrategy.createRetryStrategyFn = exponentialBackoffRetryStrategyCreate;
+    pSignalingClient->clientInfo.signalingStateMachineRetryStrategy.getCurrentRetryAttemptNumberFn = getExponentialBackoffRetryCount;
     pSignalingClient->clientInfo.signalingStateMachineRetryStrategy.freeRetryStrategyFn = exponentialBackoffRetryStrategyFree;
     pSignalingClient->clientInfo.signalingStateMachineRetryStrategy.executeRetryStrategyFn = getExponentialBackoffRetryStrategyWaitTime;
 
@@ -543,7 +544,7 @@ STATUS configureRetryStrategyForSignalingStateMachine(PSignalingClient pSignalin
     pSignalingClient->clientInfo.signalingStateMachineRetryStrategy.pRetryStrategy = pRetryStrategy;
 
     CleanUp:
-
+    DLOGD("Configuration done");
     LEAVES();
     return retStatus;
 }

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -1188,6 +1188,7 @@ STATUS signalingGetMetrics(PSignalingClient pSignalingClient, PSignalingClientMe
     pSignalingClientMetrics->signalingClientStats.numberOfReconnects = (UINT32) pSignalingClient->diagnostics.numberOfReconnects;
     pSignalingClientMetrics->signalingClientStats.cpApiCallLatency = pSignalingClient->diagnostics.cpApiLatency;
     pSignalingClientMetrics->signalingClientStats.dpApiCallLatency = pSignalingClient->diagnostics.dpApiLatency;
+    pSignalingClientMetrics->signalingClientStats.apiCallRetryCount = pSignalingClient->diagnostics.stateMachineRetryCount;
 
     pSignalingClientMetrics->signalingClientStats.connectionDuration =
         ATOMIC_LOAD_BOOL(&pSignalingClient->connected) ? curTime - pSignalingClient->diagnostics.connectTime : 0;

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -136,6 +136,7 @@ typedef struct {
     UINT64 connectTime;
     UINT64 cpApiLatency;
     UINT64 dpApiLatency;
+    UINT32 stateMachineRetryCount;
 } SignalingDiagnostics, PSignalingDiagnostics;
 
 /**

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -137,7 +137,7 @@ typedef struct {
     UINT64 cpApiLatency;
     UINT64 dpApiLatency;
     UINT32 stateMachineRetryCount;
-} SignalingDiagnostics, PSignalingDiagnostics;
+} SignalingDiagnostics, *PSignalingDiagnostics;
 
 /**
  * Internal representation of the Signaling client.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Included a retry metric to track number of retries in exponential backoff. 

Pending:
1. Including to canary
2. Update producer commit in the dependencies file once corresponding commit in producer C and PIC are merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
