### PR TITLE
Add clarifying comment for fallthrough

### DIFF
--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -910,7 +910,8 @@ STATUS turnConnectionStepState(PTurnConnection pTurnConnection)
             } else {
                 CHK(currentTime < pTurnConnection->stateTimeoutTime, STATUS_TURN_CONNECTION_STATE_TRANSITION_TIMEOUT);
             }
-
+        
+        // fallthrough here, missing break intended
         case TURN_STATE_GET_CREDENTIALS:
 
             if (pTurnConnection->credentialObtained) {


### PR DESCRIPTION
*Issue #, if available:*
#1544 

*Description of changes:*
* Add a comment clarifying that the missing `break` statement/fallthrough for the `TURN_STATE_CHECK_SOCKET_CONNECTION` case in [turnConnectionHandleStun](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/b820e2ea3d28c670da2fbc789face742cb949ef1/src/source/Ice/TurnConnection.c#L926) is intended.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
