### PR TITLE
Fix default data channel ordering mode

### DIFF
--- a/src/source/PeerConnection/DataChannel.c
+++ b/src/source/PeerConnection/DataChannel.c
@@ -30,7 +30,7 @@ STATUS createDataChannel(PRtcPeerConnection pPeerConnection, PCHAR pDataChannelN
         pKvsDataChannel->rtcDataChannelInit = *pRtcDataChannelInit;
     } else {
         // If nothing is set, set default to ordered mode
-        pKvsDataChannel->rtcDataChannelInit.ordered = FALSE;
+        pKvsDataChannel->rtcDataChannelInit.ordered = TRUE;
         NULLABLE_SET_EMPTY(pKvsDataChannel->rtcDataChannelInit.maxPacketLifeTime);
         NULLABLE_SET_EMPTY(pKvsDataChannel->rtcDataChannelInit.maxRetransmits);
     }


### PR DESCRIPTION
*Issue #, if available:*
#1438 
*Description of changes:*
Default should be ordered mode: https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/ordered

Resolves #1438 .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
