### PR TITLE
#1614 In the transactionIdStoreInsert function, when a new transactionId is inserted.If 'pTransactionIdStore->nextTransactionIdIndex == pTransactionIdStore->earliestTransactionIdIndex' the first transactionId will be eliminated, then the transactionIdCount should remain unchanged.

### DIFF
--- a/src/source/Ice/IceUtils.c
+++ b/src/source/Ice/IceUtils.c
@@ -68,6 +68,7 @@ VOID transactionIdStoreInsert(PTransactionIdStore pTransactionIdStore, PBYTE tra
     if (pTransactionIdStore->nextTransactionIdIndex == pTransactionIdStore->earliestTransactionIdIndex) {
         pTransactionIdStore->earliestTransactionIdIndex =
             (pTransactionIdStore->earliestTransactionIdIndex + 1) % pTransactionIdStore->maxTransactionIdsCount;
+        return;
     }
 
     pTransactionIdStore->transactionIdCount = MIN(pTransactionIdStore->transactionIdCount + 1, pTransactionIdStore->maxTransactionIdsCount);


### PR DESCRIPTION
#1614 
In the transactionIdStoreInsert function, when a new transactionId is inserted.If 'pTransactionIdStore->nextTransactionIdIndex == pTransactionIdStore->earliestTransactionIdIndex' the first transactionId will be eliminated, then the transactionIdCount should remain unchanged.
