### PR TITLE
introduce bypass ice servers DNS resolve feature

### DIFF
--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -46,6 +46,9 @@ extern "C" {
 #define IOT_CORE_ROLE_ALIAS          ((PCHAR) "AWS_IOT_CORE_ROLE_ALIAS")
 #define IOT_CORE_THING_NAME          ((PCHAR) "AWS_IOT_CORE_THING_NAME")
 
+// Enable this macro to bypass turn server DNS resolve to improve the speed of connection establishment
+#define BYPASS_DNS_RESOLVE_TURN
+
 #define MASTER_DATA_CHANNEL_MESSAGE "This message is from the KVS Master"
 #define VIEWER_DATA_CHANNEL_MESSAGE "This message is from the KVS Viewer"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The time spent on DNS resolving for KVS servers is frustrating in some network environment.

By resolving IP address from hostname string directly can reduce the time of DNS resolving and speed up the process of connection establishment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
