### PR TITLE
[BUG] Set a default user agent if not provided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ include(Utilities)
 include(CheckIncludeFiles)
 include(CheckFunctionExists)
 
-project(KinesisVideoWebRTCClient LANGUAGES C)
+# The version MUST be updated before every release
+project(KinesisVideoWebRTCClient VERSION 1.7.3 LANGUAGES C)
 
 # User Flags
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)
@@ -37,6 +38,7 @@ execute_process(
         OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 add_definitions(-DSDK_VERSION=\"${GIT_COMMIT_HASH}\")
+add_definitions(-DVERSION_STRING=\"${PROJECT_VERSION}\")
 add_definitions(-DDETECTED_GIT_HASH)
 
 if(NOT OPEN_SRC_INSTALL_PREFIX OR OPEN_SRC_INSTALL_PREFIX STREQUAL "")

--- a/src/source/Signaling/ChannelInfo.c
+++ b/src/source/Signaling/ChannelInfo.c
@@ -8,7 +8,8 @@ STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* pp
 
     UINT32 allocSize, nameLen = 0, arnLen = 0, regionLen = 0, cplLen = 0, certLen = 0, postfixLen = 0, agentLen = 0, userAgentLen = 0, kmsLen = 0,
                       tagsSize;
-    PCHAR pCurPtr, pRegionPtr;
+    PCHAR pCurPtr, pRegionPtr, pUserAgentPostfixPtr;
+    CHAR agentString[MAX_CUSTOM_USER_AGENT_NAME_POSTFIX_LEN + 1];
     PChannelInfo pChannelInfo = NULL;
 
     CHK(pOrigChannelInfo != NULL && ppChannelInfo != NULL, STATUS_NULL_ARG);
@@ -49,10 +50,20 @@ STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* pp
 
     userAgentLen = MAX_USER_AGENT_LEN;
 
-    if (pOrigChannelInfo->pUserAgentPostfix != NULL) {
+    if (pOrigChannelInfo->pUserAgentPostfix != NULL && STRCMP(pOrigChannelInfo->pUserAgentPostfix, EMPTY_STRING) != 0) {
         CHK((postfixLen = (UINT32) STRNLEN(pOrigChannelInfo->pUserAgentPostfix, MAX_CUSTOM_USER_AGENT_NAME_POSTFIX_LEN + 1)) <=
                 MAX_CUSTOM_USER_AGENT_NAME_POSTFIX_LEN,
             STATUS_SIGNALING_INVALID_AGENT_POSTFIX_LENGTH);
+        pUserAgentPostfixPtr = pOrigChannelInfo->pUserAgentPostfix;
+    } else {
+        // Account for the "/" in the agent string.
+        // The default user agent postfix is:AWS-WEBRTC-KVS-AGENT/<SDK-version>
+        postfixLen = STRLEN(SIGNALING_USER_AGENT_POSTFIX_NAME) + STRLEN(SIGNALING_USER_AGENT_POSTFIX_VERSION) + 1;
+        CHK(postfixLen <= MAX_CUSTOM_USER_AGENT_NAME_POSTFIX_LEN, STATUS_SIGNALING_INVALID_AGENT_POSTFIX_LENGTH);
+        SNPRINTF(agentString,
+                 postfixLen + 1, // account for null terminator
+                 (PCHAR) "%s/%s", SIGNALING_USER_AGENT_POSTFIX_NAME, SIGNALING_USER_AGENT_POSTFIX_VERSION);
+        pUserAgentPostfixPtr = agentString;
     }
 
     if (pOrigChannelInfo->pCustomUserAgent != NULL) {
@@ -139,7 +150,7 @@ STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* pp
     }
 
     if (postfixLen != 0) {
-        STRCPY(pCurPtr, pOrigChannelInfo->pUserAgentPostfix);
+        STRCPY(pCurPtr, pUserAgentPostfixPtr);
         pChannelInfo->pUserAgentPostfix = pCurPtr;
         pCurPtr += ALIGN_UP_TO_MACHINE_WORD(postfixLen + 1);
     }
@@ -150,7 +161,7 @@ STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* pp
         pCurPtr += ALIGN_UP_TO_MACHINE_WORD(agentLen + 1);
     }
 
-    getUserAgentString(pOrigChannelInfo->pUserAgentPostfix, pOrigChannelInfo->pCustomUserAgent, MAX_USER_AGENT_LEN, pCurPtr);
+    getUserAgentString(pUserAgentPostfixPtr, pOrigChannelInfo->pCustomUserAgent, MAX_USER_AGENT_LEN, pCurPtr);
     pChannelInfo->pUserAgent = pCurPtr;
     pChannelInfo->pUserAgent[MAX_USER_AGENT_LEN] = '\0';
     pCurPtr += ALIGN_UP_TO_MACHINE_WORD(userAgentLen + 1);

--- a/src/source/Signaling/ChannelInfo.h
+++ b/src/source/Signaling/ChannelInfo.h
@@ -32,6 +32,14 @@ extern "C" {
 #define MIN_SIGNALING_MESSAGE_TTL_VALUE (5 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 #define MAX_SIGNALING_MESSAGE_TTL_VALUE (120 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
+#define SIGNALING_USER_AGENT_POSTFIX_NAME (PCHAR) "AWS-WEBRTC-KVS-AGENT"
+
+#ifdef VERSION_STRING
+#define SIGNALING_USER_AGENT_POSTFIX_VERSION (PCHAR) VERSION_STRING
+#else
+#define SIGNALING_USER_AGENT_POSTFIX_VERSION (PCHAR) "UNKNOWN"
+#endif
+
 /**
  * Takes in a pointer to a public version of ChannelInfo object.
  * Validates and creates an internal object

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -13,6 +13,9 @@ TEST_F(SignalingApiTest, createValidateChannelInfo)
 {
     initializeSignalingClientStructs();
     PChannelInfo rChannelInfo;
+    CHAR agentString[MAX_CUSTOM_USER_AGENT_NAME_POSTFIX_LEN + 1];
+    UINT32 postfixLen = STRLEN(SIGNALING_USER_AGENT_POSTFIX_NAME) + STRLEN(SIGNALING_USER_AGENT_POSTFIX_VERSION) + 1;
+    SNPRINTF(agentString, postfixLen + 1, (PCHAR) "%s/%s", SIGNALING_USER_AGENT_POSTFIX_NAME, SIGNALING_USER_AGENT_POSTFIX_VERSION);
     STRCPY(mChannelArn, TEST_CHANNEL_ARN);
     STRCPY(mKmsKeyId, TEST_KMS_KEY_ID_ARN);
     mChannelInfo.pChannelArn = mChannelArn;
@@ -32,6 +35,8 @@ TEST_F(SignalingApiTest, createValidateChannelInfo)
     EXPECT_EQ(0, STRCMP(rChannelInfo->pCertPath, mCaCertPath));
     EXPECT_EQ(rChannelInfo->messageTtl, TEST_SIGNALING_MESSAGE_TTL);
     EXPECT_EQ(0, STRCMP(rChannelInfo->pRegion, TEST_DEFAULT_REGION));
+    // Test default agent postfix
+    EXPECT_PRED_FORMAT2(testing::IsSubstring, agentString, rChannelInfo->pUserAgent);
     freeChannelInfo(&rChannelInfo);
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

What was changed?
-  By default, the user agent string for the WebRTC SDK was set to`AWS-SDK-KVS/...`. Set a WebRTC SDK specific default user agent.

Why was it changed?
- When trying to debug a problem that requires checking backend, it is impossible to understand the source of the request since this SDK depends on producer SDK. This change helps with the differentiation and simplify debugging

How was it changed?
- Setting the default format to: `AWS-WEBRTC-KVS-AGENT/<version>`
- Changed the CMake to set project version which is read to set the user agent string. This would have to be changed before every release

Testing:

- Added unit test to test out default agent string and supplied agent string
- Tested locally with samples

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
