### PR TITLE
fix mips compile error

### DIFF
--- a/CMake/Dependencies/libsrtp-CMakeLists.txt
+++ b/CMake/Dependencies/libsrtp-CMakeLists.txt
@@ -52,6 +52,7 @@ ExternalProject_Add(project_libsrtp
                       -D ENABLE_OPENSSL=${LIBSRTP_ENABLE_OPENSSL}
                       -D BUILD_SHARED_LIBS=${LIBSRTP_SHARED_LIBS}
                       -D OPENSSL_ROOT_DIR=${OPEN_SRC_INSTALL_PREFIX}
+                      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
     CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
     TEST_COMMAND      ""
 )

--- a/CMake/Dependencies/libusrsctp-CMakeLists.txt
+++ b/CMake/Dependencies/libusrsctp-CMakeLists.txt
@@ -8,7 +8,9 @@ ExternalProject_Add(project_libusrsctp
     GIT_REPOSITORY    https://github.com/sctplab/usrsctp.git
     GIT_TAG           1ade45cbadfd19298d2c47dc538962d4425ad2dd
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
-    CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} -DCMAKE_C_FLAGS=-fPIC -Dsctp_werror=0
+    CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX} 
+                      "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -fPIC"
+                      -Dsctp_werror=0
     BUILD_ALWAYS      TRUE
     TEST_COMMAND      ""
 )

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -65,14 +65,14 @@ function(build_dependency lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
+    COMMAND ${CMAKE_COMMAND} --build . -v
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
   if(result)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
 
-  file(REMOVE_RECURSE ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
+  #  file(REMOVE_RECURSE ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
 endfunction()
 
 function(enableSanitizer SANITIZER)

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -65,14 +65,14 @@ function(build_dependency lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build . -v
+    COMMAND ${CMAKE_COMMAND} --build .
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
   if(result)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
 
-  #  file(REMOVE_RECURSE ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
+  file(REMOVE_RECURSE ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
 endfunction()
 
 function(enableSanitizer SANITIZER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ if(USE_OPENSSL)
 elseif(USE_MBEDTLS)
   add_definitions(-DKVS_USE_MBEDTLS)
   # FIXME: there's probably a better way to inject MBEDTLS_USER_CONFIG_FILE flag without mutating the global CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
-  set(CMAKE_C_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE='<config_mbedtls.h>' ${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE='<config_mbedtls.h>' -std=c99 ${CMAKE_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE='<config_mbedtls.h>' ${CMAKE_CXX_FLAGS}")
 endif()
 
@@ -130,7 +130,7 @@ if(BUILD_DEPENDENCIES)
                  -DOPENSSL_DIR=${OPEN_SRC_INSTALL_PREFIX}
                  -DUSE_OPENSSL=${USE_OPENSSL}
                  -DUSE_MBEDTLS=${USE_MBEDTLS}
-                 -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+                 -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -Werror=implicit-function-declaration")
   build_dependency(websockets ${BUILD_ARGS})
 
   set(BUILD_ARGS
@@ -161,7 +161,7 @@ if(BUILD_DEPENDENCIES)
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DUSE_OPENSSL=${USE_OPENSSL}
       -DUSE_MBEDTLS=${USE_MBEDTLS}
-      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+      -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -D_XOPEN_SOURCE=700")
   build_dependency(kvsCommonLws ${BUILD_ARGS})
 
   message(STATUS "Finished building dependencies.")
@@ -217,6 +217,8 @@ link_directories(${OPEN_SRC_INSTALL_PREFIX}/lib)
 
 if("${CMAKE_C_COMPILER_ID}" MATCHES "GNU|Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
 
   if(ADD_MUCLIBC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -muclibc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ endif()
 
 set(KINESIS_VIDEO_WEBRTC_CLIENT_SRC "${CMAKE_CURRENT_SOURCE_DIR}")
 
+if(ADD_MUCLIBC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -muclibc")
+endif()
+
 
 message(STATUS "Kinesis Video WebRTC Client path is ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}")
 message(STATUS "dependencies install path is ${OPEN_SRC_INSTALL_PREFIX}")
@@ -92,7 +96,7 @@ if(USE_OPENSSL)
 elseif(USE_MBEDTLS)
   add_definitions(-DKVS_USE_MBEDTLS)
   # FIXME: there's probably a better way to inject MBEDTLS_USER_CONFIG_FILE flag without mutating the global CMAKE_C_FLAGS and CMAKE_CXX_FLAGS
-  set(CMAKE_C_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE='<config_mbedtls.h>' -std=c99 ${CMAKE_C_FLAGS}")
+  set(CMAKE_C_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE='<config_mbedtls.h>' ${CMAKE_C_FLAGS}")
   set(CMAKE_CXX_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE='<config_mbedtls.h>' ${CMAKE_CXX_FLAGS}")
 endif()
 
@@ -121,7 +125,7 @@ if(BUILD_DEPENDENCIES)
     set(OPENSSL_ROOT_DIR ${OPEN_SRC_INSTALL_PREFIX})
   elseif(USE_MBEDTLS)
     set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
-                   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+                   "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -std=c99")
     build_dependency(mbedtls ${BUILD_ARGS})
   endif()
 
@@ -130,7 +134,7 @@ if(BUILD_DEPENDENCIES)
                  -DOPENSSL_DIR=${OPEN_SRC_INSTALL_PREFIX}
                  -DUSE_OPENSSL=${USE_OPENSSL}
                  -DUSE_MBEDTLS=${USE_MBEDTLS}
-                 -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -Werror=implicit-function-declaration")
+                 -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
   build_dependency(websockets ${BUILD_ARGS})
 
   set(BUILD_ARGS
@@ -140,10 +144,14 @@ if(BUILD_DEPENDENCIES)
       -DBUILD_LIBSRTP_DESTINATION_PLATFORM=${BUILD_LIBSRTP_DESTINATION_PLATFORM}
       -DUSE_OPENSSL=${USE_OPENSSL}
       -DUSE_MBEDTLS=${USE_MBEDTLS}
-  )
+      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+  
   build_dependency(srtp ${BUILD_ARGS})
 
-  build_dependency(usrsctp)
+  set(BUILD_ARGS
+      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+
+  build_dependency(usrsctp ${BUILD_ARGS})
   if(BUILD_TEST)
     build_dependency(gtest)
   endif()
@@ -161,7 +169,7 @@ if(BUILD_DEPENDENCIES)
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DUSE_OPENSSL=${USE_OPENSSL}
       -DUSE_MBEDTLS=${USE_MBEDTLS}
-      -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -D_XOPEN_SOURCE=700")
+      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
   build_dependency(kvsCommonLws ${BUILD_ARGS})
 
   message(STATUS "Finished building dependencies.")
@@ -218,11 +226,6 @@ link_directories(${OPEN_SRC_INSTALL_PREFIX}/lib)
 if("${CMAKE_C_COMPILER_ID}" MATCHES "GNU|Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
-
-  if(ADD_MUCLIBC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -muclibc")
-  endif()
 
   if(CODE_COVERAGE)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g -fprofile-arcs -ftest-coverage")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. fix mips compile error when use toolchain mips-gcc472-glibc216-64bit
2. option ADD_MUCLIBC effect to all dependencies


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
