### PR TITLE
Thread cancel on the media sender thread leads to memory leaks from w…

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -152,7 +152,9 @@ PVOID mediaSenderRoutine(PVOID customData)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) customData;
-    TID videoSenderTid = INVALID_TID_VALUE, audioSenderTid = INVALID_TID_VALUE;
+    CHK(pSampleConfiguration != NULL, STATUS_NULL_ARG);
+    pSampleConfiguration->videoSenderTid = INVALID_TID_VALUE;
+    pSampleConfiguration->audioSenderTid = INVALID_TID_VALUE;
 
     MUTEX_LOCK(pSampleConfiguration->sampleConfigurationObjLock);
     while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->connected) && !ATOMIC_LOAD_BOOL(&pSampleConfiguration->appTerminateFlag)) {
@@ -163,19 +165,19 @@ PVOID mediaSenderRoutine(PVOID customData)
     CHK(!ATOMIC_LOAD_BOOL(&pSampleConfiguration->appTerminateFlag), retStatus);
 
     if (pSampleConfiguration->videoSource != NULL) {
-        THREAD_CREATE(&videoSenderTid, pSampleConfiguration->videoSource, (PVOID) pSampleConfiguration);
+        THREAD_CREATE(&pSampleConfiguration->videoSenderTid, pSampleConfiguration->videoSource, (PVOID) pSampleConfiguration);
     }
 
     if (pSampleConfiguration->audioSource != NULL) {
-        THREAD_CREATE(&audioSenderTid, pSampleConfiguration->audioSource, (PVOID) pSampleConfiguration);
+        THREAD_CREATE(&pSampleConfiguration->audioSenderTid, pSampleConfiguration->audioSource, (PVOID) pSampleConfiguration);
     }
 
-    if (videoSenderTid != INVALID_TID_VALUE) {
-        THREAD_JOIN(videoSenderTid, NULL);
+    if (pSampleConfiguration->videoSenderTid != INVALID_TID_VALUE) {
+        THREAD_JOIN(pSampleConfiguration->videoSenderTid, NULL);
     }
 
-    if (audioSenderTid != INVALID_TID_VALUE) {
-        THREAD_JOIN(audioSenderTid, NULL);
+    if (pSampleConfiguration->audioSenderTid != INVALID_TID_VALUE) {
+        THREAD_JOIN(pSampleConfiguration->audioSenderTid, NULL);
     }
 
 CleanUp:
@@ -749,6 +751,8 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
 #endif
 
     pSampleConfiguration->mediaSenderTid = INVALID_TID_VALUE;
+    pSampleConfiguration->audioSenderTid = INVALID_TID_VALUE;
+    pSampleConfiguration->videoSenderTid = INVALID_TID_VALUE;
     pSampleConfiguration->signalingClientHandle = INVALID_SIGNALING_CLIENT_HANDLE_VALUE;
     pSampleConfiguration->sampleConfigurationObjLock = MUTEX_CREATE(TRUE);
     pSampleConfiguration->cvar = CVAR_CREATE();

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -85,6 +85,8 @@ typedef struct {
     PBYTE pVideoFrameBuffer;
     UINT32 videoBufferSize;
     TID mediaSenderTid;
+    TID audioSenderTid;
+    TID videoSenderTid;
     TIMER_QUEUE_HANDLE timerQueueHandle;
     UINT32 iceCandidatePairStatsTimerId;
     SampleStreamingMediaType mediaType;


### PR DESCRIPTION
…riteFrame() not freeing all its heap usage

*Issue #, if available:*
#1450 
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
