### PR TITLE
Fix signaling channel null terminator

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1058,6 +1058,7 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
                         if (0 == STRNCMPI(pProtocol, WSS_SCHEME_NAME, protocolLen)) {
                             STRNCPY(pSignalingClient->channelEndpointWss, pEndpoint, MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN));
                             pSignalingClient->channelEndpointWss[MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN)] = '\0';
+
                         } else if (0 == STRNCMPI(pProtocol, HTTPS_SCHEME_NAME, protocolLen)) {
                             STRNCPY(pSignalingClient->channelEndpointHttps, pEndpoint, MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN));
                             pSignalingClient->channelEndpointHttps[MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN)] = '\0';

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1057,10 +1057,10 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
                     if (protocol && endpoint) {
                         if (0 == STRNCMPI(pProtocol, WSS_SCHEME_NAME, protocolLen)) {
                             STRNCPY(pSignalingClient->channelEndpointWss, pEndpoint, MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN));
-                            pSignalingClient->channelEndpointWss[MAX_SIGNALING_ENDPOINT_URI_LEN] = '\0';
+                            pSignalingClient->channelEndpointWss[MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN)] = '\0';
                         } else if (0 == STRNCMPI(pProtocol, HTTPS_SCHEME_NAME, protocolLen)) {
                             STRNCPY(pSignalingClient->channelEndpointHttps, pEndpoint, MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN));
-                            pSignalingClient->channelEndpointHttps[MAX_SIGNALING_ENDPOINT_URI_LEN] = '\0';
+                            pSignalingClient->channelEndpointHttps[MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN)] = '\0';
                         }
                     }
 
@@ -1092,10 +1092,10 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
     if (protocol && endpoint) {
         if (0 == STRNCMPI(pProtocol, WSS_SCHEME_NAME, protocolLen)) {
             STRNCPY(pSignalingClient->channelEndpointWss, pEndpoint, MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN));
-            pSignalingClient->channelEndpointWss[MAX_SIGNALING_ENDPOINT_URI_LEN] = '\0';
+            pSignalingClient->channelEndpointWss[MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN)] = '\0';
         } else if (0 == STRNCMPI(pProtocol, HTTPS_SCHEME_NAME, protocolLen)) {
             STRNCPY(pSignalingClient->channelEndpointHttps, pEndpoint, MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN));
-            pSignalingClient->channelEndpointHttps[MAX_SIGNALING_ENDPOINT_URI_LEN] = '\0';
+            pSignalingClient->channelEndpointHttps[MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN)] = '\0';
         }
     }
 

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1058,7 +1058,6 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
                         if (0 == STRNCMPI(pProtocol, WSS_SCHEME_NAME, protocolLen)) {
                             STRNCPY(pSignalingClient->channelEndpointWss, pEndpoint, MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN));
                             pSignalingClient->channelEndpointWss[MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN)] = '\0';
-
                         } else if (0 == STRNCMPI(pProtocol, HTTPS_SCHEME_NAME, protocolLen)) {
                             STRNCPY(pSignalingClient->channelEndpointHttps, pEndpoint, MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN));
                             pSignalingClient->channelEndpointHttps[MIN(endpointLen, MAX_SIGNALING_ENDPOINT_URI_LEN)] = '\0';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We were seeing that the channel endpoint name sometimes had extra data due to not being null terminated correctly. strncpy was not copying a null terminator, so pSignalingClient->channelEndpointWss only had a null terminator at MAX_SIGNALING_ENDPOINT_URI_LEN. 

However, if the channelEndpointWss is supposed to be smaller, then it is not null terminated correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
