### PR TITLE
fix prflx update interrupted connectivity check

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2498,7 +2498,9 @@ STATUS handleStunPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen, PS
 
             pStunAttributeAddress = (PStunAttributeAddress) pStunAttr;
 
-            if (!isSameIpAddress(&pStunAttributeAddress->address, &pIceCandidatePair->local->ipAddress, FALSE)) {
+            if (pIceCandidatePair->local->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE
+                    && pIceCandidatePair->remote->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE
+                    && !isSameIpAddress(&pStunAttributeAddress->address, &pIceCandidatePair->local->ipAddress, FALSE)) {
                 // this can happen for host and server reflexive candidates. If the peer
                 // is in the same subnet, server reflexive candidate's binding response's xor mapped ip address will be
                 // the host candidate ip address. In this case we will ignore the packet since the host candidate will
@@ -2509,7 +2511,6 @@ STATUS handleStunPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen, PS
                 CHK_STATUS(iceAgentCheckPeerReflexiveCandidate(pIceAgent, &pStunAttributeAddress->address, pIceCandidatePair->local->priority, FALSE,
                                                                pSocketConnection));
 
-                CHK(FALSE, retStatus);
             }
 
             if (pIceCandidatePair->state != ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {


### PR DESCRIPTION
*Issue #, if available:*

1. when the two endpiont of connecion both are relay candidate, and the ip of local relay candidate is not the same as remote relay candidate. then can cause local relay candidate update to prflx，and interrupted connectivity check

for example
```
a ---binding req------------> relayA(ipA) --> realyB(ipB) --------------------------> b
a <--binding resp(xor=ipB)--- relayA(ipA) <-- realyB(ipB) <--binding resp(xor=ipB)--- b
```

The process is as follows:
- a have a relay candidate which ip is ipA, b have a relay candidate which ip is ipB, they are paired
- a send a binding request to b, then b find the request coming from ipB, and send binding response(xor=ipB) to a
- a receive binding response, and check ipA != ipB, then update local.candidate.addr=ipB, local.candidate.type=prflx, 
- then the code jump to CleanUp, did not continue to update pIceCandidatePair->state to ICE_CANDIDATE_PAIR_STATE_SUCCEEDED, so that the connection can not be established



2. When the LAN has two external network exits ip, then can cause interrupted connectivity check

for example：
```
  ---NAT(ip1)--> stun               
  <-------------                    
a ---NAT(ip2)----binding req-----------------------> b
  <--------------binding resp(xor=ip2)--------------
```

The process is as follows:
- a have a srflx candiate which ip is ip1, and b have srflx whic ip is ipx, they are paired
- a send binding request to b, and b finds the request coming from ip2, then send bind response(xor=ip2) to a
- a receive binding response, and check ip1 != ip2, then update local.candidate.addr=ip2, local.candidate.type=prflx
- then the code jump to CleanUp, did not continue to update pIceCandidatePair->state to ICE_CANDIDATE_PAIR_STATE_SUCCEEDED, so that the connection can not be established




*Description of changes:*
1. Do not interrupt connectivity checks when updating local candidate type to prflx
2. Only when both local.candiate.type and remote.candidate.type are srflx， then can allowed to update local.candiate.type to prflx when appropriate


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
