### PR TITLE
Fix turn allocation taken long time when credential is incorrect

### DIFF
--- a/configs/config_mbedtls.h
+++ b/configs/config_mbedtls.h
@@ -30,7 +30,7 @@ extern "C" {
  *
  * Uncomment to use your own hardware entropy collector.
  */
-//#define MBEDTLS_ENTROPY_HARDWARE_ALT
+// #define MBEDTLS_ENTROPY_HARDWARE_ALT
 
 #ifdef __cplusplus
 }

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -205,7 +205,7 @@ extern "C" {
 #define STATUS_TURN_CONNECTION_PEER_NOT_USABLE                             STATUS_ICE_BASE + 0x00000027
 #define STATUS_ICE_SERVER_INDEX_INVALID                                    STATUS_ICE_BASE + 0x00000028
 #define STATUS_ICE_CANDIDATE_STRING_MISSING_TYPE                           STATUS_ICE_BASE + 0x00000029
-#define STATUS_TURN_CONNECTION_FAILED_TO_ALLOCATION                        STATUS_ICE_BASE + 0x0000002a
+#define STATUS_TURN_CONNECTION_ALLOCAITON_FAILED                           STATUS_ICE_BASE + 0x0000002a
 /*!@} */
 
 /////////////////////////////////////////////////////

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -205,6 +205,7 @@ extern "C" {
 #define STATUS_TURN_CONNECTION_PEER_NOT_USABLE                             STATUS_ICE_BASE + 0x00000027
 #define STATUS_ICE_SERVER_INDEX_INVALID                                    STATUS_ICE_BASE + 0x00000028
 #define STATUS_ICE_CANDIDATE_STRING_MISSING_TYPE                           STATUS_ICE_BASE + 0x00000029
+#define STATUS_TURN_CONNECTION_FAILED_TO_ALLOCATION                        STATUS_ICE_BASE + 0x0000002a
 /*!@} */
 
 /////////////////////////////////////////////////////

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1767,13 +1767,13 @@ CleanUp:
     return retStatus;
 }
 
-
-STATUS turnStateFailedFn(PSocketConnection pSocketConnection, UINT64 data) {
+STATUS turnStateFailedFn(PSocketConnection pSocketConnection, UINT64 data)
+{
     UNUSED_PARAM(pSocketConnection);
 
     STATUS retStatus = STATUS_SUCCESS;
 
-    PIceCandidate pNewCandidate = (PIceCandidate)data;
+    PIceCandidate pNewCandidate = (PIceCandidate) data;
     CHK(pNewCandidate != NULL, STATUS_NULL_ARG);
 
     if (pNewCandidate->state == ICE_CANDIDATE_STATE_NEW) {
@@ -1820,9 +1820,9 @@ STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KV
     pNewCandidate->priority = computeCandidatePriority(pNewCandidate);
 
     TurnConnectionCallbacks callback = {0};
-    callback.customData = (UINT64)pNewCandidate;
+    callback.customData = (UINT64) pNewCandidate;
     callback.relayAddressAvailableFn = NULL;
-    callback.turnStateFailedFn= turnStateFailedFn;
+    callback.turnStateFailedFn = turnStateFailedFn;
 
     CHK_STATUS(createTurnConnection(&pIceAgent->iceServers[iceServerIndex], pIceAgent->timerQueueHandle,
                                     TURN_CONNECTION_DATA_TRANSFER_MODE_SEND_INDIDATION, protocol, &callback, pNewCandidate->pSocketConnection,

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2536,9 +2536,9 @@ STATUS handleStunPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen, PS
 
             pStunAttributeAddress = (PStunAttributeAddress) pStunAttr;
 
-            if (pIceCandidatePair->local->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE
-                    && pIceCandidatePair->remote->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE
-                    && !isSameIpAddress(&pStunAttributeAddress->address, &pIceCandidatePair->local->ipAddress, FALSE)) {
+            if (pIceCandidatePair->local->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE &&
+                pIceCandidatePair->remote->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE &&
+                !isSameIpAddress(&pStunAttributeAddress->address, &pIceCandidatePair->local->ipAddress, FALSE)) {
                 // this can happen for host and server reflexive candidates. If the peer
                 // is in the same subnet, server reflexive candidate's binding response's xor mapped ip address will be
                 // the host candidate ip address. In this case we will ignore the packet since the host candidate will
@@ -2548,7 +2548,6 @@ STATUS handleStunPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen, PS
                 // we have a peer reflexive local candidate
                 CHK_STATUS(iceAgentCheckPeerReflexiveCandidate(pIceAgent, &pStunAttributeAddress->address, pIceCandidatePair->local->priority, FALSE,
                                                                pSocketConnection));
-
             }
 
             if (pIceCandidatePair->state != ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1768,12 +1768,20 @@ CleanUp:
 }
 
 
-STATUS trunStateFailedFn(UINT64 data, PSocketConnection pSocketConnection) {
+STATUS trunStateFailedFn(PSocketConnection pSocketConnection, UINT64 data) {
+    UNUSED_PARAM(pSocketConnection);
+
+    STATUS retStatus = STATUS_SUCCESS;
+
     PIceCandidate pNewCandidate = (PIceCandidate)data;
-    if (pNewCandidate != NULL && pNewCandidate->state == ICE_CANDIDATE_STATE_NEW) {
+    CHK(pNewCandidate != NULL, STATUS_NULL_ARG);
+
+    if (pNewCandidate->state == ICE_CANDIDATE_STATE_NEW) {
         pNewCandidate->state = ICE_CANDIDATE_STATE_INVALID;
     }
-    return 0;
+
+CleanUp:
+    return retStatus;
 }
 
 STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KVS_SOCKET_PROTOCOL protocol)

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2536,7 +2536,9 @@ STATUS handleStunPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen, PS
 
             pStunAttributeAddress = (PStunAttributeAddress) pStunAttr;
 
-            if (!isSameIpAddress(&pStunAttributeAddress->address, &pIceCandidatePair->local->ipAddress, FALSE)) {
+            if (pIceCandidatePair->local->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE
+                    && pIceCandidatePair->remote->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE
+                    && !isSameIpAddress(&pStunAttributeAddress->address, &pIceCandidatePair->local->ipAddress, FALSE)) {
                 // this can happen for host and server reflexive candidates. If the peer
                 // is in the same subnet, server reflexive candidate's binding response's xor mapped ip address will be
                 // the host candidate ip address. In this case we will ignore the packet since the host candidate will
@@ -2547,7 +2549,6 @@ STATUS handleStunPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen, PS
                 CHK_STATUS(iceAgentCheckPeerReflexiveCandidate(pIceAgent, &pStunAttributeAddress->address, pIceCandidatePair->local->priority, FALSE,
                                                                pSocketConnection));
 
-                CHK(FALSE, retStatus);
             }
 
             if (pIceCandidatePair->state != ICE_CANDIDATE_PAIR_STATE_SUCCEEDED) {

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1767,6 +1767,15 @@ CleanUp:
     return retStatus;
 }
 
+
+STATUS trunStateFailedFn(UINT64 data, PSocketConnection pSocketConnection) {
+    PIceCandidate pNewCandidate = (PIceCandidate)data;
+    if (pNewCandidate != NULL && pNewCandidate->state == ICE_CANDIDATE_STATE_NEW) {
+        pNewCandidate->state = ICE_CANDIDATE_STATE_INVALID;
+    }
+    return 0;
+}
+
 STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KVS_SOCKET_PROTOCOL protocol)
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -1802,8 +1811,13 @@ STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KV
     pNewCandidate->foundation = pIceAgent->foundationCounter++; // we dont generate candidates that have the same foundation.
     pNewCandidate->priority = computeCandidatePriority(pNewCandidate);
 
+    TurnConnectionCallbacks callback = {0};
+    callback.customData = pNewCandidate;
+    callback.relayAddressAvailableFn = NULL;
+    callback.turnStateFailedFn= trunStateFailedFn;
+
     CHK_STATUS(createTurnConnection(&pIceAgent->iceServers[iceServerIndex], pIceAgent->timerQueueHandle,
-                                    TURN_CONNECTION_DATA_TRANSFER_MODE_SEND_INDIDATION, protocol, NULL, pNewCandidate->pSocketConnection,
+                                    TURN_CONNECTION_DATA_TRANSFER_MODE_SEND_INDIDATION, protocol, &callback, pNewCandidate->pSocketConnection,
                                     pIceAgent->pConnectionListener, &pTurnConnection));
     pNewCandidate->pIceAgent = pIceAgent;
     pNewCandidate->pTurnConnection = pTurnConnection;

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1820,7 +1820,7 @@ STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KV
     pNewCandidate->priority = computeCandidatePriority(pNewCandidate);
 
     TurnConnectionCallbacks callback = {0};
-    callback.customData = pNewCandidate;
+    callback.customData = (UINT64)pNewCandidate;
     callback.relayAddressAvailableFn = NULL;
     callback.turnStateFailedFn= trunStateFailedFn;
 

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1768,7 +1768,7 @@ CleanUp:
 }
 
 
-STATUS trunStateFailedFn(PSocketConnection pSocketConnection, UINT64 data) {
+STATUS turnStateFailedFn(PSocketConnection pSocketConnection, UINT64 data) {
     UNUSED_PARAM(pSocketConnection);
 
     STATUS retStatus = STATUS_SUCCESS;
@@ -1822,7 +1822,7 @@ STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KV
     TurnConnectionCallbacks callback = {0};
     callback.customData = (UINT64)pNewCandidate;
     callback.relayAddressAvailableFn = NULL;
-    callback.turnStateFailedFn= trunStateFailedFn;
+    callback.turnStateFailedFn= turnStateFailedFn;
 
     CHK_STATUS(createTurnConnection(&pIceAgent->iceServers[iceServerIndex], pIceAgent->timerQueueHandle,
                                     TURN_CONNECTION_DATA_TRANSFER_MODE_SEND_INDIDATION, protocol, &callback, pNewCandidate->pSocketConnection,

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -1117,7 +1117,8 @@ CleanUp:
         pTurnConnection->state = TURN_STATE_FAILED;
 
         if (pTurnConnection->turnConnectionCallbacks.turnStateFailedFn != NULL) {
-            pTurnConnection->turnConnectionCallbacks.turnStateFailedFn(pTurnConnection->pControlChannel, pTurnConnection->turnConnectionCallbacks.customData);
+            pTurnConnection->turnConnectionCallbacks.turnStateFailedFn(pTurnConnection->pControlChannel,
+                                                                       pTurnConnection->turnConnectionCallbacks.customData);
         }
 
         /* fix up state to trigger transition into TURN_STATE_FAILED  */

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -996,7 +996,7 @@ STATUS turnConnectionStepState(PTurnConnection pTurnConnection)
 
             } else {
                 pTurnConnection->stateTryCount++;
-                CHK(pTurnConnection->stateTryCount < pTurnConnection->stateTryCountMax, STATUS_TURN_CONNECTION_FAILED_TO_ALLOCATION);
+                CHK(pTurnConnection->stateTryCount < pTurnConnection->stateTryCountMax, STATUS_TURN_CONNECTION_ALLOCAITON_FAILED);
                 CHK(currentTime < pTurnConnection->stateTimeoutTime, STATUS_TURN_CONNECTION_STATE_TRANSITION_TIMEOUT);
             }
             break;
@@ -1117,7 +1117,7 @@ CleanUp:
         pTurnConnection->state = TURN_STATE_FAILED;
 
         if (pTurnConnection->turnConnectionCallbacks.turnStateFailedFn != NULL) {
-            pTurnConnection->turnConnectionCallbacks.turnStateFailedFn(pTurnConnection->turnConnectionCallbacks.customData, NULL);
+            pTurnConnection->turnConnectionCallbacks.turnStateFailedFn(pTurnConnection, pTurnConnection->turnConnectionCallbacks.customData);
         }
 
         /* fix up state to trigger transition into TURN_STATE_FAILED  */

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -1117,7 +1117,7 @@ CleanUp:
         pTurnConnection->state = TURN_STATE_FAILED;
 
         if (pTurnConnection->turnConnectionCallbacks.turnStateFailedFn != NULL) {
-            pTurnConnection->turnConnectionCallbacks.turnStateFailedFn(pTurnConnection, pTurnConnection->turnConnectionCallbacks.customData);
+            pTurnConnection->turnConnectionCallbacks.turnStateFailedFn(pTurnConnection->pControlChannel, pTurnConnection->turnConnectionCallbacks.customData);
         }
 
         /* fix up state to trigger transition into TURN_STATE_FAILED  */

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -58,7 +58,7 @@ extern "C" {
 #define TURN_STATE_UNKNOWN_STR                 (PCHAR) "TURN_STATE_UNKNOWN"
 
 typedef STATUS (*RelayAddressAvailableFunc)(UINT64, PKvsIpAddress, PSocketConnection);
-typedef STATUS (*TurnStateFailedFunc)(UINT64, PSocketConnection);
+typedef STATUS (*TurnStateFailedFunc)(PSocketConnection, UINT64);
 
 typedef enum {
     TURN_STATE_NEW,

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -37,6 +37,8 @@ extern "C" {
 #define DEFAULT_TURN_CHANNEL_DATA_BUFFER_SIZE             512
 #define DEFAULT_TURN_MAX_PEER_COUNT                       32
 
+#define DEFAULT_TURN_ALLOCATION_MAX_TRY_COUNT             3 
+
 // all turn channel numbers must be greater than 0x4000 and less than 0x7FFF
 #define TURN_CHANNEL_BIND_CHANNEL_NUMBER_BASE (UINT16) 0x4000
 
@@ -56,6 +58,7 @@ extern "C" {
 #define TURN_STATE_UNKNOWN_STR                 (PCHAR) "TURN_STATE_UNKNOWN"
 
 typedef STATUS (*RelayAddressAvailableFunc)(UINT64, PKvsIpAddress, PSocketConnection);
+typedef STATUS (*TurnStateFailedFunc)(UINT64, PSocketConnection);
 
 typedef enum {
     TURN_STATE_NEW,
@@ -90,6 +93,7 @@ typedef struct {
 typedef struct {
     UINT64 customData;
     RelayAddressAvailableFunc relayAddressAvailableFn;
+    TurnStateFailedFunc turnStateFailedFn;
 } TurnConnectionCallbacks, *PTurnConnectionCallbacks;
 
 typedef struct {
@@ -140,6 +144,8 @@ struct __TurnConnection {
     TURN_CONNECTION_STATE state;
 
     UINT64 stateTimeoutTime;
+    UINT32 stateTryCount;
+    UINT32 stateTryCountMax;
 
     STATUS errorStatus;
 

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -37,7 +37,7 @@ extern "C" {
 #define DEFAULT_TURN_CHANNEL_DATA_BUFFER_SIZE             512
 #define DEFAULT_TURN_MAX_PEER_COUNT                       32
 
-#define DEFAULT_TURN_ALLOCATION_MAX_TRY_COUNT             3 
+#define DEFAULT_TURN_ALLOCATION_MAX_TRY_COUNT 3
 
 // all turn channel numbers must be greater than 0x4000 and less than 0x7FFF
 #define TURN_CHANNEL_BIND_CHANNEL_NUMBER_BASE (UINT16) 0x4000


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/1536
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/1540

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
