### PR TITLE
Use DTLS_method for openssl >= 1.0.2

### DIFF
--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -164,7 +164,7 @@ STATUS createSslCtx(PDtlsSessionCertificateInfo pCertificates, UINT32 certCount,
     EC_KEY* ecdh = NULL;
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L)
     pSslCtx = SSL_CTX_new(DTLS_method());
 #elif (OPENSSL_VERSION_NUMBER >= 0x10001000L)
     pSslCtx = SSL_CTX_new(DTLSv1_method());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
DTLSv2 is available for openssl >= 1.0.2, so use DTLSv2 when available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
