### PR TITLE
update transactionId for SrflxCandidateRequest

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -740,7 +740,7 @@ typedef enum {
     ICE_TRANSPORT_POLICY_RELAY = 1, //!< The ICE Agent uses only media relay candidates such as candidates
                                     //!< passing through a TURN server
 
-    ICE_TRANSPORT_POLICY_ALL = 2, //!< The ICE Agent can use any type of candidate when this value is specified.
+    ICE_TRANSPORT_POLICY_ALL = 2,   //!< The ICE Agent can use any type of candidate when this value is specified.
 } ICE_TRANSPORT_POLICY;
 
 /**
@@ -838,7 +838,7 @@ typedef enum {
  * @brief Type of caching implementation to use with the signaling client
  */
 typedef enum {
-    SIGNALING_API_CALL_CACHE_TYPE_NONE, //!< No caching. The calls to the backend will be made for every API.
+    SIGNALING_API_CALL_CACHE_TYPE_NONE,                 //!< No caching. The calls to the backend will be made for every API.
 
     SIGNALING_API_CALL_CACHE_TYPE_DESCRIBE_GETENDPOINT, //!< Cache DeleteSignalingChannel and GetSignalingChannelEndpoint
                                                         //!< backend API calls.
@@ -1055,18 +1055,18 @@ typedef struct {
  *  issues that we have today.
  */
 typedef struct {
-    UINT16 maximumTransmissionUnit; //!< Controls the size of the largest packet the WebRTC SDK will send
-                                    //!< Some networks may drop packets if they exceed a certain size, and is useful in those conditions.
-                                    //!< A smaller MTU will incur higher bandwidth usage however since more packets will be generated with
-                                    //!< smaller payloads. If unset DEFAULT_MTU_SIZE will be used
+    UINT16 maximumTransmissionUnit;           //!< Controls the size of the largest packet the WebRTC SDK will send
+                                              //!< Some networks may drop packets if they exceed a certain size, and is useful in those conditions.
+                                              //!< A smaller MTU will incur higher bandwidth usage however since more packets will be generated with
+                                              //!< smaller payloads. If unset DEFAULT_MTU_SIZE will be used
 
     UINT32 iceLocalCandidateGatheringTimeout; //!< Maximum time ice will wait for gathering STUN and RELAY candidates. Once
                                               //!< it's reached, ice will proceed with whatever candidate it current has. Use default value if 0.
 
-    UINT32 iceConnectionCheckTimeout; //!< Maximum time allowed waiting for at least one ice candidate pair to receive
-                                      //!< binding response from the peer. Use default value if 0.
+    UINT32 iceConnectionCheckTimeout;         //!< Maximum time allowed waiting for at least one ice candidate pair to receive
+                                              //!< binding response from the peer. Use default value if 0.
 
-    UINT32 iceCandidateNominationTimeout; //!< If client is ice controlling, this is the timeout for receiving bind response of requests that has
+    UINT32 iceCandidateNominationTimeout;     //!< If client is ice controlling, this is the timeout for receiving bind response of requests that has
                                           //!< USE_CANDIDATE attribute. If client is ice controlled, this is the timeout for receiving binding request
                                           //!< that has USE_CANDIDATE attribute after connection check is done. Use default value if 0.
 
@@ -1077,17 +1077,17 @@ typedef struct {
                                     //!< A smaller amount of bits may result in less CPU usage on startup, but will cause a weaker certificate to be
                                     //!< generated If set to 0 the default GENERATED_CERTIFICATE_BITS will be used
 
-    BOOL generateRSACertificate; //!< GenerateRSACertificate controls if an ECDSA or RSA certificate is generated.
-                                 //!< By default we generate an ECDSA certificate but some platforms may not support them.
+    BOOL generateRSACertificate;    //!< GenerateRSACertificate controls if an ECDSA or RSA certificate is generated.
+                                    //!< By default we generate an ECDSA certificate but some platforms may not support them.
 
-    UINT32 sendBufSize; //!< Socket send buffer length. Item larger then this size will get dropped. Use system default if 0.
+    UINT32 sendBufSize;             //!< Socket send buffer length. Item larger then this size will get dropped. Use system default if 0.
 
-    UINT64 filterCustomData; //!< Custom Data that can be populated by the developer while developing filter function
+    UINT64 filterCustomData;        //!< Custom Data that can be populated by the developer while developing filter function
 
     IceSetInterfaceFilterFunc iceSetInterfaceFilterFunc; //!< Filter function callback to be set when the developer
                                                          //!< would like to whitelist/blacklist specific network interfaces
 
-    BOOL disableSenderSideBandwidthEstimation; //!< Disable TWCC feedback based sender bandwidth estimation, enabled by default.
+    BOOL disableSenderSideBandwidthEstimation;           //!< Disable TWCC feedback based sender bandwidth estimation, enabled by default.
                                                //!< You want to set this to TRUE if you are on a very stable connection and want to save 1.2MB of
                                                //!< memory
 } KvsRtcConfiguration, *PKvsRtcConfiguration;
@@ -1152,29 +1152,29 @@ typedef struct {
  * @brief Structure defining the basic signaling message
  */
 typedef struct {
-    UINT32 version; //!< Current version of the structure
+    UINT32 version;                                     //!< Current version of the structure
 
-    SIGNALING_MESSAGE_TYPE messageType; //!< Type of signaling message.
+    SIGNALING_MESSAGE_TYPE messageType;                 //!< Type of signaling message.
 
-    CHAR correlationId[MAX_CORRELATION_ID_LEN + 1]; //!< Correlation Id string
+    CHAR correlationId[MAX_CORRELATION_ID_LEN + 1];     //!< Correlation Id string
 
     CHAR peerClientId[MAX_SIGNALING_CLIENT_ID_LEN + 1]; //!< Sender client id
 
-    UINT32 payloadLen; //!< Optional payload length. If 0, the length will be calculated
+    UINT32 payloadLen;                                  //!< Optional payload length. If 0, the length will be calculated
 
-    CHAR payload[MAX_SIGNALING_MESSAGE_LEN + 1]; //!< Actual signaling message payload
+    CHAR payload[MAX_SIGNALING_MESSAGE_LEN + 1];        //!< Actual signaling message payload
 } SignalingMessage, *PSignalingMessage;
 
 /**
  * @brief Structure defining the signaling message to be received
  */
 typedef struct {
-    SignalingMessage signalingMessage; //!< The signaling message with details such as message type, correlation ID,
-                                       //!< peer client ID and payload
+    SignalingMessage signalingMessage;                 //!< The signaling message with details such as message type, correlation ID,
+                                                       //!< peer client ID and payload
 
-    SERVICE_CALL_RESULT statusCode; //!< Response status code
+    SERVICE_CALL_RESULT statusCode;                    //!< Response status code
 
-    CHAR errorType[MAX_ERROR_TYPE_STRING_LEN + 1]; //!< Error type of the signaling message
+    CHAR errorType[MAX_ERROR_TYPE_STRING_LEN + 1];     //!< Error type of the signaling message
 
     CHAR description[MAX_MESSAGE_DESCRIPTION_LEN + 1]; //!< Optional description of the message
 } ReceivedSignalingMessage, *PReceivedSignalingMessage;
@@ -1203,59 +1203,59 @@ typedef struct {
  * @brief Contains all signaling channel related information
  */
 typedef struct {
-    UINT32 version; //!< Version of the structure
+    UINT32 version;                              //!< Version of the structure
 
-    PCHAR pChannelName; //!< Name of the signaling channel name. Maximum length is defined by MAX_CHANNEL_NAME_LEN + 1
+    PCHAR pChannelName;                          //!< Name of the signaling channel name. Maximum length is defined by MAX_CHANNEL_NAME_LEN + 1
 
-    PCHAR pChannelArn; //!< Channel Amazon Resource Name (ARN). This is an optional parameter
-                       //!< Maximum length is defined by MAX_ARN_LEN+1
+    PCHAR pChannelArn;                           //!< Channel Amazon Resource Name (ARN). This is an optional parameter
+                                                 //!< Maximum length is defined by MAX_ARN_LEN+1
 
-    PCHAR pRegion; //!< AWS Region in which the channel is to be opened. Can be empty for default
-                   //!< Maximum length is defined by MAX_REGION_NAME_LEN+1
+    PCHAR pRegion;                               //!< AWS Region in which the channel is to be opened. Can be empty for default
+                                                 //!< Maximum length is defined by MAX_REGION_NAME_LEN+1
 
-    PCHAR pControlPlaneUrl; //!< Optional fully qualified control plane URL
-                            //!< Maximum length is defined by MAX_ARN_LEN+1
+    PCHAR pControlPlaneUrl;                      //!< Optional fully qualified control plane URL
+                                                 //!< Maximum length is defined by MAX_ARN_LEN+1
 
-    PCHAR pCertPath; //!< Optional certificate path. Maximum length is defined by MAX_PATH_LEN+1
+    PCHAR pCertPath;                             //!< Optional certificate path. Maximum length is defined by MAX_PATH_LEN+1
 
-    PCHAR pUserAgentPostfix; //!< Optional user agent post-fix. Maximum length is defined by
-                             //!< MAX_CUSTOM_USER_AGENT_NAME_POSTFIX_LEN+1
+    PCHAR pUserAgentPostfix;                     //!< Optional user agent post-fix. Maximum length is defined by
+                                                 //!< MAX_CUSTOM_USER_AGENT_NAME_POSTFIX_LEN+1
 
-    PCHAR pCustomUserAgent; //!< Optional custom user agent name. Maximum length is defined by MAX_USER_AGENT_LEN+1
+    PCHAR pCustomUserAgent;                      //!< Optional custom user agent name. Maximum length is defined by MAX_USER_AGENT_LEN+1
 
-    PCHAR pUserAgent; //!< Combined user agent.  Maximum length is defined by MAX_USER_AGENT_LEN+1
+    PCHAR pUserAgent;                            //!< Combined user agent.  Maximum length is defined by MAX_USER_AGENT_LEN+1
 
-    PCHAR pKmsKeyId; //!< Optional KMS key id ARN. Maximum length is defined by MAX_ARN_LEN+1
+    PCHAR pKmsKeyId;                             //!< Optional KMS key id ARN. Maximum length is defined by MAX_ARN_LEN+1
 
-    SIGNALING_CHANNEL_TYPE channelType; //!< Channel type when creating.
+    SIGNALING_CHANNEL_TYPE channelType;          //!< Channel type when creating.
 
     SIGNALING_CHANNEL_ROLE_TYPE channelRoleType; //!< Channel role type for the endpoint - master/viewer
 
-    BOOL reserved; //!< Reserved field for compatibility
+    BOOL reserved;                               //!< Reserved field for compatibility
 
-    UINT64 cachingPeriod; //!< Endpoint caching TTL.
-                          //!< For no caching policy this param will be ignored.
-                          //!< For caching policies the default value will be used
-                          //!< if this parameter is 0 (::SIGNALING_API_CALL_CACHE_TTL_SENTINEL_VALUE).
+    UINT64 cachingPeriod;                        //!< Endpoint caching TTL.
+                                                 //!< For no caching policy this param will be ignored.
+                                                 //!< For caching policies the default value will be used
+                                                 //!< if this parameter is 0 (::SIGNALING_API_CALL_CACHE_TTL_SENTINEL_VALUE).
 
-    BOOL retry; //!< Flag determines if a retry of the network calls is to be done on errors up to max retry times
+    BOOL retry;                                  //!< Flag determines if a retry of the network calls is to be done on errors up to max retry times
 
-    BOOL reconnect; //!< Flag determines if reconnection should be attempted on connection drop
+    BOOL reconnect;                              //!< Flag determines if reconnection should be attempted on connection drop
 
-    UINT64 messageTtl; //!< The message TTL. Must be in the range of 5ns and 120ns.
-                       //!< Specifying zero will default to 60ns
+    UINT64 messageTtl;                           //!< The message TTL. Must be in the range of 5ns and 120ns.
+                                                 //!< Specifying zero will default to 60ns
 
-    UINT32 tagCount; //!< Number of tags associated with the stream
+    UINT32 tagCount;                             //!< Number of tags associated with the stream
 
-    PTag pTags; //!< Stream tags array
+    PTag pTags;                                  //!< Stream tags array
 
     /* --- V1 members --- */
 
     SIGNALING_API_CALL_CACHE_TYPE cachingPolicy; //!< Backend API call caching policy
 
-    BOOL asyncIceServerConfig; //!< This parameter has no effect any longer. All ICE config retrieving
-                               //!< is done reactively when needed which will simplify the processing
-                               //!< and will help with issues on a small footprint platforms
+    BOOL asyncIceServerConfig;                   //!< This parameter has no effect any longer. All ICE config retrieving
+                                                 //!< is done reactively when needed which will simplify the processing
+                                                 //!< and will help with issues on a small footprint platforms
 
 } ChannelInfo, *PChannelInfo;
 

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -274,14 +274,14 @@ typedef struct {
     DOMString remoteCertificateId;               //!< For components where DTLS is negotiated, give remote certificate
     CHAR tlsVersion[MAX_TLS_VERSION_LENGTH + 1]; //!< For components where DTLS is negotiated, the TLS version agreed
     CHAR dtlsCipher[MAX_DTLS_CIPHER_LENGTH +
-                    1]; //!< Descriptive name of the cipher suite used for the DTLS transport.
+                    1];                          //!< Descriptive name of the cipher suite used for the DTLS transport.
                         //!< Acceptable values: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4
     CHAR srtpCipher[MAX_SRTP_CIPHER_LENGTH + 1]; //!< Descriptive name of the protection profile used for the SRTP transport
                                                  //!< Acceptable values: https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml
     CHAR tlsGroup[MAX_TLS_GROUP_LENGHTH +
-                  1];     //!< Descriptive name of the group used for the encryption
-                          //!< Acceptable values: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
-    RTC_ICE_ROLE iceRole; //!< Set to the current value of the "role" attribute of the underlying RTCDtlsTransport's "transport"
+                  1];                            //!< Descriptive name of the group used for the encryption
+                      //!< Acceptable values: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8
+    RTC_ICE_ROLE iceRole;                     //!< Set to the current value of the "role" attribute of the underlying RTCDtlsTransport's "transport"
     RTC_DTLS_TRANSPORT_STATE_STATS dtlsState; //!< Set to the current value of the "state" attribute of the underlying RTCDtlsTransport
     UINT64 packetsSent;                       //!< Total number of packets sent over the transport
     UINT64 packetsReceived;                   //!< Total number of packets received over the transport
@@ -461,7 +461,7 @@ typedef struct {
                                         //!< after a frame has been decoded. See totalInterFrameDelay for details on how to calculate the interframe
                                         //!< delay variance.
 
-    BOOL voiceActivityFlag; //!< TODO Only valid for audio. Whether the last RTP packet whose frame was delivered to the RTCRtpReceiver's
+    BOOL voiceActivityFlag;             //!< TODO Only valid for audio. Whether the last RTP packet whose frame was delivered to the RTCRtpReceiver's
                             //!< MediaStreamTrack for playout contained voice activity or not based on the presence of the V bit in the extension
                             //!< header, as defined in [RFC6464]. This is the stats-equivalent of RTCRtpSynchronizationSource.voiceActivityFlag in
                             //!< [[WEBRTC].

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1380,7 +1380,8 @@ STATUS iceAgentSendSrflxCandidateRequest(PIceAgent pIceAgent)
                     pIceServer = &(pIceAgent->iceServers[pCandidate->iceServerIndex]);
                     if (pIceServer->ipAddress.family == pCandidate->ipAddress.family) {
                         // update transactionId
-                        CHK_STATUS(iceUtilsGenerateTransactionId(pBindingRequest->header.transactionId, ARRAY_SIZE(pBindingRequest->header.transactionId)));
+                        CHK_STATUS(
+                            iceUtilsGenerateTransactionId(pBindingRequest->header.transactionId, ARRAY_SIZE(pBindingRequest->header.transactionId)));
 
                         transactionIdStoreInsert(pIceAgent->pStunBindingRequestTransactionIdStore, pBindingRequest->header.transactionId);
                         checkSum = COMPUTE_CRC32(pBindingRequest->header.transactionId, ARRAY_SIZE(pBindingRequest->header.transactionId));
@@ -2645,7 +2646,7 @@ STATUS iceAgentCheckPeerReflexiveCandidate(PIceAgent pIceAgent, PKvsIpAddress pI
     CHK_STATUS(doubleListGetNodeCount(pIceAgent->remoteCandidates, &candidateCount));
     CHK_WARN(candidateCount < KVS_ICE_MAX_REMOTE_CANDIDATE_COUNT, retStatus, "max remote candidate count exceeded"); // return early if limit exceeded
     CHK_STATUS(findCandidateWithIp(pIpAddress, pIceAgent->remoteCandidates, &pIceCandidate));
-    CHK(pIceCandidate == NULL, retStatus); // return early if duplicated
+    CHK(pIceCandidate == NULL, retStatus);                                                                           // return early if duplicated
     DLOGD("New remote peer reflexive candidate found");
 
     CHK((pIceCandidate = MEMCALLOC(1, SIZEOF(IceCandidate))) != NULL, STATUS_NOT_ENOUGH_MEMORY);

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1379,6 +1379,9 @@ STATUS iceAgentSendSrflxCandidateRequest(PIceAgent pIceAgent)
                 case ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE:
                     pIceServer = &(pIceAgent->iceServers[pCandidate->iceServerIndex]);
                     if (pIceServer->ipAddress.family == pCandidate->ipAddress.family) {
+                        // update transactionId
+                        CHK_STATUS(iceUtilsGenerateTransactionId(pBindingRequest->header.transactionId, ARRAY_SIZE(pBindingRequest->header.transactionId)));
+
                         transactionIdStoreInsert(pIceAgent->pStunBindingRequestTransactionIdStore, pBindingRequest->header.transactionId);
                         checkSum = COMPUTE_CRC32(pBindingRequest->header.transactionId, ARRAY_SIZE(pBindingRequest->header.transactionId));
                         CHK_STATUS(iceAgentSendStunPacket(pBindingRequest, NULL, 0, pIceAgent, pCandidate, &pIceServer->ipAddress));

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1018,7 +1018,7 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
             if (count == 4) {
                 codecs = attributeValue; // codecs = 111 63 103 104 9 0 8 106 105 13 110 112 113 126
             }
-            if (count > 3) { // look for codec values from payload types (111 63 103 104 9 0 8 106 105 13 110 112 113 126)
+            if (count > 3) {             // look for codec values from payload types (111 63 103 104 9 0 8 106 105 13 110 112 113 126)
                 if (STRNCMP(DEFAULT_PAYLOAD_MULAW_STR, attributeValue, tokenLen) == 0) {
                     supportCodec = TRUE;
                     rtcCodec = RTC_CODEC_MULAW;

--- a/src/source/Rtcp/RtcpPacket.h
+++ b/src/source/Rtcp/RtcpPacket.h
@@ -47,7 +47,7 @@ extern "C" {
 #define RTCP_FIRST_REPORT_DELAY (3 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
 typedef enum {
-    RTCP_PACKET_TYPE_FIR = 192, // https://tools.ietf.org/html/rfc2032#section-5.2.1
+    RTCP_PACKET_TYPE_FIR = 192,             // https://tools.ietf.org/html/rfc2032#section-5.2.1
     RTCP_PACKET_TYPE_SENDER_REPORT = 200,
     RTCP_PACKET_TYPE_RECEIVER_REPORT = 201, // https://tools.ietf.org/html/rfc3550#section-6.4.2
     RTCP_PACKET_TYPE_SOURCE_DESCRIPTION = 202,


### PR DESCRIPTION
*Issue #, if available:*
always appears 0x40100001 error when process STUN_PACKET_TYPE_BINDING_RESPONSE_SUCCESS packets

```
[W][0330 21:11:18.687][IceAgent.c:2480](MIRTC) Unable to fetch request Timestamp from the hash table. No update to totalRoundTripTime (error code: 0x40100001), stunBindingRequest
[E][0330 21:11:18.687][IceAgent.c:2603](MIRTC) operation returned status code: 0x40100001
[E][0330 21:11:18.688][IceAgent.c:2343](MIRTC) operation returned status code: 0x40100001
```


because all transactionId in binding request send from srflx candidate are the same.
See details in iceAgentSendSrflxCandidateRequest(line:1369)


*Description of changes:*
update transactionId for SrflxCandidateRequest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
