### PR TITLE
RTSP with Ingestion Sample

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -77,14 +77,14 @@ if(GST_FOUND)
   target_link_libraries(kvsWebrtcClientMasterGstSample kvsWebrtcClient kvsWebrtcSignalingClient ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils websockets)
 
   add_executable(
-    kvsWebrtcClientMasterRtspSample
+    kvsWebRTCClientGstreamerStorageSession
     Common.c
-    kvsWebRTCClientMasterRtspSample.c
+    kvsWebRTCClientGstreamerStorageSession.c
   )
-  target_link_libraries(kvsWebrtcClientMasterRtspSample kvsWebrtcClient kvsWebrtcSignalingClient ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils websockets)
+  target_link_libraries(kvsWebRTCClientGstreamerStorageSession kvsWebrtcClient kvsWebrtcSignalingClient ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils websockets)
 
   install(TARGETS
-    kvsWebrtcClientMasterRtspSample
+    kvsWebRTCClientGstreamerStorageSession
     kvsWebrtcClientMasterGstSample
     RUNTIME DESTINATION bin
   )

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -76,7 +76,16 @@ if(GST_FOUND)
   )
   target_link_libraries(kvsWebrtcClientMasterGstSample kvsWebrtcClient kvsWebrtcSignalingClient ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils websockets)
 
-  install(TARGETS kvsWebrtcClientMasterGstSample
+  add_executable(
+    kvsWebrtcClientMasterRtspSample
+    Common.c
+    kvsWebRTCClientMasterRtspSample.c
+  )
+  target_link_libraries(kvsWebrtcClientMasterRtspSample kvsWebrtcClient kvsWebrtcSignalingClient ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils websockets)
+
+  install(TARGETS
+    kvsWebrtcClientMasterRtspSample
+    kvsWebrtcClientMasterGstSample
     RUNTIME DESTINATION bin
   )
 endif()

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -122,6 +122,8 @@ typedef struct {
     PStackQueue pregeneratedCertificates; // Max MAX_RTCCONFIGURATION_CERTIFICATES certificates
 
     UINT32 joinSessionTimerId;
+
+    PCHAR rtspUrl;
 } SampleConfiguration, *PSampleConfiguration;
 
 typedef struct {

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -40,6 +40,8 @@ extern "C" {
 #define SAMPLE_HASH_TABLE_BUCKET_COUNT  50
 #define SAMPLE_HASH_TABLE_BUCKET_LENGTH 2
 
+#define RTSP_PIPELINE_MAX_CHAR_COUNT 1000
+
 #define SAMPLE_PERIODIC_JOIN_SESSION        FALSE
 #define SAMPLE_PERIODIC_JOIN_SESSION_PERIOD (300 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
@@ -61,6 +63,12 @@ typedef enum {
     SAMPLE_STREAMING_AUDIO_VIDEO,
 } SampleStreamingMediaType;
 
+typedef enum {
+    TEST_SOURCE,
+    DEVICE_SOURCE,
+    RTSP_SOURCE,
+} SampleSourceType;
+
 typedef struct __SampleStreamingSession SampleStreamingSession;
 typedef struct __SampleStreamingSession* PSampleStreamingSession;
 
@@ -79,7 +87,7 @@ typedef struct {
     volatile ATOMIC_BOOL mediaThreadStarted;
     volatile ATOMIC_BOOL recreateSignalingClient;
     volatile ATOMIC_BOOL connected;
-    BOOL useTestSrc;
+    SampleSourceType srcType;
     ChannelInfo channelInfo;
     PCHAR pCaCertPath;
     PAwsCredentialProvider pCredentialProvider;

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -123,7 +123,7 @@ typedef struct {
 
     UINT32 joinSessionTimerId;
 
-    PCHAR rtspUrl;
+    PCHAR rtspUri;
 } SampleConfiguration, *PSampleConfiguration;
 
 typedef struct {

--- a/samples/kvsWebRTCClientGstreamerStorageSession.c
+++ b/samples/kvsWebRTCClientGstreamerStorageSession.c
@@ -150,7 +150,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                             pSampleConfiguration->rtspUri);
 
             if (stringOutcome > pipeLineBufferSize) {
-                printf("[KVS RTSP Master] ERROR: rtsp url entered exceeds maximum allowed length set by pipeLineBufferSize\n");
+                printf("[KVS RTSP Master] ERROR: rtsp uri entered exceeds maximum allowed length set by pipeLineBufferSize\n");
                 goto CleanUp;
             }
 
@@ -171,7 +171,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                             pSampleConfiguration->rtspUri);
 
             if (stringOutcome > pipeLineBufferSize) {
-                printf("[KVS RTSP Master] ERROR: rtsp url entered exceeds maximum allowed length set by pipeLineBufferSize\n");
+                printf("[KVS RTSP Master] ERROR: rtsp uri entered exceeds maximum allowed length set by pipeLineBufferSize\n");
                 goto CleanUp;
             }
 
@@ -381,8 +381,8 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc < 4) {
         printf("[KVS RTSP Master] ERROR: Not enough argument parameters.\n");
-        printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> rtsp://<rtsp url> audio-video\n"
-               "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> video-only\n");
+        printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> rtsp://<rtsp uri> audio-video\n"
+               "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp uri> video-only\n");
         goto CleanUp;
     }
 
@@ -396,8 +396,8 @@ INT32 main(INT32 argc, CHAR* argv[])
         printf("[KVS RTSP Master] Streaming audio and video\n");
     } else {
         printf("[KVS RTSP Master] ERROR Unrecognized streaming type.\n");
-        printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> rtsp://<rtsp url> audio-video\n"
-               "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> video-only\n");
+        printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> rtsp://<rtsp uri> audio-video\n"
+               "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp uri> video-only\n");
         goto CleanUp;
     }
 

--- a/samples/kvsWebRTCClientGstreamerStorageSession.c
+++ b/samples/kvsWebRTCClientGstreamerStorageSession.c
@@ -397,7 +397,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     } else {
         printf("[KVS RTSP Master] ERROR Unrecognized streaming type.\n");
         printf("[KVS RTSP Master] Usage: ./kvsWebRTCClientGstreamerStorageSession <channel name> rtsp://<rtsp uri> audio-video\n"
-               "or ./kvsWebRTCClientGstreamerStorageSession <channel name> <rtsp://<rtsp uri> video-only\n");
+               "or ./kvsWebRTCClientGstreamerStorageSession <channel name> <rtsp://<rtsp uri> video-only \n");
         goto CleanUp;
     }
 

--- a/samples/kvsWebRTCClientGstreamerStorageSession.c
+++ b/samples/kvsWebRTCClientGstreamerStorageSession.c
@@ -164,7 +164,9 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                         gst_parse_launch("videotestsrc is-live=TRUE ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
                                          "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
                                          "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE emit-signals=TRUE "
-                                         "name=appsink-video",
+                                         "name=appsink-video audiotestsrc is-live=TRUE wave=silence ! audioconvert ! "
+                                         "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
+                                         "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
                                          &error);
                     break;
                 }
@@ -172,7 +174,9 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                     pipeline = gst_parse_launch("autovideosrc ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
                                                 "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
                                                 "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE "
-                                                "emit-signals=TRUE name=appsink-video",
+                                                "emit-signals=TRUE name=appsink-video audiotestsrc is-live=TRUE wave=silence ! audioconvert ! "
+                                                "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
+                                                "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
                                                 &error);
                     break;
                 }
@@ -246,8 +250,6 @@ PVOID sendGstreamerAudioVideo(PVOID args)
             break;
         }
     }
-
-    pipeline = gst_parse_launch(rtspPipeLineBuffer, &error);
 
     appsinkVideo = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-video");
     appsinkAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-audio");

--- a/samples/kvsWebRTCClientGstreamerStorageSession.c
+++ b/samples/kvsWebRTCClientGstreamerStorageSession.c
@@ -147,7 +147,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                             "audiotestsrc is-live=TRUE wave=silence ! audioconvert ! "
                                             "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
                                             "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
-                                            pSampleConfiguration->rtspUrl);
+                                            pSampleConfiguration->rtspUri);
 
             if (stringOutcome > pipeLineBufferSize) {
                 printf("[KVS RTSP Master] ERROR: rtsp url entered exceeds maximum allowed length set by pipeLineBufferSize\n");
@@ -168,7 +168,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                             "src. ! audioconvert ! "
                                             "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
                                             "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
-                                            pSampleConfiguration->rtspUrl);
+                                            pSampleConfiguration->rtspUri);
 
             if (stringOutcome > pipeLineBufferSize) {
                 printf("[KVS RTSP Master] ERROR: rtsp url entered exceeds maximum allowed length set by pipeLineBufferSize\n");
@@ -386,7 +386,7 @@ INT32 main(INT32 argc, CHAR* argv[])
         goto CleanUp;
     }
 
-    pSampleConfiguration->rtspUrl = argv[2];
+    pSampleConfiguration->rtspUri = argv[2];
 
     if (STRCMP(argv[3], "video-only") == 0) {
         pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;

--- a/samples/kvsWebRTCClientGstreamerStorageSession.c
+++ b/samples/kvsWebRTCClientGstreamerStorageSession.c
@@ -130,7 +130,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
         goto CleanUp;
     }
 
-     /**
+    /**
      * Use x264enc as its available on mac, pi, ubuntu and windows
      * mac pipeline fails if resolution is not 720p
      *
@@ -183,18 +183,19 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                 case RTSP_SOURCE: {
                     // This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases.
                     UINT16 stringOutcome = snprintf(rtspPipeLineBuffer, RTSP_PIPELINE_MAX_CHAR_COUNT,
-                                            "uridecodebin uri=%s ! "
-                                            "videoconvert ! "
-                                            "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
-                                            "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! queue ! "
-                                            "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
-                                            "audiotestsrc is-live=TRUE wave=silence ! audioconvert ! "
-                                            "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
-                                            "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
-                                            pSampleConfiguration->rtspUri);
+                                                    "uridecodebin uri=%s ! "
+                                                    "videoconvert ! "
+                                                    "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                                                    "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! queue ! "
+                                                    "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
+                                                    "audiotestsrc is-live=TRUE wave=silence ! audioconvert ! "
+                                                    "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
+                                                    "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
+                                                    pSampleConfiguration->rtspUri);
 
                     if (stringOutcome > RTSP_PIPELINE_MAX_CHAR_COUNT) {
-                        printf("[KVS Gst Storage Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
+                        printf(
+                            "[KVS Gst Storage Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
                         goto CleanUp;
                     }
                     pipeline = gst_parse_launch(rtspPipeLineBuffer, &error);
@@ -230,17 +231,18 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                 case RTSP_SOURCE: {
                     // NOTE: This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases.
                     UINT16 stringOutcome = snprintf(rtspPipeLineBuffer, RTSP_PIPELINE_MAX_CHAR_COUNT,
-                                            "uridecodebin uri=%s name=src ! videoconvert ! "
-                                            "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
-                                            "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! queue ! "
-                                            "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
-                                            "src. ! audioconvert ! "
-                                            "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
-                                            "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
-                                            pSampleConfiguration->rtspUri);
+                                                    "uridecodebin uri=%s name=src ! videoconvert ! "
+                                                    "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                                                    "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! queue ! "
+                                                    "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
+                                                    "src. ! audioconvert ! "
+                                                    "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
+                                                    "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
+                                                    pSampleConfiguration->rtspUri);
 
                     if (stringOutcome > RTSP_PIPELINE_MAX_CHAR_COUNT) {
-                        printf("[KVS Gst Storage Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
+                        printf(
+                            "[KVS Gst Storage Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
                         goto CleanUp;
                     }
                     pipeline = gst_parse_launch(rtspPipeLineBuffer, &error);
@@ -255,7 +257,8 @@ PVOID sendGstreamerAudioVideo(PVOID args)
     appsinkAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-audio");
 
     if (!(appsinkVideo != NULL || appsinkAudio != NULL)) {
-        printf("[KVS Gst Storage Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n", STATUS_INTERNAL_ERROR);
+        printf("[KVS Gst Storage Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n",
+               STATUS_INTERNAL_ERROR);
         goto CleanUp;
     }
 
@@ -447,7 +450,6 @@ INT32 main(INT32 argc, CHAR* argv[])
     gst_init(&argc, &argv);
     printf("[KVS Gst Storage Master] Finished initializing GStreamer\n");
 
-
     if (argc > 2) {
         if (STRCMP(argv[2], "video-only") == 0) {
             pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
@@ -486,7 +488,6 @@ INT32 main(INT32 argc, CHAR* argv[])
     } else {
         printf("[KVS Gst Storage Master] Using device source in GStreamer\n");
     }
-
 
     // Initialize KVS WebRTC. This must be done before anything else, and must only be done once.
     retStatus = initKvsWebRtc();

--- a/samples/kvsWebRTCClientGstreamerStorageSession.c
+++ b/samples/kvsWebRTCClientGstreamerStorageSession.c
@@ -381,8 +381,8 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc < 4) {
         printf("[KVS RTSP Master] ERROR: Not enough argument parameters.\n");
-        printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> rtsp://<rtsp uri> audio-video\n"
-               "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp uri> video-only\n");
+        printf("[KVS RTSP Master] Usage: ./kvsWebRTCClientGstreamerStorageSession <channel name> rtsp://<rtsp uri> audio-video\n"
+               "or ./kvsWebRTCClientGstreamerStorageSession <channel name> <rtsp://<rtsp uri> video-only\n");
         goto CleanUp;
     }
 
@@ -396,8 +396,8 @@ INT32 main(INT32 argc, CHAR* argv[])
         printf("[KVS RTSP Master] Streaming audio and video\n");
     } else {
         printf("[KVS RTSP Master] ERROR Unrecognized streaming type.\n");
-        printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> rtsp://<rtsp uri> audio-video\n"
-               "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp uri> video-only\n");
+        printf("[KVS RTSP Master] Usage: ./kvsWebRTCClientGstreamerStorageSession <channel name> rtsp://<rtsp uri> audio-video\n"
+               "or ./kvsWebRTCClientGstreamerStorageSession <channel name> <rtsp://<rtsp uri> video-only\n");
         goto CleanUp;
     }
 

--- a/samples/kvsWebRTCClientMasterGstreamerSample.c
+++ b/samples/kvsWebRTCClientMasterGstreamerSample.c
@@ -399,7 +399,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     if (argc > 3) {
         if (STRCMP(argv[3], "testsrc") == 0) {
             printf("[KVS GStreamer Master] Using test source in GStreamer\n");
-            pSampleConfiguration->useTestSrc = FALSE;
+            pSampleConfiguration->useTestSrc = TRUE;
         }
     }
 

--- a/samples/kvsWebRTCClientMasterRtspSample.c
+++ b/samples/kvsWebRTCClientMasterRtspSample.c
@@ -123,13 +123,13 @@ PVOID sendGstreamerAudioVideo(PVOID args)
     GError* error = NULL;
     PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) args;
 
+    UINT16 pipeLineBufferSize = 1000;
+    CHAR pipeLineBuffer[pipeLineBufferSize];
+
     if (pSampleConfiguration == NULL) {
         printf("[KVS RTSP Master] sendGstreamerAudioVideo(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
         goto CleanUp;
     }
-
-    UINT16 pipeLineBufferSize = 1000;
-    CHAR pipeLineBuffer[pipeLineBufferSize];
 
     switch (pSampleConfiguration->mediaType) {
         case SAMPLE_STREAMING_VIDEO_ONLY: {
@@ -137,7 +137,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
 
             // NOTE: For video-only, audio is added to the stream to be compatible with media-server ingestion.
             // This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases and
-            // works fine even if the rtsp steam does have audio coming in with it - that audio will be ignored.
+            // works fine even if the rtsp steam does have audio coming in with it - the audio will be ignored.
             UINT16 stringOutcome = snprintf(pipeLineBuffer, pipeLineBufferSize,
                                             "uridecodebin uri=%s ! "
                                             "videoconvert ! "
@@ -150,19 +150,14 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                             pSampleConfiguration->rtspUrl);
 
             if (stringOutcome > pipeLineBufferSize) {
-                printf("[KVS RTSP Master] ERROR: rtsp url entered exceeds maximum allowed length set by pipeLineBufferSize\n")
+                printf("[KVS RTSP Master] ERROR: rtsp url entered exceeds maximum allowed length set by pipeLineBufferSize\n");
                 goto CleanUp;
             }
-
-            pipeline = gst_parse_launch(pipeLineBuffer, &error);
 
             break;
         }
         case SAMPLE_STREAMING_AUDIO_VIDEO: {
             printf("[KVS RTSP Master] Streaming from RTSP source with audio and video\n");
-
-            UINT16 pipeLineBufferSize = 1000;
-            CHAR pipeLineBuffer[pipeLineBufferSize];
 
             // NOTE: This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases.
             UINT16 stringOutcome = snprintf(pipeLineBuffer, pipeLineBufferSize,
@@ -176,15 +171,15 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                             pSampleConfiguration->rtspUrl);
 
             if (stringOutcome > pipeLineBufferSize) {
-                printf("[KVS RTSP Master] ERROR: rtsp url entered exceeds maximum allowed length set by pipeLineBufferSize\n")
+                printf("[KVS RTSP Master] ERROR: rtsp url entered exceeds maximum allowed length set by pipeLineBufferSize\n");
                 goto CleanUp;
             }
-
-            pipeline = gst_parse_launch(pipeLineBuffer, &error);
 
             break;
         }
     }
+
+    pipeline = gst_parse_launch(pipeLineBuffer, &error);
 
     appsinkVideo = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-video");
     appsinkAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-audio");

--- a/samples/kvsWebRTCClientMasterRtspSample.c
+++ b/samples/kvsWebRTCClientMasterRtspSample.c
@@ -137,7 +137,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
 
             // NOTE: For video-only, audio is added to the stream to be compatible with media-server ingestion.
             // This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases and
-            // works fine even if the rtsp steam does have audio coming in with it - the audio will be ignored.
+            // works fine even if the rtsp stream does have audio coming in with it - the audio will be ignored.
             UINT16 stringOutcome = snprintf(pipeLineBuffer, pipeLineBufferSize,
                                             "uridecodebin uri=%s ! "
                                             "videoconvert ! "

--- a/samples/kvsWebRTCClientMasterRtspSample.c
+++ b/samples/kvsWebRTCClientMasterRtspSample.c
@@ -173,10 +173,10 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                             "audio/x-opus,rate=48000,channels=2 ! appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
                                             &error);
             } else {
-                printf("Streaming from rtsp source\n");
+                printf("Streaming from RTSP source\n");
 
                 UINT16 pipeLineBufferSize = 1000;
-                CHAR pipeLineBuffer[1000];
+                CHAR pipeLineBuffer[pipeLineBufferSize];
 
                 snprintf(pipeLineBuffer, pipeLineBufferSize,
                     "rtspsrc location=%s" 

--- a/samples/kvsWebRTCClientMasterRtspSample.c
+++ b/samples/kvsWebRTCClientMasterRtspSample.c
@@ -400,7 +400,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     if (argc < 4) {
         printf("[KVS RTSP Master] ERROR Not enough argument parameters.\n");
-        printf("[KVS RTSP Master] ERROR Usage: ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> audio-video\n"
+        printf("[KVS RTSP Master] ERROR Usage: ./kvsWebrtcClientMasterRtspSample <channel name> rtsp://<rtsp url> audio-video\n"
                "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> video-only\n");
         goto CleanUp;
     }
@@ -415,7 +415,7 @@ INT32 main(INT32 argc, CHAR* argv[])
         printf("[KVS RTSP Master] Streaming audio and video\n");
     } else {
         printf("[KVS RTSP Master] ERROR Unrecognized streaming type.\n");
-        printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> audio-video\n"
+        printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> rtsp://<rtsp url> audio-video\n"
                "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> video-only\n");
         goto CleanUp;
     }

--- a/samples/kvsWebRTCClientMasterRtspSample.c
+++ b/samples/kvsWebRTCClientMasterRtspSample.c
@@ -175,8 +175,8 @@ PVOID sendGstreamerAudioVideo(PVOID args)
             } else {
                 printf("Streaming from rtsp source\n");
 
-                int pipeLineBufferSize = 1000;
-                char pipeLineBuffer[1000];
+                UINT16 pipeLineBufferSize = 1000;
+                CHAR pipeLineBuffer[1000];
 
                 snprintf(pipeLineBuffer, pipeLineBufferSize,
                     "rtspsrc location=%s" 
@@ -190,9 +190,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                     "appsink sync=TRUE emit-signals=TRUE name=appsink-audio"
                     , pSampleConfiguration->rtspUrl);
 
-                pipeline = gst_parse_launch(
-                    pipeLineBuffer,
-                    &error);
+                pipeline = gst_parse_launch(pipeLineBuffer, &error);
             }
             break;
     }

--- a/samples/kvsWebRTCClientMasterRtspSample.c
+++ b/samples/kvsWebRTCClientMasterRtspSample.c
@@ -131,12 +131,13 @@ PVOID sendGstreamerAudioVideo(PVOID args)
     switch (pSampleConfiguration->mediaType) {
         case SAMPLE_STREAMING_VIDEO_ONLY:
         {
-            printf("Streaming from RTSP source with video only\n"); //TODO: remove this ( no need for a test source )
+            // NOTE: For video-only, audio is added to the stream to be compatible with media-server ingestion.
+            printf("Streaming from RTSP source with video only\n");
 
                 UINT16 pipeLineBufferSize = 1000;
                 CHAR pipeLineBuffer[pipeLineBufferSize];
 
-                // TODO: size check before ? (snprintf can already corrupt memory before current check)
+                // TODO: Size check before ? (snprintf can already corrupt memory before current check)
 
                 // NOTE: This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases.
                 // NOTE: This works fine even if the rtsp steam does have audio coming in with it - that audio will be ignored.
@@ -153,7 +154,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                     , pSampleConfiguration->rtspUrl);
 
                 if(stringOutcome > 1000) {}//throw error: rtsp source string is too long
-                // ask: if I go straight to clean up, is this secure?
+                // TODO: ask: if I go straight to clean up, is this secure?
 
                 pipeline = gst_parse_launch(pipeLineBuffer, &error);
                 
@@ -163,7 +164,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
         // TODO: THIS IS THE ONLY CASE WORKING AS OF NOW AND THE PIPELINE IS ACTUALLY FOR VIDEO ONLY MODE
         case SAMPLE_STREAMING_AUDIO_VIDEO:
         {
-                printf("Streaming from RTSP source with audio and video\n"); //TODO: remove this ( no need for a test source )
+                printf("Streaming from RTSP source with audio and video\n");
 
                 UINT16 pipeLineBufferSize = 1000;
                 CHAR pipeLineBuffer[pipeLineBufferSize];
@@ -396,7 +397,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     printf("[KVS RTSP Master] Finished initializing GStreamer\n");
 
     // TODO: make a check for audio-video vs video-only incoming RTSP stream
-    //        to eliminate the need for that argument.
+    //        to eliminate the need for that argument ?
 
     if (argc < 4) {
         printf("[KVS RTSP Master] ERROR Not enough argument parameters.\n");

--- a/samples/kvsWebRTCClientMasterRtspSample.c
+++ b/samples/kvsWebRTCClientMasterRtspSample.c
@@ -129,66 +129,66 @@ PVOID sendGstreamerAudioVideo(PVOID args)
     }
 
     switch (pSampleConfiguration->mediaType) {
-        case SAMPLE_STREAMING_VIDEO_ONLY:
-        {
+        case SAMPLE_STREAMING_VIDEO_ONLY: {
             // NOTE: For video-only, audio is added to the stream to be compatible with media-server ingestion.
             printf("Streaming from RTSP source with video only\n");
 
-                UINT16 pipeLineBufferSize = 1000;
-                CHAR pipeLineBuffer[pipeLineBufferSize];
+            UINT16 pipeLineBufferSize = 1000;
+            CHAR pipeLineBuffer[pipeLineBufferSize];
 
-                // TODO: Size check before ? (snprintf can already corrupt memory before current check)
+            // TODO: Size check before ? (snprintf can already corrupt memory before current check)
 
-                // NOTE: This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases.
-                // NOTE: This works fine even if the rtsp steam does have audio coming in with it - that audio will be ignored.
-                UINT16 stringOutcome = snprintf(pipeLineBuffer, pipeLineBufferSize,
-                    "uridecodebin uri=%s ! "
-                    "videoconvert ! "
-                    "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
-                    "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! queue ! "
-                    "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
-                    "audiotestsrc is-live=TRUE ! audioconvert ! "
-    // For silence: "audiotestsrc is-live=TRUE wave=silence ! audioconvert ! " ---------------- (TODO: should be released as silent)
-                    "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
-                    "appsink sync=TRUE emit-signals=TRUE name=appsink-audio"
-                    , pSampleConfiguration->rtspUrl);
+            // NOTE: This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases.
+            // NOTE: This works fine even if the rtsp steam does have audio coming in with it - that audio will be ignored.
+            UINT16 stringOutcome = snprintf(
+                pipeLineBuffer, pipeLineBufferSize,
+                "uridecodebin uri=%s ! "
+                "videoconvert ! "
+                "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! queue ! "
+                "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
+                "audiotestsrc is-live=TRUE ! audioconvert ! "
+                // For silence: "audiotestsrc is-live=TRUE wave=silence ! audioconvert ! " ---------------- (TODO: should be released as silent)
+                "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
+                "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
+                pSampleConfiguration->rtspUrl);
 
-                if(stringOutcome > 1000) {}//throw error: rtsp source string is too long
-                // TODO: ask: if I go straight to clean up, is this secure?
+            if (stringOutcome > 1000) {
+            } // throw error: rtsp source string is too long
+            // TODO: ask: if I go straight to clean up, is this secure?
 
-                pipeline = gst_parse_launch(pipeLineBuffer, &error);
-                
+            pipeline = gst_parse_launch(pipeLineBuffer, &error);
+
             break;
         }
 
         // TODO: THIS IS THE ONLY CASE WORKING AS OF NOW AND THE PIPELINE IS ACTUALLY FOR VIDEO ONLY MODE
-        case SAMPLE_STREAMING_AUDIO_VIDEO:
-        {
-                printf("Streaming from RTSP source with audio and video\n");
+        case SAMPLE_STREAMING_AUDIO_VIDEO: {
+            printf("Streaming from RTSP source with audio and video\n");
 
-                UINT16 pipeLineBufferSize = 1000;
-                CHAR pipeLineBuffer[pipeLineBufferSize];
+            UINT16 pipeLineBufferSize = 1000;
+            CHAR pipeLineBuffer[pipeLineBufferSize];
 
-                // TODO: size check before ? (snprintf can already corrupt memory before current check)
+            // TODO: size check before ? (snprintf can already corrupt memory before current check)
 
-                // NOTE: This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases.
-                // NOTE: This works fine even if the rtsp steam does have audio coming in with it - that audio will be ignored.
-                UINT16 stringOutcome = snprintf(pipeLineBuffer, pipeLineBufferSize,
-                    "uridecodebin uri=%s name=src ! videoconvert ! "
-                    "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
-                    "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! queue ! "
-                    "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
-                    "src. ! audioconvert ! "
-                    "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
-                    "appsink sync=TRUE emit-signals=TRUE name=appsink-audio"
-                    , pSampleConfiguration->rtspUrl);
+            // NOTE: This pipeline will work for both RAW and H264 cases as "uridecodebin" can handle both cases.
+            // NOTE: This works fine even if the rtsp steam does have audio coming in with it - that audio will be ignored.
+            UINT16 stringOutcome = snprintf(pipeLineBuffer, pipeLineBufferSize,
+                                            "uridecodebin uri=%s name=src ! videoconvert ! "
+                                            "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                                            "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! queue ! "
+                                            "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
+                                            "src. ! audioconvert ! "
+                                            "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! queue ! "
+                                            "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
+                                            pSampleConfiguration->rtspUrl);
 
+            if (stringOutcome > 1000) {
+            } // throw error: rtsp source string is too long
+            // ask: if I go straight to clean up, is this secure?
 
-                if(stringOutcome > 1000) {} //throw error: rtsp source string is too long
-                // ask: if I go straight to clean up, is this secure?
+            pipeline = gst_parse_launch(pipeLineBuffer, &error);
 
-                pipeline = gst_parse_launch(pipeLineBuffer, &error);
-            
             break;
         }
     }
@@ -203,8 +203,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
     appsinkAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-audio");
 
     if (!(appsinkVideo != NULL || appsinkAudio != NULL)) {
-        printf("[KVS RTSP Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n",
-               STATUS_INTERNAL_ERROR);
+        printf("[KVS RTSP Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n", STATUS_INTERNAL_ERROR);
         goto CleanUp;
     }
 
@@ -402,7 +401,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     if (argc < 4) {
         printf("[KVS RTSP Master] ERROR Not enough argument parameters.\n");
         printf("[KVS RTSP Master] ERROR Usage: ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> audio-video\n"
-        "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> video-only\n");
+               "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> video-only\n");
         goto CleanUp;
     }
 
@@ -417,10 +416,9 @@ INT32 main(INT32 argc, CHAR* argv[])
     } else {
         printf("[KVS RTSP Master] ERROR Unrecognized streaming type.\n");
         printf("[KVS RTSP Master] Usage: ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> audio-video\n"
-        "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> video-only\n");
+               "or ./kvsWebrtcClientMasterRtspSample <channel name> <rtsp://<rtsp url> video-only\n");
         goto CleanUp;
     }
-  
 
     // Initialize KVS WebRTC. This must be done before anything else, and must only be done once.
     retStatus = initKvsWebRtc();
@@ -461,13 +459,13 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     // Join storage session for media ingestion
     if (pSampleConfiguration->channelInfo.useMediaStorage == TRUE) {
-    printf("invoke join storage session");
-    retStatus = signalingClientJoinSessionSync(pSampleConfiguration->signalingClientHandle);
-    if (retStatus != STATUS_SUCCESS) {
-        printf("[KVS Master] signalingClientConnectSync(): operation returned status code: 0x%08x", retStatus);
-        goto CleanUp;
-    }
-    printf("[KVS Master] Signaling client connection to socket established");
+        printf("invoke join storage session");
+        retStatus = signalingClientJoinSessionSync(pSampleConfiguration->signalingClientHandle);
+        if (retStatus != STATUS_SUCCESS) {
+            printf("[KVS Master] signalingClientConnectSync(): operation returned status code: 0x%08x", retStatus);
+            goto CleanUp;
+        }
+        printf("[KVS Master] Signaling client connection to socket established");
     }
 
     gSampleConfiguration = pSampleConfiguration;

--- a/samples/kvsWebRTCClientMasterRtspSample.c
+++ b/samples/kvsWebRTCClientMasterRtspSample.c
@@ -1,0 +1,530 @@
+#include "Samples.h"
+#include <gst/gst.h>
+#include <gst/app/gstappsink.h>
+
+extern PSampleConfiguration gSampleConfiguration;
+
+// #define VERBOSE
+
+GstFlowReturn on_new_sample(GstElement* sink, gpointer data, UINT64 trackid)
+{
+    GstBuffer* buffer;
+    BOOL isDroppable, delta;
+    GstFlowReturn ret = GST_FLOW_OK;
+    GstSample* sample = NULL;
+    GstMapInfo info;
+    GstSegment* segment;
+    GstClockTime buf_pts;
+    Frame frame;
+    STATUS status;
+    PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) data;
+    PSampleStreamingSession pSampleStreamingSession = NULL;
+    PRtcRtpTransceiver pRtcRtpTransceiver = NULL;
+    UINT32 i;
+
+    if (pSampleConfiguration == NULL) {
+        printf("[KVS GStreamer Master] on_new_sample(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+        goto CleanUp;
+    }
+
+    info.data = NULL;
+    sample = gst_app_sink_pull_sample(GST_APP_SINK(sink));
+
+    buffer = gst_sample_get_buffer(sample);
+    isDroppable = GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_CORRUPTED) || GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DECODE_ONLY) ||
+        (GST_BUFFER_FLAGS(buffer) == GST_BUFFER_FLAG_DISCONT) ||
+        (GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DISCONT) && GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT)) ||
+        // drop if buffer contains header only and has invalid timestamp
+        !GST_BUFFER_PTS_IS_VALID(buffer);
+
+    if (!isDroppable) {
+        delta = GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT);
+
+        frame.flags = delta ? FRAME_FLAG_NONE : FRAME_FLAG_KEY_FRAME;
+
+        // convert from segment timestamp to running time in live mode.
+        segment = gst_sample_get_segment(sample);
+        buf_pts = gst_segment_to_running_time(segment, GST_FORMAT_TIME, buffer->pts);
+        if (!GST_CLOCK_TIME_IS_VALID(buf_pts)) {
+            printf("[KVS GStreamer Master] Frame contains invalid PTS dropping the frame. \n");
+        }
+
+        if (!(gst_buffer_map(buffer, &info, GST_MAP_READ))) {
+            printf("[KVS GStreamer Master] on_new_sample(): Gst buffer mapping failed\n");
+            goto CleanUp;
+        }
+
+        frame.trackId = trackid;
+        frame.duration = 0;
+        frame.version = FRAME_CURRENT_VERSION;
+        frame.size = (UINT32) info.size;
+        frame.frameData = (PBYTE) info.data;
+
+        MUTEX_LOCK(pSampleConfiguration->streamingSessionListReadLock);
+        for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
+            pSampleStreamingSession = pSampleConfiguration->sampleStreamingSessionList[i];
+            frame.index = (UINT32) ATOMIC_INCREMENT(&pSampleStreamingSession->frameIndex);
+
+            if (trackid == DEFAULT_AUDIO_TRACK_ID) {
+                pRtcRtpTransceiver = pSampleStreamingSession->pAudioRtcRtpTransceiver;
+                frame.presentationTs = pSampleStreamingSession->audioTimestamp;
+                frame.decodingTs = frame.presentationTs;
+                pSampleStreamingSession->audioTimestamp +=
+                    SAMPLE_AUDIO_FRAME_DURATION; // assume audio frame size is 20ms, which is default in opusenc
+            } else {
+                pRtcRtpTransceiver = pSampleStreamingSession->pVideoRtcRtpTransceiver;
+                frame.presentationTs = pSampleStreamingSession->videoTimestamp;
+                frame.decodingTs = frame.presentationTs;
+                pSampleStreamingSession->videoTimestamp += SAMPLE_VIDEO_FRAME_DURATION; // assume video fps is 25
+            }
+            status = writeFrame(pRtcRtpTransceiver, &frame);
+            if (status != STATUS_SRTP_NOT_READY_YET && status != STATUS_SUCCESS) {
+#ifdef VERBOSE
+                printf("writeFrame() failed with 0x%08x", status);
+#endif
+            }
+        }
+        MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);
+    }
+
+CleanUp:
+
+    if (info.data != NULL) {
+        gst_buffer_unmap(buffer, &info);
+    }
+
+    if (sample != NULL) {
+        gst_sample_unref(sample);
+    }
+
+    if (ATOMIC_LOAD_BOOL(&pSampleConfiguration->appTerminateFlag)) {
+        ret = GST_FLOW_EOS;
+    }
+
+    return ret;
+}
+
+GstFlowReturn on_new_sample_video(GstElement* sink, gpointer data)
+{
+    return on_new_sample(sink, data, DEFAULT_VIDEO_TRACK_ID);
+}
+
+GstFlowReturn on_new_sample_audio(GstElement* sink, gpointer data)
+{
+    return on_new_sample(sink, data, DEFAULT_AUDIO_TRACK_ID);
+}
+
+PVOID sendGstreamerAudioVideo(PVOID args)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    GstElement *appsinkVideo = NULL, *appsinkAudio = NULL, *pipeline = NULL;
+    GstBus* bus;
+    GstMessage* msg;
+    GError* error = NULL;
+    PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) args;
+
+    if (pSampleConfiguration == NULL) {
+        printf("[KVS GStreamer Master] sendGstreamerAudioVideo(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+        goto CleanUp;
+    }
+
+    /**
+     * Use x264enc as its available on mac, pi, ubuntu and windows
+     * mac pipeline fails if resolution is not 720p
+     *
+     * For alaw
+     * audiotestsrc is-live=TRUE ! queue leaky=2 max-size-buffers=400 ! audioconvert ! audioresample !
+     * audio/x-raw, rate=8000, channels=1, format=S16LE, layout=interleaved ! alawenc ! appsink sync=TRUE emit-signals=TRUE name=appsink-audio
+     *
+     * For VP8
+     * videotestsrc is-live=TRUE ! video/x-raw,width=1280,height=720,framerate=30/1 !
+     * vp8enc error-resilient=partitions keyframe-max-dist=10 auto-alt-ref=true cpu-used=5 deadline=1 !
+     * appsink sync=TRUE emit-signals=TRUE name=appsink-video
+     */
+
+    switch (pSampleConfiguration->mediaType) {
+        case SAMPLE_STREAMING_VIDEO_ONLY:
+            if (pSampleConfiguration->useTestSrc) {
+                pipeline = gst_parse_launch(
+                    "videotestsrc is-live=TRUE ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
+                    "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                    "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE emit-signals=TRUE name=appsink-video",
+                    &error);
+            } else {
+                pipeline = gst_parse_launch(
+                    "autovideosrc ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
+                    "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                    "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE emit-signals=TRUE name=appsink-video",
+                    &error);
+            }
+            break;
+
+
+        case SAMPLE_STREAMING_AUDIO_VIDEO:
+            if (pSampleConfiguration->useTestSrc) {
+                printf("Streaming from test source\n");
+                pipeline = gst_parse_launch("videotestsrc is-live=TRUE ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
+                                            "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                                            "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE "
+                                            "emit-signals=TRUE name=appsink-video audiotestsrc is-live=TRUE ! "
+                                            "queue leaky=2 max-size-buffers=400 ! audioconvert ! audioresample ! opusenc ! "
+                                            "audio/x-opus,rate=48000,channels=2 ! appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
+                                            &error);
+            } else {
+                printf("Streaming from rtsp source\n");
+                // pipeline = gst_parse_launch(
+                //     "rtspsrc location=rtsp://0.0.0.0:8558/live.sdp ! queue ! decodebin ! videoconvert ! "
+                //     "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                //     "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! "
+                //     "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
+                //     "audiotestsrc is-live=TRUE ! queue leaky=2 max-size-buffers=400 ! audioconvert ! "
+                //     "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! "
+                //     "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
+                //     &error);
+                pipeline = gst_parse_launch(
+                    "rtspsrc location=rtsp://0.0.0.0:8558/live.sdp ! decodebin ! queue ! videoconvert ! "
+                    "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
+                    "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! "
+                    "appsink sync=TRUE emit-signals=TRUE name=appsink-video "
+                    "audiotestsrc is-live=TRUE ! queue ! audioconvert ! "
+    // For silence: "audiotestsrc is-live=TRUE wave=silence ! queue ! audioconvert ! "
+                    "audioresample ! opusenc ! audio/x-opus,rate=48000,channels=2 ! "
+                    "appsink sync=TRUE emit-signals=TRUE name=appsink-audio",
+                    &error);
+            }
+            break;
+    }
+
+    if (pipeline == NULL) {
+        printf("[KVS GStreamer Master] sendGstreamerAudioVideo(): Failed to launch gstreamer, operation returned status code: 0x%08x \n",
+               STATUS_INTERNAL_ERROR);
+        goto CleanUp;
+    }
+
+    appsinkVideo = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-video");
+    appsinkAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-audio");
+
+    if (!(appsinkVideo != NULL || appsinkAudio != NULL)) {
+        printf("[KVS GStreamer Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n",
+               STATUS_INTERNAL_ERROR);
+        goto CleanUp;
+    }
+
+    if (appsinkVideo != NULL) {
+        g_signal_connect(appsinkVideo, "new-sample", G_CALLBACK(on_new_sample_video), (gpointer) pSampleConfiguration);
+    }
+
+    if (appsinkAudio != NULL) {
+        g_signal_connect(appsinkAudio, "new-sample", G_CALLBACK(on_new_sample_audio), (gpointer) pSampleConfiguration);
+    }
+
+    gst_element_set_state(pipeline, GST_STATE_PLAYING);
+
+    /* block until error or EOS */
+    bus = gst_element_get_bus(pipeline);
+    msg = gst_bus_timed_pop_filtered(bus, GST_CLOCK_TIME_NONE, GST_MESSAGE_ERROR | GST_MESSAGE_EOS);
+
+    /* Free resources */
+    if (msg != NULL) {
+        gst_message_unref(msg);
+    }
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    gst_object_unref(appsinkAudio);
+    gst_object_unref(appsinkVideo);
+
+CleanUp:
+
+    if (error != NULL) {
+        printf("%s", error->message);
+        g_clear_error(&error);
+    }
+
+    return (PVOID) (ULONG_PTR) retStatus;
+}
+
+VOID onGstAudioFrameReady(UINT64 customData, PFrame pFrame)
+{
+    GstFlowReturn ret;
+    GstBuffer* buffer;
+    GstElement* appsrcAudio = (GstElement*) customData;
+
+    /* Create a new empty buffer */
+    buffer = gst_buffer_new_and_alloc(pFrame->size);
+    gst_buffer_fill(buffer, 0, pFrame->frameData, pFrame->size);
+
+    /* Push the buffer into the appsrc */
+    g_signal_emit_by_name(appsrcAudio, "push-buffer", buffer, &ret);
+
+    /* Free the buffer now that we are done with it */
+    gst_buffer_unref(buffer);
+}
+
+VOID onSampleStreamingSessionShutdown(UINT64 customData, PSampleStreamingSession pSampleStreamingSession)
+{
+    (void) (pSampleStreamingSession);
+    GstElement* appsrc = (GstElement*) customData;
+    GstFlowReturn ret;
+
+    g_signal_emit_by_name(appsrc, "end-of-stream", &ret);
+}
+
+PVOID receiveGstreamerAudioVideo(PVOID args)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    GstElement *pipeline = NULL, *appsrcAudio = NULL;
+    GstBus* bus;
+    GstMessage* msg;
+    GError* error = NULL;
+    PSampleStreamingSession pSampleStreamingSession = (PSampleStreamingSession) args;
+    gchar *videoDescription = "", *audioDescription = "", *audioVideoDescription;
+
+    if (pSampleStreamingSession == NULL) {
+        printf("[KVS GStreamer Master] receiveGstreamerAudioVideo(): operation returned status code: 0x%08x \n", STATUS_NULL_ARG);
+        goto CleanUp;
+    }
+
+    // TODO: Wire video up with gstreamer pipeline
+
+    switch (pSampleStreamingSession->pAudioRtcRtpTransceiver->receiver.track.codec) {
+        case RTC_CODEC_OPUS:
+            audioDescription = "appsrc name=appsrc-audio ! opusparse ! decodebin ! autoaudiosink";
+            break;
+
+        case RTC_CODEC_MULAW:
+        case RTC_CODEC_ALAW:
+            audioDescription = "appsrc name=appsrc-audio ! rawaudioparse ! decodebin ! autoaudiosink";
+            break;
+        default:
+            break;
+    }
+
+    audioVideoDescription = g_strjoin(" ", audioDescription, videoDescription, NULL);
+
+    pipeline = gst_parse_launch(audioVideoDescription, &error);
+
+    appsrcAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsrc-audio");
+    if (appsrcAudio == NULL) {
+        printf("[KVS GStreamer Master] gst_bin_get_by_name(): cant find appsrc, operation returned status code: 0x%08x \n", STATUS_INTERNAL_ERROR);
+        goto CleanUp;
+    }
+
+    transceiverOnFrame(pSampleStreamingSession->pAudioRtcRtpTransceiver, (UINT64) appsrcAudio, onGstAudioFrameReady);
+
+    retStatus = streamingSessionOnShutdown(pSampleStreamingSession, (UINT64) appsrcAudio, onSampleStreamingSessionShutdown);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS GStreamer Master] streamingSessionOnShutdown(): operation returned status code: 0x%08x \n", STATUS_INTERNAL_ERROR);
+        goto CleanUp;
+    }
+
+    g_free(audioVideoDescription);
+
+    if (pipeline == NULL) {
+        printf("[KVS GStreamer Master] receiveGstreamerAudioVideo(): Failed to launch gstreamer, operation returned status code: 0x%08x \n",
+               STATUS_INTERNAL_ERROR);
+        goto CleanUp;
+    }
+
+    gst_element_set_state(pipeline, GST_STATE_PLAYING);
+
+    /* block until error or EOS */
+    bus = gst_element_get_bus(pipeline);
+    msg = gst_bus_timed_pop_filtered(bus, GST_CLOCK_TIME_NONE, GST_MESSAGE_ERROR | GST_MESSAGE_EOS);
+
+    /* Free resources */
+    if (msg != NULL) {
+        gst_message_unref(msg);
+    }
+    gst_object_unref(bus);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+    gst_object_unref(appsrcAudio);
+
+CleanUp:
+    if (error != NULL) {
+        printf("%s", error->message);
+        g_clear_error(&error);
+    }
+
+    return (PVOID) (ULONG_PTR) retStatus;
+}
+
+INT32 main(INT32 argc, CHAR* argv[])
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PSampleConfiguration pSampleConfiguration = NULL;
+    PCHAR pChannelName;
+
+    SET_INSTRUMENTED_ALLOCATORS();
+
+    signal(SIGINT, sigintHandler);
+
+    // do trickle-ice by default
+    printf("[KVS GStreamer Master] Using trickleICE by default\n");
+
+#ifdef IOT_CORE_ENABLE_CREDENTIALS
+    CHK_ERR((pChannelName = getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
+#else
+    pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
+#endif
+
+    retStatus = createSampleConfiguration(pChannelName, SIGNALING_CHANNEL_ROLE_TYPE_MASTER, TRUE, TRUE, TRUE, &pSampleConfiguration);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS GStreamer Master] createSampleConfiguration(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
+
+    printf("[KVS GStreamer Master] Created signaling channel %s\n", pChannelName);
+
+    if (pSampleConfiguration->enableFileLogging) {
+        retStatus =
+            createFileLogger(FILE_LOGGING_BUFFER_SIZE, MAX_NUMBER_OF_LOG_FILES, (PCHAR) FILE_LOGGER_LOG_FILE_DIRECTORY_PATH, TRUE, TRUE, NULL);
+        if (retStatus != STATUS_SUCCESS) {
+            printf("[KVS Master] createFileLogger(): operation returned status code: 0x%08x \n", retStatus);
+            pSampleConfiguration->enableFileLogging = FALSE;
+        }
+    }
+
+    pSampleConfiguration->videoSource = sendGstreamerAudioVideo;
+    pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
+    pSampleConfiguration->receiveAudioVideoSource = receiveGstreamerAudioVideo;
+    pSampleConfiguration->onDataChannel = onDataChannel;
+    pSampleConfiguration->customData = (UINT64) pSampleConfiguration;
+    pSampleConfiguration->useTestSrc = FALSE;
+    /* Initialize GStreamer */
+    gst_init(&argc, &argv);
+    printf("[KVS Gstreamer Master] Finished initializing GStreamer\n");
+
+    if (argc > 2) {
+        if (STRCMP(argv[2], "video-only") == 0) {
+            pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
+            printf("[KVS Gstreamer Master] Streaming video only\n");
+        } else if (STRCMP(argv[2], "audio-video") == 0) {
+            pSampleConfiguration->mediaType = SAMPLE_STREAMING_AUDIO_VIDEO;
+            printf("[KVS Gstreamer Master] Streaming audio and video\n");
+        } else {
+            printf("[KVS Gstreamer Master] Unrecognized streaming type. Default to video-only\n");
+        }
+    } else {
+        printf("[KVS Gstreamer Master] Streaming video only\n");
+    }
+
+    if (argc > 3) {
+        if (STRCMP(argv[3], "testsrc") == 0) {
+            printf("[KVS GStreamer Master] Using test source in GStreamer\n");
+            pSampleConfiguration->useTestSrc = TRUE;
+        }
+    }
+
+    switch (pSampleConfiguration->mediaType) {
+        case SAMPLE_STREAMING_VIDEO_ONLY:
+            printf("[KVS GStreamer Master] streaming type video-only");
+            break;
+        case SAMPLE_STREAMING_AUDIO_VIDEO:
+            printf("[KVS GStreamer Master] streaming type audio-video");
+            break;
+    }
+
+    // Initalize KVS WebRTC. This must be done before anything else, and must only be done once.
+    retStatus = initKvsWebRtc();
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS GStreamer Master] initKvsWebRtc(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
+    printf("[KVS GStreamer Master] KVS WebRTC initialization completed successfully\n");
+
+    pSampleConfiguration->signalingClientCallbacks.messageReceivedFn = signalingMessageReceived;
+
+    strcpy(pSampleConfiguration->clientInfo.clientId, SAMPLE_MASTER_CLIENT_ID);
+
+    retStatus = createSignalingClientSync(&pSampleConfiguration->clientInfo, &pSampleConfiguration->channelInfo,
+                                          &pSampleConfiguration->signalingClientCallbacks, pSampleConfiguration->pCredentialProvider,
+                                          &pSampleConfiguration->signalingClientHandle);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS GStreamer Master] createSignalingClientSync(): operation returned status code: 0x%08x \n", retStatus);
+    }
+    printf("[KVS GStreamer Master] Signaling client created successfully\n");
+
+    // Enable the processing of the messages
+    retStatus = signalingClientFetchSync(pSampleConfiguration->signalingClientHandle);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] signalingClientFetchSync(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
+
+    retStatus = signalingClientConnectSync(pSampleConfiguration->signalingClientHandle);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS GStreamer Master] signalingClientConnectSync(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
+    printf("[KVS GStreamer Master] Signaling client connection to socket established\n");
+
+    printf("[KVS Gstreamer Master] Beginning streaming...check the stream over channel %s\n", pChannelName);
+
+
+
+
+    if (pSampleConfiguration->channelInfo.useMediaStorage == TRUE) {
+    printf("invoke join storage session");
+    retStatus = signalingClientJoinSessionSync(pSampleConfiguration->signalingClientHandle);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS Master] signalingClientConnectSync(): operation returned status code: 0x%08x", retStatus);
+        goto CleanUp;
+    }
+    printf("[KVS Master] Signaling client connection to socket established");
+    }
+
+
+
+    gSampleConfiguration = pSampleConfiguration;
+
+    // Checking for termination
+    retStatus = sessionCleanupWait(pSampleConfiguration);
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS GStreamer Master] sessionCleanupWait(): operation returned status code: 0x%08x \n", retStatus);
+        goto CleanUp;
+    }
+
+    printf("[KVS GStreamer Master] Streaming session terminated\n");
+
+CleanUp:
+
+    if (retStatus != STATUS_SUCCESS) {
+        printf("[KVS GStreamer Master] Terminated with status code 0x%08x", retStatus);
+    }
+
+    printf("[KVS GStreamer Master] Cleaning up....\n");
+
+    if (pSampleConfiguration != NULL) {
+        // Kick of the termination sequence
+        ATOMIC_STORE_BOOL(&pSampleConfiguration->appTerminateFlag, TRUE);
+
+        if (pSampleConfiguration->mediaSenderTid != INVALID_TID_VALUE) {
+            THREAD_JOIN(pSampleConfiguration->mediaSenderTid, NULL);
+        }
+
+        if (pSampleConfiguration->enableFileLogging) {
+            freeFileLogger();
+        }
+        retStatus = freeSignalingClient(&pSampleConfiguration->signalingClientHandle);
+        if (retStatus != STATUS_SUCCESS) {
+            printf("[KVS GStreamer Master] freeSignalingClient(): operation returned status code: 0x%08x \n", retStatus);
+        }
+
+        retStatus = freeSampleConfiguration(&pSampleConfiguration);
+        if (retStatus != STATUS_SUCCESS) {
+            printf("[KVS GStreamer Master] freeSampleConfiguration(): operation returned status code: 0x%08x \n", retStatus);
+        }
+    }
+    printf("[KVS Gstreamer Master] Cleanup done\n");
+
+    RESET_INSTRUMENTED_ALLOCATORS();
+
+    // https://www.gnu.org/software/libc/manual/html_node/Exit-Status.html
+    // We can only return with 0 - 127. Some platforms treat exit code >= 128
+    // to be a success code, which might give an unintended behaviour.
+    // Some platforms also treat 1 or 0 differently, so it's better to use
+    // EXIT_FAILURE and EXIT_SUCCESS macros for portability.
+    return STATUS_FAILED(retStatus) ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
Adds a GStreamer sample for media-server ingestion capable of streaming from test, device, and RTSP sources. Fixes minor bug in existing GStreamer sample.

- Should work with RTSP streams using any codec (have tested raw and h.264/AAC)
- If `video-only`, silent audio is added to be compatible with media-server ingestion
- If user mistakenly passes `video-only` while their source sends both audio and video, there is no issue (source audio is ignored, silent audio still added)
- However, passing `audio-video` without there being audio present will not work (the silent audio will not be added)

Usage:
- `./kvsWebRTCClientGstreamerStorageSession <KVS channel name> <audio-video or video-only> <testsrc or devicesrc>`
- `./kvsWebRTCClientGstreamerStorageSession <KVS channel name> <audio-video or video-only> rtspsrc rtsp://<rtsp url>`

To setup an RTSP audio-video broadcast for testing:
- Download and extract mediamtx https://github.com/bluenviron/mediamtx#basic-usage.
- Follow the setup instructions, and in one terminal run `./mediamtx`, in a second terminal run either:
  - (Raw): `gst-launch-1.0 rtspclientsink name=s location=rtsp://localhost:8554/mystream videotestsrc ! queue ! s.sink_0 audiotestsrc ! queue ! s.sink_1`
  - (H.264, AAC): `gst-launch-1.0 rtspclientsink name=s location=rtsp://localhost:8554/mystream videotestsrc ! x264enc ! queue ! s.sink_0 audiotestsrc ! avenc_aac ! queue ! s.sink_1`
- In a third terminal you can run `gst-launch-1.0 uridecodebin uri=rtsp://127.0.0.1:8554/mystream name=src ! videoconvert ! autovideosink` to playback.
    > **Note** &nbsp; Having "localhost" in place of "127.0.0.1" may cause a GStreamer pipeline error.

KVS channel with ingestion setup as per usual.

<br>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
