### PR TITLE
Jitter buffer overflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ open-source/
 outputs
 tags
 CMakeLists.txt.user
+*.swp

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -622,6 +622,11 @@ extern "C" {
 #define MAX_SEQUENCE_NUM ((UINT32) MAX_UINT16)
 
 /**
+ * Maximum timestamp in rtp packet/jitter buffer
+ */
+#define MAX_TIMESTAMP ((UINT32) MAX_UINT32)
+
+/**
  * Parameterized string for KVS STUN Server
  */
 #define KINESIS_VIDEO_STUN_URL "stun:stun.kinesisvideo.%s.amazonaws.com:443"

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -619,12 +619,12 @@ extern "C" {
 /**
  * Maximum sequence number in rtp packet/jitter buffer
  */
-#define MAX_SEQUENCE_NUM ((UINT32) MAX_UINT16)
+#define MAX_RTP_SEQUENCE_NUM ((UINT32) MAX_UINT16)
 
 /**
  * Maximum timestamp in rtp packet/jitter buffer
  */
-#define MAX_TIMESTAMP ((UINT32) MAX_UINT32)
+#define MAX_RTP_TIMESTAMP ((UINT32) MAX_UINT32)
 
 /**
  * Parameterized string for KVS STUN Server

--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -89,7 +89,7 @@ CleanUp:
 
 BOOL underflowPossible(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
     BOOL retVal = FALSE;
-    UINT16 seqNoDifference = 0;
+    UINT32 seqNoDifference = 0;
     UINT64 timestampDifference = 0;
     UINT64 maxTimePassed = 0;
     if(pJitterBuffer->headTimestamp == pRtpPacket->header.timestamp) {
@@ -106,7 +106,12 @@ BOOL underflowPossible(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
 
         //1 frame per second, and 1 packet per frame, the most charitable case we can consider
         //TODO track most recent FPS to improve this metric
-        maxTimePassed = pJitterBuffer->clockRate * seqNoDifference;
+        if((MAX_RTP_TIMESTAMP / pJitterBuffer->clockRate) <= seqNoDifference) {
+            maxTimePassed = MAX_RTP_TIMESTAMP;
+        }
+        else {
+            maxTimePassed = pJitterBuffer->clockRate * seqNoDifference;
+        }
 
         if(maxTimePassed >= timestampDifference) {
             retVal = TRUE;

--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -200,7 +200,6 @@ BOOL enterSequenceNumberOverflowCheck(PJitterBuffer pJitterBuffer, PRtpPacket pR
     BOOL overflow = FALSE;
     BOOL underflow = FALSE;
     UINT16 packetsUntilOverflow = MAX_RTP_SEQUENCE_NUM - pJitterBuffer->tailSequenceNumber;
-    UINT16 underflowFromMaxRange = 0;
 
     if (!pJitterBuffer->sequenceNumberOverflowState) {
         // overflow case
@@ -398,7 +397,6 @@ STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOO
     STATUS retStatus = STATUS_SUCCESS, status = STATUS_SUCCESS;
     UINT64 hashValue = 0;
     PRtpPacket pCurPacket = NULL;
-    UINT16 packetsUntilOverflow = 0;
 
     CHK(pJitterBuffer != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
 

--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -32,11 +32,14 @@ STATUS createJitterBuffer(FrameReadyFunc onFrameReadyFunc, FrameDroppedFunc onFr
     }
     pJitterBuffer->maxLatency = pJitterBuffer->maxLatency * pJitterBuffer->clockRate / HUNDREDS_OF_NANOS_IN_A_SECOND;
 
-    pJitterBuffer->lastPushTimestamp = 0;
+    pJitterBuffer->tailTimestamp = 0;
     pJitterBuffer->headTimestamp = MAX_UINT32;
     pJitterBuffer->headSequenceNumber = MAX_SEQUENCE_NUM;
+    pJitterBuffer->tailSequenceNumber = MAX_SEQUENCE_NUM;
     pJitterBuffer->started = FALSE;
     pJitterBuffer->firstFrameProcessed = FALSE;
+    pJitterBuffer->timestampOverFlowState = FALSE;
+    pJitterBuffer->sequenceNumberOverflowState = FALSE;
 
     pJitterBuffer->customData = customData;
     CHK_STATUS(hashTableCreateWithParams(JITTER_BUFFER_HASH_TABLE_BUCKET_COUNT, JITTER_BUFFER_HASH_TABLE_BUCKET_LENGTH,
@@ -82,12 +85,291 @@ CleanUp:
     return retStatus;
 }
 
+//return true if sequence numbers are now overflowing
+BOOL enterSequenceNumberOverflowCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
+    BOOL overflow = FALSE;
+    BOOL underflow = FALSE;
+    UINT16 packetsUntilOverflow = MAX_SEQUENCE_NUM - pJitterBuffer->tailSequenceNumber;
+    UINT16 underflowFromMaxRange = 0;
+
+    if(!pJitterBuffer->sequenceNumberOverflowState) {
+
+        //overflow case
+        if(MAX_OUT_OF_ORDER_PACKET_DIFFERENCE >= packetsUntilOverflow) {
+            //It's possible sequence numbers and timestamps are both overflowing.
+            if(pRtpPacket->header.sequenceNumber < pJitterBuffer->tailSequenceNumber &&
+               pRtpPacket->header.sequenceNumber <= MAX_OUT_OF_ORDER_PACKET_DIFFERENCE - packetsUntilOverflow) {
+                //Sequence number overflow detected
+                overflow = TRUE;
+            }
+        }
+        //underflow case
+        else if(headCheckingAllowed(pJitterBuffer, pRtpPacket)) { 
+            if (pJitterBuffer->headSequenceNumber < MAX_OUT_OF_ORDER_PACKET_DIFFERENCE) {
+                if ((pRtpPacket->header.sequenceNumber >=
+                            (MAX_UINT16 - (MAX_OUT_OF_ORDER_PACKET_DIFFERENCE - pJitterBuffer->headSequenceNumber))) ||
+                        (pJitterBuffer->headSequenceNumber > pRtpPacket->header.sequenceNumber)) {
+                    //Sequence number underflow detected
+                    underflow = TRUE;
+                }
+            }
+        }
+    }
+    if(overflow && underflow) {
+        //This shouldn't be possible. 
+        DLOGE("Critical underflow/overflow error in jitterbuffer");
+    }
+    if(overflow) {
+        pJitterBuffer->sequenceNumberOverflowState = TRUE;
+        pJitterBuffer->tailSequenceNumber = pRtpPacket->header.sequenceNumber;
+    }
+    if(underflow) {
+        pJitterBuffer->sequenceNumberOverflowState = TRUE;
+        pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
+    }
+    return (overflow || underflow);
+}
+
+BOOL enterTimestampOverflowCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
+    BOOL underflow = FALSE;
+    BOOL overflow = FALSE;
+    if(!pJitterBuffer->timestampOverFlowState) {
+        //overflow check
+        if(pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp &&
+           pJitterBuffer->tailTimestamp > pRtpPacket->header.timestamp) {
+            //Check to see if this could be a timestamp overflow case
+            //We always check sequence number first, so the 'or equal to' checks if we just set the tail.
+            //That would be a corner case of sequence number and timestamp both overflowing
+            //in this one packet.
+            if(pRtpPacket->header.sequenceNumber >= pJitterBuffer->tailSequenceNumber) {
+                //RTP timestamp overflow detected!
+                overflow = TRUE;
+            }
+        }
+        //underflow check
+        else if (pJitterBuffer->headTimestamp < pRtpPacket->header.timestamp &&
+                pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
+            if(headSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
+                underflow = TRUE;
+            }
+        }
+
+    }
+    if(overflow && underflow) {
+        //This shouldn't be possible. 
+        DLOGE("Critical underflow/overflow error in jitterbuffer");
+    }
+    if(overflow) {
+        pJitterBuffer->timestampOverFlowState = TRUE;
+        pJitterBuffer->tailTimestamp = pRtpPacket->header.timestamp;
+    }
+    else if(underflow) {
+        pJitterBuffer->timestampOverFlowState = TRUE;
+        pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+    }
+    return (underflow || overflow);
+}
+
+BOOL exitSequenceNumberOverflowCheck(PJitterBuffer pJitterBuffer) {
+    BOOL retVal = FALSE;
+
+    //can't exit if you're not in it
+    if(pJitterBuffer->sequenceNumberOverflowState) {
+        if(pJitterBuffer->headSequenceNumber <= pJitterBuffer->tailSequenceNumber) {
+            retVal = TRUE;
+        }
+    }
+
+    return retVal;
+}
+
+BOOL exitTimestampOverflowCheck(PJitterBuffer pJitterBuffer) {
+    BOOL retVal = FALSE;
+
+    //can't exit if you're not in it
+    if(pJitterBuffer->timestampOverFlowState) {
+        if(pJitterBuffer->headTimestamp <= pJitterBuffer->tailTimestamp) {
+            retVal = TRUE;
+        }
+    }
+
+    return retVal;
+}
+
+BOOL headCheckingAllowed(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
+    BOOL retVal = FALSE;
+    /*If we haven't yet processed a frame yet, then we don't have a definitive way of knowing if
+     *the first packet we receive is actually the earliest packet we'll ever receive. Since sequence numbers
+     *can start anywhere from 0 - 65535, we need to incorporate some checks to determine if a newly received packet
+     *should be considered the new head. Part of how we determine this is by setting a limit to how many packets off we allow
+     *this out of order case to be. Without setting a limit, then we could run into an odd scenario.
+     * Example:
+     * Push->Packet->SeqNumber == 0. //FIRST PACKET! new head of buffer!
+     * Push->Packet->SeqNumber == 3. //... new head of 65532 packet sized frame? maybe? was 0 the tail?
+     *
+     * To resolve that insanity we set a MAX, and will use that MAX for the range.
+     * This logic is present in headSequenceNumberCheck()
+     *
+     *After the first frame has been processed we don't need or want to make this consideration, since if our parser has
+     *dropped a frame for a good reason then we want to ignore any packets from that dropped frame that may come later.
+     *
+     *However if the packet's timestamp is the same as the head timestamp, then it's possible this is simply an earlier
+     *sequence number of the same packet.
+     */
+    if(!(pJitterBuffer->firstFrameProcessed) || 
+         pJitterBuffer->headTimestamp == pRtpPacket->header.timestamp) {
+        retVal = TRUE;
+    }
+    return retVal;
+}
+
+//return true if pRtpPacket contains a new head timestamp
+BOOL headTimestampCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
+    BOOL retVal = FALSE;
+
+    if(headCheckingAllowed(pJitterBuffer, pRtpPacket)) {
+        if(pJitterBuffer->timestampOverFlowState) {
+            if(pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp &&
+               pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
+                //in the correct range to be a new head or new tail.
+                //if it's also the head sequence number then it's the new headtimestamp
+                if(headSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
+                    pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+                    retVal = TRUE;
+                }
+            }
+        }
+        else {
+            if(pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp ||
+               pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
+                //in the correct range to be a new head or new tail.
+                //if it's also the head sequence number then it's the new headtimestamp
+                if(headSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
+                    pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+                    retVal = TRUE;
+                }
+            }
+        }
+    }
+    return retVal;
+}
+
+//return true if pRtpPacket contains a new tail timestamp
+BOOL tailTimestampCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
+    BOOL retVal = FALSE;
+
+    if(pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
+        if(!pJitterBuffer->timestampOverFlowState ||
+            pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp) {
+            //in the correct range to be a new head or new tail.
+            //if it's also the tail sequence number then it's the new tail timestamp
+            if(tailSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
+                pJitterBuffer->tailTimestamp = pRtpPacket->header.timestamp;
+                retVal = TRUE;
+            }
+        }
+    }
+    return retVal;
+}
+
+//return true if pRtpPacket contains the head sequence number
+BOOL headSequenceNumberCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
+    BOOL retVal = FALSE;
+    UINT16 minimumHead = 0;
+    if(pJitterBuffer->headSequenceNumber >= MAX_OUT_OF_ORDER_PACKET_DIFFERENCE) {
+        minimumHead = pJitterBuffer->headSequenceNumber - MAX_OUT_OF_ORDER_PACKET_DIFFERENCE;
+    }
+
+    //If we've already done this check and it was true
+    if(pJitterBuffer->headSequenceNumber == pRtpPacket->header.sequenceNumber) {
+        retVal = TRUE;
+    }
+    else if(headCheckingAllowed(pJitterBuffer, pRtpPacket)){
+        if(pJitterBuffer->sequenceNumberOverflowState) {
+            if(pJitterBuffer->tailSequenceNumber < pRtpPacket->header.sequenceNumber &&
+               pJitterBuffer->headSequenceNumber > pRtpPacket->header.sequenceNumber &&
+               pRtpPacket->header.sequenceNumber >= minimumHead) {
+                //This purposefully misses the usecase where the buffer has >65000 entries.
+                //Our buffer is not designed for that use case, and it becomes far too ambiguous
+                //as to which packets are new tails or new heads without adding epoch checks.
+                pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
+                retVal = TRUE;
+            }
+        }
+        else {
+            if(pRtpPacket->header.sequenceNumber < pJitterBuffer->headSequenceNumber) {
+                if(pRtpPacket->header.sequenceNumber >= minimumHead) {
+                    pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
+                    retVal = TRUE;
+                }
+            }
+        }
+
+    }
+    return retVal;
+}
+
+//return true if pRtpPacket contains a new tail sequence number
+BOOL tailSequenceNumberCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
+    BOOL retVal = FALSE;
+    //If we've already done this check and it was true
+    if(pJitterBuffer->tailSequenceNumber == pRtpPacket->header.sequenceNumber) {
+        retVal = TRUE;
+    }
+    else if(pRtpPacket->header.sequenceNumber > pJitterBuffer->tailSequenceNumber &&
+            (!pJitterBuffer->sequenceNumberOverflowState ||
+            pJitterBuffer->headSequenceNumber > pRtpPacket->header.sequenceNumber)) {
+        retVal = TRUE;
+        pJitterBuffer->tailSequenceNumber = pRtpPacket->header.sequenceNumber;            
+    }
+    return retVal;
+}
+
+//return true if pRtpPacket is within the latency tolerance (not much earlier than current head)
+BOOL withinLatencyTolerance(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket) {
+    BOOL retVal = FALSE;
+    UINT32 minimumTimestamp = 0;
+
+    //Simple check, if we're at or past the tail timestamp then we're always within latency tolerance.
+    //overflow is checked earlier
+    if(tailTimestampCheck(pJitterBuffer, pRtpPacket) || pJitterBuffer->tailTimestamp == pRtpPacket->header.timestamp) {
+        retVal = TRUE;
+    }
+    else {
+        //Is our tail current less than our head due to timestamp overflow?
+        if(pJitterBuffer->timestampOverFlowState) {
+            //calculate max-latency across the overflow boundry without triggering underflow
+            if(pJitterBuffer->tailTimestamp < pJitterBuffer->maxLatency) {
+                minimumTimestamp = MAX_TIMESTAMP - (pJitterBuffer->maxLatency - pJitterBuffer->tailTimestamp);
+            }
+            //Is the packet within the current range or is it a new head/tail
+            if(pRtpPacket->header.timestamp < pJitterBuffer->tailTimestamp ||
+               pRtpPacket->header.timestamp > pJitterBuffer->headTimestamp) {
+                //The packet is within the current range
+                retVal = TRUE;
+            }
+            //The only remaining option is that timestamp must be before headTimestamp
+            else if(pRtpPacket->header.timestamp >= minimumTimestamp) {
+                retVal = TRUE;                
+            }
+        }
+        else {
+            if ((pRtpPacket->header.timestamp < pJitterBuffer->maxLatency && pJitterBuffer->tailTimestamp <= pJitterBuffer->maxLatency) ||
+                pRtpPacket->header.timestamp >= pJitterBuffer->tailTimestamp - pJitterBuffer->maxLatency) {
+                retVal = TRUE;
+            }
+        }
+    }
+    return retVal;
+}
+
 STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOOL pPacketDiscarded)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS, status = STATUS_SUCCESS;
     UINT64 hashValue = 0;
     PRtpPacket pCurPacket = NULL;
+    UINT16 packetsUntilOverflow = 0;
 
     CHK(pJitterBuffer != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
 
@@ -95,16 +377,24 @@ STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOO
         // Set to started and initialize the sequence number
         pJitterBuffer->started = TRUE;
         pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
+        pJitterBuffer->tailSequenceNumber = pRtpPacket->header.sequenceNumber;
         pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
     }
 
-    if (pJitterBuffer->lastPushTimestamp < pRtpPacket->header.timestamp) {
-        pJitterBuffer->lastPushTimestamp = pRtpPacket->header.timestamp;
+    //We'll check sequence numbers first, with our MAX Out of Order packet count to avoid
+    //defining a timestamp window for overflow
+    //Returning true means this packet is a new tail AND we've entered overflow state.
+    if(!enterSequenceNumberOverflowCheck(pJitterBuffer, pRtpPacket)) {
+        DLOGS("Entered sequenceNumber overflow state");
+        tailSequenceNumberCheck(pJitterBuffer, pRtpPacket);
+    }
+    if(!enterTimestampOverflowCheck(pJitterBuffer, pRtpPacket)) {
+        DLOGS("Entered timestamp overflow state");
+        tailTimestampCheck(pJitterBuffer, pRtpPacket);
     }
 
     // is the packet within the accepted latency range, if so, add it to the hashtable
-    if ((pRtpPacket->header.timestamp < pJitterBuffer->maxLatency && pJitterBuffer->lastPushTimestamp <= pJitterBuffer->maxLatency) ||
-        pRtpPacket->header.timestamp >= pJitterBuffer->lastPushTimestamp - pJitterBuffer->maxLatency) {
+    if (withinLatencyTolerance(pJitterBuffer, pRtpPacket)) {
         status = hashTableGet(pJitterBuffer->pPkgBufferHashTable, pRtpPacket->header.sequenceNumber, &hashValue);
         pCurPacket = (PRtpPacket) hashValue;
         if (STATUS_SUCCEEDED(status) && pCurPacket != NULL) {
@@ -114,38 +404,13 @@ STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOO
 
         CHK_STATUS(hashTablePut(pJitterBuffer->pPkgBufferHashTable, pRtpPacket->header.sequenceNumber, (UINT64) pRtpPacket));
 
-        /*If we haven't yet processed a frame yet, then we don't have a definitive way of knowing if
-         *the first packet we receive is actually the earliest packet we'll ever receive. Since sequence numbers
-         *can start anywhere from 0 - 65535, we need to incorporate some checks to determine if a newly received packet
-         *should be considered the new head. Part of how we determine this is by setting a limit to how many packets off we allow
-         *this out of order case to be. Without setting a limit, then we could run into an odd scenario.
-         * Example:
-         * Push->Packet->SeqNumber == 0. //FIRST PACKET! new head of buffer!
-         * Push->Packet->SeqNumber == 3. //... new head of 65532 packet sized frame? maybe? was 0 the tail?
-         *
-         * To resolve that insanity we set a MAX, and will use that MAX for the range.
-         *
-         *After the first frame has been processed we don't need or want to make this consideration, since if our parser has
-         *dropped a frame for a good reason then we want to ignore any packets from that dropped frame that may come later.
-         */
-        if (!(pJitterBuffer->firstFrameProcessed)) {
+        if (headCheckingAllowed(pJitterBuffer, pRtpPacket)) {
             // if the timestamp is less, we'll accept it as a new head, since it must be an earlier frame.
-            if (pRtpPacket->header.timestamp < pJitterBuffer->headTimestamp) {
-                pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
-                pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+            if(headTimestampCheck(pJitterBuffer, pRtpPacket)) {
+                DLOGS("New jitterbuffer head timestamp");
             }
-            // timestamp is equal, we're in the same frame.
-            else if (pRtpPacket->header.timestamp == pJitterBuffer->headTimestamp) {
-                if (pJitterBuffer->headSequenceNumber < MAX_OUT_OF_ORDER_PACKET_DIFFERENCE) {
-                    if ((pRtpPacket->header.sequenceNumber >=
-                         (MAX_UINT16 - (MAX_OUT_OF_ORDER_PACKET_DIFFERENCE - pJitterBuffer->headSequenceNumber))) ||
-                        (pJitterBuffer->headSequenceNumber > pRtpPacket->header.sequenceNumber)) {
-                        pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
-                    }
-                } else if ((pRtpPacket->header.sequenceNumber >= pJitterBuffer->headSequenceNumber - MAX_OUT_OF_ORDER_PACKET_DIFFERENCE) &&
-                           (pRtpPacket->header.sequenceNumber < pJitterBuffer->headSequenceNumber)) {
-                    pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
-                }
+            if(headSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
+                DLOGS("New jitterbuffer head sequenceNumber");
             }
         }
         // DONE with considering the head.
@@ -187,13 +452,13 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
     PRtpPacket pCurPacket = NULL;
 
     CHK(pJitterBuffer != NULL && pJitterBuffer->onFrameDroppedFn != NULL && pJitterBuffer->onFrameReadyFn != NULL, STATUS_NULL_ARG);
-    CHK(pJitterBuffer->lastPushTimestamp != 0, retStatus);
+    CHK(pJitterBuffer->tailTimestamp != 0, retStatus);
 
-    if (pJitterBuffer->lastPushTimestamp > pJitterBuffer->maxLatency) {
-        earliestAllowedTimestamp = pJitterBuffer->lastPushTimestamp - pJitterBuffer->maxLatency;
+    if (pJitterBuffer->tailTimestamp > pJitterBuffer->maxLatency) {
+        earliestAllowedTimestamp = pJitterBuffer->tailTimestamp - pJitterBuffer->maxLatency;
     }
 
-    lastIndex = pJitterBuffer->headSequenceNumber - 1;
+    lastIndex = pJitterBuffer->tailSequenceNumber;
     index = pJitterBuffer->headSequenceNumber;
     startDropIndex = index;
     // Loop through entire buffer to find complete frames.
@@ -210,7 +475,6 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
      *
      *The buffer is parsed in order of sequence numbers. It is important to note that if the Frame ready
      *conditions have been met from dropping an earlier frame, then it will be processed.
-     *
      */
     for (; index != lastIndex; index++) {
         CHK_STATUS(hashTableContains(pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
@@ -242,10 +506,10 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
                     startDropIndex = index;
                     containStartForEarliestFrame = FALSE;
                 }
-                // are we force clearing out the buffer? if so drop the contents of incomplete frame
+                // are we forcibly clearing out the buffer? if so drop the contents of incomplete frame
                 else if (pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed) {
-                    CHK_STATUS(
-                        pJitterBuffer->onFrameDroppedFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), pJitterBuffer->headTimestamp));
+                    //do not CHK_STATUS of onFrameDropped because we need to clear the jitter buffer no matter what else happens.
+                    pJitterBuffer->onFrameDroppedFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), pJitterBuffer->headTimestamp);
                     CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, UINT16_DEC(index), curTimestamp));
                     pJitterBuffer->firstFrameProcessed = TRUE;
                     isFrameDataContinuous = TRUE;
@@ -325,6 +589,12 @@ STATUS jitterBufferDropBufferData(PJitterBuffer pJitterBuffer, UINT16 startIndex
     }
     pJitterBuffer->headTimestamp = nextTimestamp;
     pJitterBuffer->headSequenceNumber = endIndex + 1;
+    if(exitTimestampOverflowCheck(pJitterBuffer)) {
+        DLOGS("Exited timestamp overflow state");
+    }
+    if(exitSequenceNumberOverflowCheck(pJitterBuffer)) {
+        DLOGS("Exited sequenceNumber overflow state");
+    }
 
 CleanUp:
     CHK_LOG_ERR(retStatus);

--- a/src/source/PeerConnection/JitterBuffer.h
+++ b/src/source/PeerConnection/JitterBuffer.h
@@ -32,7 +32,9 @@ typedef struct {
     UINT16 tailSequenceNumber;
     UINT32 headTimestamp;
     UINT32 tailTimestamp;
-    UINT32 maxLatency;
+    //this is set to U64 even though rtp timestamps are U32
+    //in order to allow calculations to not cause overflow
+    UINT64 maxLatency;
     UINT64 customData;
     UINT32 clockRate;
     BOOL started;

--- a/src/source/PeerConnection/JitterBuffer.h
+++ b/src/source/PeerConnection/JitterBuffer.h
@@ -32,8 +32,8 @@ typedef struct {
     UINT16 tailSequenceNumber;
     UINT32 headTimestamp;
     UINT32 tailTimestamp;
-    //this is set to U64 even though rtp timestamps are U32
-    //in order to allow calculations to not cause overflow
+    // this is set to U64 even though rtp timestamps are U32
+    // in order to allow calculations to not cause overflow
     UINT64 maxLatency;
     UINT64 customData;
     UINT32 clockRate;

--- a/src/source/PeerConnection/JitterBuffer.h
+++ b/src/source/PeerConnection/JitterBuffer.h
@@ -28,14 +28,17 @@ typedef struct {
     UINT64 transit;
     // holds estimated jitter, in clockRate units
     DOUBLE jitter;
-    UINT32 lastPushTimestamp;
     UINT16 headSequenceNumber;
+    UINT16 tailSequenceNumber;
     UINT32 headTimestamp;
-    UINT64 maxLatency;
+    UINT32 tailTimestamp;
+    UINT32 maxLatency;
     UINT64 customData;
     UINT32 clockRate;
     BOOL started;
     BOOL firstFrameProcessed;
+    BOOL sequenceNumberOverflowState;
+    BOOL timestampOverFlowState;
     PHashTable pPkgBufferHashTable;
 } JitterBuffer, *PJitterBuffer;
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -367,7 +367,6 @@ STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex,
     } else {
         CHK(FALSE, retStatus);
     }
-    // TODO: handle multi-packet frames
     CHK(pPacket != NULL, STATUS_NULL_ARG);
     MUTEX_LOCK(pTransceiver->statsLock);
     // https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferdelay

--- a/tst/JitterBufferFunctionalityTest.cpp
+++ b/tst/JitterBufferFunctionalityTest.cpp
@@ -15,10 +15,10 @@ TEST_F(JitterBufferFunctionalityTest, continousPacketsComeInOrder)
     UINT32 i;
     UINT32 pktCount = 5;
     UINT32 startingSequenceNumber = 0;
-
-    initializeJitterBuffer(3, 0, pktCount);
     srand(time(0));
     startingSequenceNumber = rand()%UINT16_MAX;
+
+    initializeJitterBuffer(3, 0, pktCount);
 
     // First frame "1" at timestamp 100 - rtp packet #0
     mPRtpPackets[0]->payloadLength = 1;
@@ -1137,6 +1137,137 @@ TEST_F(JitterBufferFunctionalityTest, timestampOverflowTest)
 
 TEST_F(JitterBufferFunctionalityTest, timestampUnderflowTest)
 {
+    UINT32 i;
+    UINT32 pktCount = 8;
+    UINT32 startingSequenceNumber = 0;
+    UINT32 missingSequenceNumber = 0;
+    UINT32 firstSequenceNumber = 0;
+    srand(time(0));
+    startingSequenceNumber = rand()%UINT16_MAX;
+    firstSequenceNumber = startingSequenceNumber - 1;
+
+    initializeJitterBuffer(5, 0, pktCount);
+
+    // Second frame "1234" at timestamp 0 -- first frame comes later
+    // The "4" will come late
+    mPRtpPackets[0]->payloadLength = 1;
+    mPRtpPackets[0]->payload = (PBYTE) MEMALLOC(mPRtpPackets[0]->payloadLength + 1);
+    mPRtpPackets[0]->payload[0] = 1;
+    mPRtpPackets[0]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[0]->header.timestamp = 0;
+    mPRtpPackets[0]->header.sequenceNumber = startingSequenceNumber++;
+
+    mPRtpPackets[1]->payloadLength = 1;
+    mPRtpPackets[1]->payload = (PBYTE) MEMALLOC(mPRtpPackets[1]->payloadLength + 1);
+    mPRtpPackets[1]->payload[0] = 2;
+    mPRtpPackets[1]->payload[1] = 0;
+    mPRtpPackets[1]->header.timestamp = 0;
+    mPRtpPackets[1]->header.sequenceNumber = startingSequenceNumber++;
+
+    mPRtpPackets[2]->payloadLength = 1;
+    mPRtpPackets[2]->payload = (PBYTE) MEMALLOC(mPRtpPackets[2]->payloadLength + 1);
+    mPRtpPackets[2]->payload[0] = 3;
+    mPRtpPackets[2]->payload[1] = 0;
+    mPRtpPackets[2]->header.timestamp = 0;
+    mPRtpPackets[2]->header.sequenceNumber = startingSequenceNumber++;
+
+    //sequence number of 4th packet of this frame
+    missingSequenceNumber = startingSequenceNumber++;
+
+    // Expected to get frame "1234"
+    mPExpectedFrameArr[1] = (PBYTE) MEMALLOC(4);
+    mPExpectedFrameArr[1][0] = 1;
+    mPExpectedFrameArr[1][1] = 2;
+    mPExpectedFrameArr[1][2] = 3;
+    mPExpectedFrameArr[1][3] = 4;
+    mExpectedFrameSizeArr[1] = 4;
+
+    // Third frame "2" at timestamp 300
+    mPRtpPackets[3]->payloadLength = 1;
+    mPRtpPackets[3]->payload = (PBYTE) MEMALLOC(mPRtpPackets[3]->payloadLength + 1);
+    mPRtpPackets[3]->payload[0] = 2;
+    mPRtpPackets[3]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[3]->header.timestamp = 300;
+    mPRtpPackets[3]->header.sequenceNumber = startingSequenceNumber++;
+
+    // Expected to get frame "2"
+    mPExpectedFrameArr[2] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[2][0] = 2;
+    mExpectedFrameSizeArr[2] = 1;
+
+    // Fourth frame "3" at timestamp 600
+    mPRtpPackets[4]->payloadLength = 1;
+    mPRtpPackets[4]->payload = (PBYTE) MEMALLOC(mPRtpPackets[4]->payloadLength + 1);
+    mPRtpPackets[4]->payload[0] = 3;
+    mPRtpPackets[4]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[4]->header.timestamp = 600;
+    mPRtpPackets[4]->header.sequenceNumber = startingSequenceNumber++;
+
+    // Expected to get frame "3" at close
+    mPExpectedFrameArr[3] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[3][0] = 3;
+    mExpectedFrameSizeArr[3] = 1;
+
+    // Fifth frame "4" at timestamp 400 - rtp packet #1
+    mPRtpPackets[5]->payloadLength = 1;
+    mPRtpPackets[5]->payload = (PBYTE) MEMALLOC(mPRtpPackets[5]->payloadLength + 1);
+    mPRtpPackets[5]->payload[0] = 4;
+    mPRtpPackets[5]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[5]->header.timestamp = 900;
+    mPRtpPackets[5]->header.sequenceNumber = startingSequenceNumber++;
+
+    // Expected to get frame "4" at close
+    mPExpectedFrameArr[4] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[4][0] = 4;
+    mExpectedFrameSizeArr[4] = 1;
+
+    // Actual first frame, underflow timestamp
+    mPRtpPackets[6]->payloadLength = 1;
+    mPRtpPackets[6]->payload = (PBYTE) MEMALLOC(mPRtpPackets[6]->payloadLength + 1);
+    mPRtpPackets[6]->payload[0] = 4;
+    mPRtpPackets[6]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[6]->header.timestamp = MAX_RTP_TIMESTAMP - 300;
+    mPRtpPackets[6]->header.sequenceNumber = firstSequenceNumber;
+
+    // Expected to get frame "4" at close
+    mPExpectedFrameArr[0] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[0][0] = 4;
+    mExpectedFrameSizeArr[0] = 1;
+
+    // Missing 4th packet in 2nd frame
+    mPRtpPackets[7]->payloadLength = 1;
+    mPRtpPackets[7]->payload = (PBYTE) MEMALLOC(mPRtpPackets[7]->payloadLength + 1);
+    mPRtpPackets[7]->payload[0] = 4;
+    mPRtpPackets[7]->payload[1] = 0; 
+    mPRtpPackets[7]->header.timestamp = 0;
+    mPRtpPackets[7]->header.sequenceNumber = missingSequenceNumber;
+
+    setPayloadToFree();
+
+    for (i = 0; i < pktCount; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, jitterBufferPush(mJitterBuffer, mPRtpPackets[i], nullptr));
+        switch (i) {
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+                EXPECT_EQ(0, mReadyFrameIndex);
+                break;
+            case 6:
+                EXPECT_EQ(1, mReadyFrameIndex);
+                break;
+            case 7:
+                EXPECT_EQ(4, mReadyFrameIndex);
+                break;
+            default:
+                ASSERT_TRUE(FALSE);
+        }
+        EXPECT_EQ(0, mDroppedFrameIndex);
+    }
+
+    clearJitterBufferForTest();
 }
 
 TEST_F(JitterBufferFunctionalityTest, SequenceNumberOverflowTest)
@@ -1248,9 +1379,249 @@ TEST_F(JitterBufferFunctionalityTest, SequenceNumberOverflowTest)
 
 TEST_F(JitterBufferFunctionalityTest, SequenceNumberUnderflowTest)
 {
+    UINT32 i;
+    UINT32 pktCount = 8;
+    UINT32 startingSequenceNumber = 0;
+    UINT32 missingSequenceNumber = 0;
+    UINT32 firstSequenceNumber = MAX_RTP_SEQUENCE_NUM-2;
+
+    srand(time(0));
+    UINT32 startingTimestamp = rand()%UINT32_MAX;
+
+    initializeJitterBuffer(5, 0, pktCount);
+
+    // Fourth frame "1234", first frame comes later
+    // The "4" will come late
+    mPRtpPackets[0]->payloadLength = 1;
+    mPRtpPackets[0]->payload = (PBYTE) MEMALLOC(mPRtpPackets[0]->payloadLength + 1);
+    mPRtpPackets[0]->payload[0] = 1;
+    mPRtpPackets[0]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[0]->header.timestamp = startingTimestamp + 300;
+    mPRtpPackets[0]->header.sequenceNumber = startingSequenceNumber++;
+
+    mPRtpPackets[1]->payloadLength = 1;
+    mPRtpPackets[1]->payload = (PBYTE) MEMALLOC(mPRtpPackets[1]->payloadLength + 1);
+    mPRtpPackets[1]->payload[0] = 2;
+    mPRtpPackets[1]->payload[1] = 0;
+    mPRtpPackets[1]->header.timestamp = startingTimestamp + 300;
+    mPRtpPackets[1]->header.sequenceNumber = startingSequenceNumber++;
+
+    mPRtpPackets[2]->payloadLength = 1;
+    mPRtpPackets[2]->payload = (PBYTE) MEMALLOC(mPRtpPackets[2]->payloadLength + 1);
+    mPRtpPackets[2]->payload[0] = 3;
+    mPRtpPackets[2]->payload[1] = 0;
+    mPRtpPackets[2]->header.timestamp = startingTimestamp + 300;
+    mPRtpPackets[2]->header.sequenceNumber = startingSequenceNumber++;
+
+    //sequence number of 4th packet of this frame
+    missingSequenceNumber = startingSequenceNumber++;
+
+    // Expected to get frame "1234"
+    mPExpectedFrameArr[3] = (PBYTE) MEMALLOC(4);
+    mPExpectedFrameArr[3][0] = 1;
+    mPExpectedFrameArr[3][1] = 2;
+    mPExpectedFrameArr[3][2] = 3;
+    mPExpectedFrameArr[3][3] = 4;
+    mExpectedFrameSizeArr[3] = 4;
+
+    // First frame "2" at timestamp 300
+    mPRtpPackets[3]->payloadLength = 1;
+    mPRtpPackets[3]->payload = (PBYTE) MEMALLOC(mPRtpPackets[3]->payloadLength + 1);
+    mPRtpPackets[3]->payload[0] = 2;
+    mPRtpPackets[3]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[3]->header.timestamp = startingTimestamp;
+    mPRtpPackets[3]->header.sequenceNumber = firstSequenceNumber++;
+
+    // Expected to get frame "2"
+    mPExpectedFrameArr[0] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[0][0] = 2;
+    mExpectedFrameSizeArr[0] = 1;
+
+    // Second frame "3" at timestamp 600
+    mPRtpPackets[4]->payloadLength = 1;
+    mPRtpPackets[4]->payload = (PBYTE) MEMALLOC(mPRtpPackets[4]->payloadLength + 1);
+    mPRtpPackets[4]->payload[0] = 3;
+    mPRtpPackets[4]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[4]->header.timestamp = startingTimestamp+100;
+    mPRtpPackets[4]->header.sequenceNumber = firstSequenceNumber++;
+
+    // Expected to get frame "3" at close
+    mPExpectedFrameArr[1] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[1][0] = 3;
+    mExpectedFrameSizeArr[1] = 1;
+
+    // Third frame "4" 
+    mPRtpPackets[5]->payloadLength = 1;
+    mPRtpPackets[5]->payload = (PBYTE) MEMALLOC(mPRtpPackets[5]->payloadLength + 1);
+    mPRtpPackets[5]->payload[0] = 4;
+    mPRtpPackets[5]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[5]->header.timestamp = startingTimestamp+200;
+    mPRtpPackets[5]->header.sequenceNumber = firstSequenceNumber++;
+
+    // Expected to get frame "4" at close
+    mPExpectedFrameArr[2] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[2][0] = 4;
+    mExpectedFrameSizeArr[2] = 1;
+
+    // Fifth frame
+    mPRtpPackets[6]->payloadLength = 1;
+    mPRtpPackets[6]->payload = (PBYTE) MEMALLOC(mPRtpPackets[6]->payloadLength + 1);
+    mPRtpPackets[6]->payload[0] = 4;
+    mPRtpPackets[6]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[6]->header.timestamp = startingTimestamp+400;
+    mPRtpPackets[6]->header.sequenceNumber = startingSequenceNumber++;
+
+    // Expected to get frame "4" at close
+    mPExpectedFrameArr[4] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[4][0] = 4;
+    mExpectedFrameSizeArr[4] = 1;
+
+    // Missing 4th packet in 4th frame
+    mPRtpPackets[7]->payloadLength = 1;
+    mPRtpPackets[7]->payload = (PBYTE) MEMALLOC(mPRtpPackets[7]->payloadLength + 1);
+    mPRtpPackets[7]->payload[0] = 4;
+    mPRtpPackets[7]->payload[1] = 0; 
+    mPRtpPackets[7]->header.timestamp = startingTimestamp+300;
+    mPRtpPackets[7]->header.sequenceNumber = missingSequenceNumber;
+
+    setPayloadToFree();
+
+    for (i = 0; i < pktCount; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, jitterBufferPush(mJitterBuffer, mPRtpPackets[i], nullptr));
+        switch (i) {
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+                EXPECT_EQ(0, mReadyFrameIndex);
+                break;
+            case 4:
+                EXPECT_EQ(1, mReadyFrameIndex);
+                break;
+            case 5:
+            case 6:
+                EXPECT_EQ(3, mReadyFrameIndex);
+                break;
+            case 7:
+                EXPECT_EQ(4, mReadyFrameIndex);
+                break;
+            default:
+                ASSERT_TRUE(FALSE);
+        }
+        EXPECT_EQ(0, mDroppedFrameIndex);
+    }
+
+    clearJitterBufferForTest();
 }
 
 TEST_F(JitterBufferFunctionalityTest, DoubleOverflowTest)
+{
+    UINT32 i;
+    UINT32 pktCount = 7;
+    initializeJitterBuffer(4, 0, pktCount);
+
+    // First frame "1" at timestamp 100 - rtp packet #65534
+    mPRtpPackets[0]->payloadLength = 1;
+    mPRtpPackets[0]->payload = (PBYTE) MEMALLOC(mPRtpPackets[0]->payloadLength + 1);
+    mPRtpPackets[0]->payload[0] = 1;
+    mPRtpPackets[0]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[0]->header.timestamp = MAX_RTP_TIMESTAMP - 500;
+    mPRtpPackets[0]->header.sequenceNumber = 65534;
+
+    mPRtpPackets[1]->payloadLength = 1;
+    mPRtpPackets[1]->payload = (PBYTE) MEMALLOC(mPRtpPackets[1]->payloadLength + 1);
+    mPRtpPackets[1]->payload[0] = 2;
+    mPRtpPackets[1]->payload[1] = 0;
+    mPRtpPackets[1]->header.timestamp = MAX_RTP_TIMESTAMP - 500;
+    mPRtpPackets[1]->header.sequenceNumber = 65535;
+
+    mPRtpPackets[2]->payloadLength = 1;
+    mPRtpPackets[2]->payload = (PBYTE) MEMALLOC(mPRtpPackets[2]->payloadLength + 1);
+    mPRtpPackets[2]->payload[0] = 3;
+    mPRtpPackets[2]->payload[1] = 0;
+    mPRtpPackets[2]->header.timestamp = MAX_RTP_TIMESTAMP - 500;
+    mPRtpPackets[2]->header.sequenceNumber = 0;
+
+    // Expected to get frame "1234"
+    mPExpectedFrameArr[0] = (PBYTE) MEMALLOC(4);
+    mPExpectedFrameArr[0][0] = 1;
+    mPExpectedFrameArr[0][1] = 2;
+    mPExpectedFrameArr[0][2] = 3;
+    mPExpectedFrameArr[0][3] = 4;
+    mExpectedFrameSizeArr[0] = 4;
+
+    // Second frame "2" at timestamp 200 - rtp packet #65535
+    mPRtpPackets[3]->payloadLength = 1;
+    mPRtpPackets[3]->payload = (PBYTE) MEMALLOC(mPRtpPackets[3]->payloadLength + 1);
+    mPRtpPackets[3]->payload[0] = 2;
+    mPRtpPackets[3]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[3]->header.timestamp = MAX_RTP_TIMESTAMP - 100;
+    mPRtpPackets[3]->header.sequenceNumber = 2;
+
+    // Expected to get frame "2"
+    mPExpectedFrameArr[1] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[1][0] = 2;
+    mExpectedFrameSizeArr[1] = 1;
+
+    // Third frame "3" at timestamp 300 - rtp packet #0
+    mPRtpPackets[4]->payloadLength = 1;
+    mPRtpPackets[4]->payload = (PBYTE) MEMALLOC(mPRtpPackets[4]->payloadLength + 1);
+    mPRtpPackets[4]->payload[0] = 3;
+    mPRtpPackets[4]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[4]->header.timestamp = 300;
+    mPRtpPackets[4]->header.sequenceNumber = 3;
+
+    // Expected to get frame "3" at close
+    mPExpectedFrameArr[2] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[2][0] = 3;
+    mExpectedFrameSizeArr[2] = 1;
+
+    // Third frame "4" at timestamp 400 - rtp packet #1
+    mPRtpPackets[5]->payloadLength = 1;
+    mPRtpPackets[5]->payload = (PBYTE) MEMALLOC(mPRtpPackets[5]->payloadLength + 1);
+    mPRtpPackets[5]->payload[0] = 4;
+    mPRtpPackets[5]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[5]->header.timestamp = 600;
+    mPRtpPackets[5]->header.sequenceNumber = 4;
+
+    // Expected to get frame "4" at close
+    mPExpectedFrameArr[3] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[3][0] = 4;
+    mExpectedFrameSizeArr[3] = 1;
+
+    mPRtpPackets[6]->payloadLength = 1;
+    mPRtpPackets[6]->payload = (PBYTE) MEMALLOC(mPRtpPackets[6]->payloadLength + 1);
+    mPRtpPackets[6]->payload[0] = 4;
+    mPRtpPackets[6]->payload[1] = 0; // First packet of a frame
+    mPRtpPackets[6]->header.timestamp = MAX_RTP_TIMESTAMP - 500;
+    mPRtpPackets[6]->header.sequenceNumber = 1;
+
+    setPayloadToFree();
+
+    for (i = 0; i < pktCount; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, jitterBufferPush(mJitterBuffer, mPRtpPackets[i], nullptr));
+        switch (i) {
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+                EXPECT_EQ(0, mReadyFrameIndex);
+                break;
+            case 6:
+                EXPECT_EQ(3, mReadyFrameIndex);
+                break;
+            default:
+                ASSERT_TRUE(FALSE);
+        }
+        EXPECT_EQ(0, mDroppedFrameIndex);
+    }
+
+    clearJitterBufferForTest();
+}
+
+TEST_F(JitterBufferFunctionalityTest, LongRunningWithDroppedPacketsTest)
 {
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Added tracking of tail timestamp of the buffer
2. Added overflow state tracking for when tail or head wrap around the MAX_UINT16 or MAX_UINT32 for the respective bit counts
3. Added considerations for timestamp overflow & underflow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
