### PR TITLE
new Chrome v98 produces extra sdp attributes, up the limit so we do n…

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -151,7 +151,8 @@ STATUS setPayloadTypesFromOffer(PHashTable codecTable, PHashTable rtxTable, PSes
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PSdpMediaDescription pMediaDescription = NULL;
-    UINT8 currentMedia, currentAttribute;
+    UINT8 currentAttribute;
+    UINT16 currentMedia;
     PCHAR attributeValue, end;
     UINT64 parsedPayloadType, hashmapPayloadType, fmtpVal, aptVal;
     UINT16 aptFmtpVals[MAX_SDP_FMTP_VALUES];

--- a/src/source/Sdp/Deserialize.c
+++ b/src/source/Sdp/Deserialize.c
@@ -5,7 +5,6 @@ STATUS parseMediaName(PSessionDescription pSessionDescription, PCHAR pch, UINT32
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-
     CHK(pSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_BUFFER_TOO_SMALL);
 
     STRNCPY(pSessionDescription->mediaDescriptions[pSessionDescription->mediaCount].mediaName, (pch + SDP_ATTRIBUTE_LENGTH),
@@ -48,7 +47,7 @@ STATUS parseMediaAttributes(PSessionDescription pSessionDescription, PCHAR pch, 
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PCHAR search;
-    UINT8 currentMediaAttributesCount;
+    UINT16 currentMediaAttributesCount;
 
     currentMediaAttributesCount = pSessionDescription->mediaDescriptions[pSessionDescription->mediaCount - 1].mediaAttributesCount;
 

--- a/src/source/Sdp/Sdp.h
+++ b/src/source/Sdp/Sdp.h
@@ -75,7 +75,7 @@ extern "C" {
 #define MAX_SDP_SESSION_MEDIA_COUNT   5
 #define MAX_SDP_MEDIA_BANDWIDTH_COUNT 2
 
-#define MAX_SDP_ATTRIBUTES_COUNT 128
+#define MAX_SDP_ATTRIBUTES_COUNT 256
 
 /*
  * c=<nettype> <addrtype> <connection-address>
@@ -198,9 +198,9 @@ typedef struct {
 
     SdpMediaDescription mediaDescriptions[MAX_SDP_SESSION_MEDIA_COUNT];
 
-    UINT8 sessionAttributesCount;
+    UINT16 sessionAttributesCount;
 
-    UINT8 mediaCount;
+    UINT16 mediaCount;
 
     UINT8 timezoneCount;
 

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -232,7 +232,7 @@ s=-
 t=0 0
 )";
 
-    for (auto i = 0; i < 250; i++) {
+    for (auto i = 0; i <= MAX_SDP_ATTRIBUTES_COUNT + 1; i++) {
         sessionDescriptionNoMedia += "a=b\n";
     }
 


### PR DESCRIPTION
…… (#1391)

* new Chrome v98 produces extra sdp attributes, up the limit so we do not reject

* Fix test and change count to unit16 to avoid overflow issues

* fix issue reported by codeql

Co-authored-by: Divya Sampath Kumar <disa6302@colorado.edu>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
