### PR TITLE
Fix deadlock getIceCandidatePairStatsCallback

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -870,7 +870,7 @@ STATUS getIceCandidatePairStatsCallback(UINT32 timerId, UINT64 currentTime, UINT
     } else {
         locked = TRUE;
     }
-    
+
     for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
         if (STATUS_SUCCEEDED(rtcPeerConnectionGetMetrics(pSampleConfiguration->sampleStreamingSessionList[i]->pPeerConnection, NULL,
                                                          &pSampleConfiguration->rtcIceCandidatePairMetrics))) {


### PR DESCRIPTION
*Issue #1560*

*Description of changes:*
avoid deadlock via MUTEX_TRYLOCK and just try again later via timer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
