### PR TITLE
Fix swapped SSL_free() and SSL_CTX_free()

### DIFF
--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -414,10 +414,10 @@ STATUS freeDtlsSession(PDtlsSession* ppDtlsSession)
     }
 
     if (pDtlsSession->pSsl != NULL) {
-        SSL_CTX_free(pDtlsSession->pSslCtx);
+        SSL_free(pDtlsSession->pSsl);
     }
     if (pDtlsSession->pSslCtx != NULL) {
-        SSL_free(pDtlsSession->pSsl);
+        SSL_CTX_free(pDtlsSession->pSslCtx);
     }
     if (IS_VALID_MUTEX_VALUE(pDtlsSession->sslLock)) {
         MUTEX_FREE(pDtlsSession->sslLock);


### PR DESCRIPTION
*Description of changes:*

`SSL_free()` and `SSL_CTX_free()` calls are swapped within their respective checks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
