### PR TITLE
Parse IP address if the hostname conforms to Public ipv4 DNS format

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -145,6 +145,8 @@ extern "C" {
 #define STATUS_CLOSE_SOCKET_FAILED                 STATUS_NETWORKING_BASE + 0x00000026
 #define STATUS_CREATE_SOCKET_PAIR_FAILED           STATUS_NETWORKING_BASE + 0x00000027
 #define STATUS_SOCKET_WRITE_FAILED                 STATUS_NETWORKING_BASE + 0X00000028
+#define STATUS_INVALID_ADDRESS_LENGTH              STATUS_NETWORKING_BASE + 0X00000029
+
 /*!@} */
 
 /////////////////////////////////////////////////////

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -123,6 +123,17 @@ STATUS socketWrite(INT32, const void*, SIZE_T);
  */
 STATUS getIpWithHostName(PCHAR, PKvsIpAddress);
 
+/**
+ * @param - PCHAR - IN - IP address string to verify if it is IPv4 or IPv6 format
+ *
+ * @param - UINT16 - IN - Length of string
+ *
+ * @param - BOOL - OUT - Evaluates to TRUE if the provided string is IPv4/IPv6. False otherwise
+ *
+ * @return - STATUS status of execution
+ */
+BOOL isIpAddr(PCHAR, UINT16);
+
 STATUS getIpAddrStr(PKvsIpAddress, PCHAR, UINT32);
 
 BOOL isSameIpAddress(PKvsIpAddress, PKvsIpAddress, BOOL);

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -22,6 +22,9 @@ extern "C" {
 
 #define KVS_GET_IP_ADDRESS_PORT(a) ((UINT16) getInt16((a)->port))
 
+#define IPV4_TEMPLATE "%d.%d.%d.%d"
+#define IPV6_TEMPLATE "%04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x"
+
 #if defined(__MACH__)
 #define NO_SIGNAL SO_NOSIGPIPE
 #else

--- a/tst/DataChannelFunctionalityTest.cpp
+++ b/tst/DataChannelFunctionalityTest.cpp
@@ -107,7 +107,7 @@ TEST_F(DataChannelFunctionalityTest, dataChannelSendRecvMessageAfterDtlsComplete
 
     MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
 
-    auto onDataChannel = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) { ATOMIC_STORE((PSIZE_T) customData, (SIZE_T) pRtcDataChannel); };
+    auto onDataChannel = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) { ATOMIC_STORE((PSIZE_T)customData, reinterpret_cast<UINT64>(pRtcDataChannel)); };
 
     auto dataChannelOnOpenCallback = [](UINT64 customData, PRtcDataChannel pDataChannel) {
         UNUSED_PARAM(pDataChannel);

--- a/tst/NetworkApiTest.cpp
+++ b/tst/NetworkApiTest.cpp
@@ -1,0 +1,28 @@
+#include "WebRTCClientTestFixture.h"
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+class NetworkApiTest : public WebRtcClientTestBase {
+};
+
+TEST_F(NetworkApiTest, GetIpWithHostNameTest)
+{
+    KvsIpAddress ipAddress;
+    EXPECT_EQ(STATUS_NULL_ARG, getIpWithHostName(NULL, &ipAddress));
+    EXPECT_EQ(STATUS_RESOLVE_HOSTNAME_FAILED, getIpWithHostName((PCHAR) "stun:stun.test.net:3478", &ipAddress));
+    EXPECT_EQ(STATUS_SUCCESS, getIpWithHostName((PCHAR) "35-90-63-38.t-ae7dd61a.kinesisvideo.us-west-2.amazonaws.com", &ipAddress));
+    EXPECT_EQ(STATUS_SUCCESS, getIpWithHostName((PCHAR) "12.34.45.40", &ipAddress));
+    EXPECT_EQ(STATUS_SUCCESS, getIpWithHostName((PCHAR) "2001:0db8:85a3:0000:0000:8a2e:0370:7334", &ipAddress));
+    EXPECT_EQ(STATUS_RESOLVE_HOSTNAME_FAILED, getIpWithHostName((PCHAR) ".12.34.45.40", &ipAddress));
+}
+
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/NetworkApiTest.cpp
+++ b/tst/NetworkApiTest.cpp
@@ -18,6 +18,16 @@ TEST_F(NetworkApiTest, GetIpWithHostNameTest)
     EXPECT_EQ(STATUS_SUCCESS, getIpWithHostName((PCHAR) "12.34.45.40", &ipAddress));
     EXPECT_EQ(STATUS_SUCCESS, getIpWithHostName((PCHAR) "2001:0db8:85a3:0000:0000:8a2e:0370:7334", &ipAddress));
     EXPECT_EQ(STATUS_RESOLVE_HOSTNAME_FAILED, getIpWithHostName((PCHAR) ".12.34.45.40", &ipAddress));
+    EXPECT_EQ(STATUS_RESOLVE_HOSTNAME_FAILED, getIpWithHostName((PCHAR) "...........", &ipAddress));
+}
+
+TEST_F(NetworkApiTest, ipIpAddrTest)
+{
+    EXPECT_EQ(FALSE, isIpAddr((PCHAR) "stun:stun.test.net:3478", STRLEN("stun:stun.test.net:3478")));
+    EXPECT_EQ(TRUE, isIpAddr((PCHAR) "12.34.45.40", STRLEN("12.34.45.40")));
+    EXPECT_EQ(FALSE, isIpAddr((PCHAR) "567.123.345.000", STRLEN("567.123.345.000")));
+    EXPECT_EQ(TRUE, isIpAddr((PCHAR) "2001:0db8:85a3:0000:0000:8a2e:0370:7334", STRLEN("2001:0db8:85a3:0000:0000:8a2e:0370:7334")));
+    EXPECT_EQ(FALSE, isIpAddr((PCHAR) "2001:85a3:0000:0000:8a2e:0370:7334", STRLEN("2001:85a3:0000:0000:8a2e:0370:7334")));
 }
 
 


### PR DESCRIPTION
What was changed?

The function to extract IP address from hostname through DNS resolution is modified to parse IP address from hostname if possible and fallback on getaddrinfo() if the hostname format does not comply to format. Also added a unit test to test this under different inputs.

Why was it changed?

getaddrinfo has been noticed to take a long time to resolve or even be unreliable in smaller embedded devices. Having this in place helps in bypassing this call altogether if the IP address complies with AWS public IPv4 DNS format.

How was it changed?

Checks and parser logic is added to ensure we verify if parsing is a feasibility.

Testing:

- Local testing with samples through logs monitoring
- Testing via newly added unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
