### PR TITLE
Fix retry count to indicate count only after a retry has occured

### DIFF
--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -147,11 +147,7 @@ STATUS defaultSignalingStateTransitionHook(
     CHK(pSignalingClient->result > SERVICE_CALL_RESULT_OK &&
         pSignalingStateMachineRetryStrategyCallbacks->executeRetryStrategyFn != NULL, STATUS_SUCCESS);
 
-    DLOGV("Signaling Client base result is [%u]. Executing KVS retry handler of retry strategy type [%u]",
-          pSignalingClient->result, pSignalingStateMachineRetryStrategy->retryStrategyType);
-    pSignalingStateMachineRetryStrategyCallbacks->executeRetryStrategyFn(pSignalingStateMachineRetryStrategy, &retryWaitTime);
-    *stateTransitionWaitTime = retryWaitTime;
-
+    // A retry is considered only after executeRetry is executed. This will avoid publishing count + 1
     if(pSignalingStateMachineRetryStrategyCallbacks->getCurrentRetryAttemptNumberFn != NULL) {
         if((countStatus = pSignalingStateMachineRetryStrategyCallbacks->getCurrentRetryAttemptNumberFn(pSignalingStateMachineRetryStrategy, &pSignalingClient->diagnostics.stateMachineRetryCount)) != STATUS_SUCCESS) {
             DLOGW("Failed to get retry count. Error code: %08x", countStatus);
@@ -160,6 +156,10 @@ STATUS defaultSignalingStateTransitionHook(
             DLOGD("Retry count: %llu", pSignalingClient->diagnostics.stateMachineRetryCount);
         }
     }
+    DLOGV("Signaling Client base result is [%u]. Executing KVS retry handler of retry strategy type [%u]",
+          pSignalingClient->result, pSignalingStateMachineRetryStrategy->retryStrategyType);
+    pSignalingStateMachineRetryStrategyCallbacks->executeRetryStrategyFn(pSignalingStateMachineRetryStrategy, &retryWaitTime);
+    *stateTransitionWaitTime = retryWaitTime;
 
 CleanUp:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, if number of retries is set to 1, we retry only once. However, the count indicates retry count to be 1 more than actual value which is an incorrect indication. This PR fixes it by getting retry count only after executeRetry is executed. 

In the first attempt, if call fails, retry count = 0 followed by `executeRetryStrategy` which indicates a retry. The next time the hook function is executed, the retry count would appropriately reflect the count value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
