### PR TITLE
metrics: allow viewer sample to get ice candidate pair stats

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -1313,6 +1313,8 @@ STATUS signalingMessageReceived(UINT64 customData, PReceivedSignalingMessage pRe
                 // NULL the pointer to avoid it being freed in the cleanup
                 pPendingMessageQueue = NULL;
             }
+
+            startStats = pSampleConfiguration->iceCandidatePairStatsTimerId == MAX_UINT32;
             break;
 
         case SIGNALING_MESSAGE_TYPE_ICE_CANDIDATE:


### PR DESCRIPTION
Signed-off-by: Alex.Li <zhiqinli@amazon.com>

*Issue #, if available:*
In current code, `getIceCandidatePairStatsCallback` will not be triggered if user is running viewer sample because `startStats` is not set:

```
    if (startStats &&
        STATUS_FAILED(retStatus = timerQueueAddTimer(pSampleConfiguration->timerQueueHandle, SAMPLE_STATS_DURATION, SAMPLE_STATS_DURATION,
                                                     getIceCandidatePairStatsCallback, (UINT64) pSampleConfiguration,
                                                     &pSampleConfiguration->iceCandidatePairStatsTimerId))) {
        DLOGW("Failed to add getIceCandidatePairStatsCallback to add to timer queue (code 0x%08x). "
              "Cannot pull ice candidate pair metrics periodically",
              retStatus);
```

*Description of changes:*
This commit will set `startStats` when received offer when sample work as viewer, which allows viewer sample gathering candidates pairs metrics as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
