### PR TITLE
support ice-lite

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1010,6 +1010,7 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PCHAR remoteIceUfrag = NULL, remoteIcePwd = NULL;
+    BOOL controlling = FALSE;
     UINT32 i, j;
 
     CHK(pPeerConnection != NULL, STATUS_NULL_ARG);
@@ -1024,6 +1025,7 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     NULLABLE_SET_VALUE(pKvsPeerConnection->canTrickleIce, FALSE);
 
     CHK_STATUS(deserializeSessionDescription(pSessionDescription, pSessionDescriptionInit->sdp));
+    controlling = pKvsPeerConnection->isOffer;
 
     for (i = 0; i < pSessionDescription->sessionAttributesCount; i++) {
         if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "fingerprint") == 0) {
@@ -1034,6 +1036,9 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
         } else if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "ice-options") == 0 &&
                    STRSTR(pSessionDescription->sdpAttributes[i].attributeValue, "trickle") != NULL) {
             NULLABLE_SET_VALUE(pKvsPeerConnection->canTrickleIce, TRUE);
+        } else if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "ice-lite") == 0) {
+            //if remote description says "ice-lite" we are always the ice controlling side
+            controlling = TRUE;
         }
     }
 
@@ -1086,7 +1091,7 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     STRNCPY(pKvsPeerConnection->remoteIcePwd, remoteIcePwd, MAX_ICE_PWD_LEN);
 
     CHK_STATUS(iceAgentStartAgent(pKvsPeerConnection->pIceAgent, pKvsPeerConnection->remoteIceUfrag, pKvsPeerConnection->remoteIcePwd,
-                                  pKvsPeerConnection->isOffer));
+                                  controlling));
 
     if (!pKvsPeerConnection->isOffer) {
         CHK_STATUS(setPayloadTypesFromOffer(pKvsPeerConnection->pCodecTable, pKvsPeerConnection->pRtxTable, pSessionDescription));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Support ice-lite

ice-lite is a minimal version of the ICE specification, intended for servers running on a public IP address.

ice-lite is easy to implement, requiring the media server to only answer incoming STUN binding requests and acting as a controlled entity in the ICE process itself. This simplicity makes it quite popular among implementations of [SFUs] and other media servers.

Support for ice-lite is announced in the SDP as `a=ice-lite`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
