### PR TITLE
Fix typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
   static-build-linux:
     runs-on: ubuntu-18.04
     container: 
-      image: alpine:latest
+      image: alpine:3.15.4
     env:
       CC: gcc
       CXX: g++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           apk upgrade
           apk add alpine-sdk cmake clang linux-headers perl bash openssl-dev
       - name: Build Repository
-        run: | 
+        run: |
           mkdir build && cd build
           cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
           make

--- a/CMake/Dependencies/libgtest-CMakeLists.txt
+++ b/CMake/Dependencies/libgtest-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libgtest-download
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           release-1.8.1
+    GIT_TAG           release-1.11.0
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMake/Dependencies/libgtest-CMakeLists.txt
+++ b/CMake/Dependencies/libgtest-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libgtest-download
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           release-1.11.0
+    GIT_TAG           release-1.8.1
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/src/source/Signaling/ChannelInfo.c
+++ b/src/source/Signaling/ChannelInfo.c
@@ -156,7 +156,7 @@ STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* pp
     pCurPtr += ALIGN_UP_TO_MACHINE_WORD(userAgentLen + 1);
 
     if (kmsLen != 0) {
-        STRCPY(pCurPtr, pOrigChannelInfo->pCustomUserAgent);
+        STRCPY(pCurPtr, pOrigChannelInfo->pKmsKeyId);
         pChannelInfo->pKmsKeyId = pCurPtr;
         pCurPtr += ALIGN_UP_TO_MACHINE_WORD(kmsLen + 1);
     }

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -32,8 +32,7 @@ TEST_F(SignalingApiTest, createValidateChannelInfo)
     EXPECT_EQ(0, STRCMP(rChannelInfo->pCertPath, mCaCertPath));
     EXPECT_EQ(rChannelInfo->messageTtl, TEST_SIGNALING_MESSAGE_TTL);
     EXPECT_EQ(0, STRCMP(rChannelInfo->pRegion, TEST_DEFAULT_REGION));
-
-    SAFE_MEMFREE(rChannelInfo);
+    freeChannelInfo(&rChannelInfo);
 }
 
 TEST_F(SignalingApiTest, signalingSendMessageSync)

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -9,6 +9,33 @@ namespace webrtcclient {
 class SignalingApiTest : public WebRtcClientTestBase {
 };
 
+TEST_F(SignalingApiTest, createValidateChannelInfo)
+{
+    initializeSignalingClientStructs();
+    PChannelInfo rChannelInfo = NULL;
+    STRCPY(mChannelArn, TEST_CHANNEL_ARN);
+    STRCPY(mKmsKeyId, TEST_KMS_KEY_ID_ARN);
+    mChannelInfo.pChannelArn = mChannelArn;
+    mChannelInfo.pKmsKeyId = mKmsKeyId;
+    EXPECT_EQ(STATUS_SUCCESS, createValidateChannelInfo(&mChannelInfo, &rChannelInfo));
+    EXPECT_EQ(0, STRCMP(rChannelInfo->pChannelArn, TEST_CHANNEL_ARN));
+    EXPECT_EQ(0, STRCMP(rChannelInfo->pKmsKeyId, TEST_KMS_KEY_ID_ARN));
+    EXPECT_EQ(rChannelInfo->version, CHANNEL_INFO_CURRENT_VERSION);
+    EXPECT_EQ(rChannelInfo->tagCount, 3);
+    EXPECT_EQ(rChannelInfo->retry, TRUE);
+    EXPECT_EQ(rChannelInfo->channelType, SIGNALING_CHANNEL_TYPE_SINGLE_MASTER);
+    EXPECT_EQ(rChannelInfo->channelRoleType, SIGNALING_CHANNEL_ROLE_TYPE_MASTER);
+    EXPECT_EQ(rChannelInfo->cachingPolicy, SIGNALING_API_CALL_CACHE_TYPE_NONE);
+    // The createValidateChannelInfo() is expected to fix up caching period to an hour
+    EXPECT_EQ(rChannelInfo->cachingPeriod, SIGNALING_DEFAULT_API_CALL_CACHE_TTL);
+    EXPECT_EQ(rChannelInfo->reconnect, TRUE);
+    EXPECT_EQ(0, STRCMP(rChannelInfo->pCertPath, mCaCertPath));
+    EXPECT_EQ(rChannelInfo->messageTtl, TEST_SIGNALING_MESSAGE_TTL);
+    EXPECT_EQ(0, STRCMP(rChannelInfo->pRegion, TEST_DEFAULT_REGION));
+
+    SAFE_MEMFREE(rChannelInfo);
+}
+
 TEST_F(SignalingApiTest, signalingSendMessageSync)
 {
     STATUS expectedStatus;

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -12,7 +12,7 @@ class SignalingApiTest : public WebRtcClientTestBase {
 TEST_F(SignalingApiTest, createValidateChannelInfo)
 {
     initializeSignalingClientStructs();
-    PChannelInfo rChannelInfo = NULL;
+    PChannelInfo rChannelInfo;
     STRCPY(mChannelArn, TEST_CHANNEL_ARN);
     STRCPY(mKmsKeyId, TEST_KMS_KEY_ID_ARN);
     mChannelInfo.pChannelArn = mChannelArn;

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -13,6 +13,8 @@
 #define TEST_SIGNALING_MASTER_CLIENT_ID (PCHAR) "Test_Master_ClientId"
 #define TEST_SIGNALING_VIEWER_CLIENT_ID (PCHAR) "Test_Viewer_ClientId"
 #define TEST_SIGNALING_CHANNEL_NAME     (PCHAR) "ScaryTestChannel_"
+#define TEST_KMS_KEY_ID_ARN             (PCHAR) "arn:aws:kms:us-west-2:123456789012:key/0000-0000-0000-0000-0000"
+#define TEST_CHANNEL_ARN                (PCHAR) "arn:aws:kinesisvideo:us-west-2:123456789012:channel/ScaryTestChannel"
 #define SIGNAING_TEST_CORRELATION_ID    (PCHAR) "Test_correlation_id"
 #define TEST_SIGNALING_MESSAGE_TTL      (120 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 #define TEST_VIDEO_FRAME_SIZE           (120 * 1024)
@@ -293,6 +295,8 @@ class WebRtcClientTestBase : public ::testing::Test {
     CHAR mDefaultRegion[MAX_REGION_NAME_LEN + 1];
     BOOL mAccessKeyIdSet;
     CHAR mChannelName[MAX_CHANNEL_NAME_LEN + 1];
+    CHAR mChannelArn[MAX_ARN_LEN + 1];
+    CHAR mKmsKeyId[MAX_ARN_LEN + 1];
 
     PJitterBuffer mJitterBuffer;
     PBYTE mFrame;


### PR DESCRIPTION
*Issue #, if available:*
#1461 
*Description of changes:*

- Fixed typo
- Added unit test
- Changed alpine image version on static-build-linux since the latest image uses gcc11 that causes gtest version build 1.8.1 to fail. Long term solution would be to update gtest version to 1.11.0 since it fixes the issue on gcc11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
