### PR TITLE
Fix compilation of OpenSSL 1.1.1t on Raspberry Pi 4B with 64-bit

### DIFF
--- a/CMake/Dependencies/libopenssl-CMakeLists.txt
+++ b/CMake/Dependencies/libopenssl-CMakeLists.txt
@@ -16,6 +16,22 @@ else()
     SET(OPENSSL_EXTRA ${OPENSSL_EXTRA} no-shared no-dso)
   endif()
 
+  # Raspberry pi 4 has a 64-bit ARM cpu, but the camera module is not
+  # currently supported with a 64-bit userland. So the default
+  # raspbian configuration is a 64-bit kernel with a 32-bit userland.
+  # This is not correctly identified by OpenSSL version 1.1.1t as used
+  # in the Amazon Kinesis Video Streams with WebRTC SDK. So in this
+  # case if the BUILD_OPENSSL_PLATFORM is not set, set it to
+  # linux-armv4, which will cause OpenSSL to select the correct
+  # assembly module for the 32-bit Raspberry Pi userland.
+
+  if (BUILD_OPENSSL_PLATFORM STREQUAL OFF)
+    execute_process(COMMAND bash -c "if [ $(uname -m) = aarch64 ] ; then file $(which file) | grep -q 32-bit; fi" RESULTS_VARIABLE USER32)
+    if (USER32 STREQUAL 0)
+      SET(BUILD_OPENSSL_PLATFORM "linux-armv4")
+    endif()
+  endif()
+
   if (DEFINED BUILD_OPENSSL_PLATFORM AND NOT BUILD_OPENSSL_PLATFORM STREQUAL OFF)
     SET(CONFIGURE_COMMAND ${CMAKE_CURRENT_BINARY_DIR}/build/src/project_libopenssl/Configure ${OPENSSL_EXTRA} no-async --prefix=${OPEN_SRC_INSTALL_PREFIX} --openssldir=${OPEN_SRC_INSTALL_PREFIX} ${BUILD_OPENSSL_PLATFORM} -Wno-nullability-completeness -Wno-expansion-to-defined)
   else()

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -182,7 +182,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                     gst_parse_launch("autovideosrc ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
                                      "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
                                      "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE emit-signals=TRUE "
-                                     "name=appsink-video autoaudiosrc ! "
+                                     "name=appsink-video alsasrc device=hw:3,0 ! "
                                      "queue leaky=2 max-size-buffers=400 ! audioconvert ! audioresample ! opusenc ! "
                                      "audio/x-opus,rate=48000,channels=2 ! appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
                                      &error);

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -182,7 +182,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                     gst_parse_launch("autovideosrc ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
                                      "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
                                      "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE emit-signals=TRUE "
-                                     "name=appsink-video alsasrc device=hw:3,0 ! "
+                                     "name=appsink-video autoaudiosrc ! "
                                      "queue leaky=2 max-size-buffers=400 ! audioconvert ! audioresample ! opusenc ! "
                                      "audio/x-opus,rate=48000,channels=2 ! appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
                                      &error);


### PR DESCRIPTION
Description of changes:

Raspberry pi 4B has a 64-bit ARM cpu, but the camera module is not currently supported with a 64-bit userland. So the default raspbian configuration is a 64-bit kernel with a 32-bit userland. This is not correctly identified by OpenSSL version 1.1.1t as used in the Amazon Kinesis Video Streams with WebRTC SDK. It results in an attempt to use 64-bit assembly opcodes in a 32-bit assembler. So in this case if the BUILD_OPENSSL_PLATFORM is not set, set it to linux-armv4, which will cause OpenSSL to select the correct assembly module for the 32-bit Raspberry Pi userland.

OpenSSL issue related to this: https://github.com/openssl/openssl/issues/20804

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
