### PR TITLE
Include log timestamp fix

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           7d1b76f53680c1e23afb6f35f0cca97ccdb35e3f
+    GIT_TAG           include-hotfix-change
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CheckIncludeFiles)
 include(CheckFunctionExists)
 
 # The version MUST be updated before every release
-project(KinesisVideoWebRTCClient VERSION 1.8.0 LANGUAGES C)
+project(KinesisVideoWebRTCClient VERSION 1.8.1 LANGUAGES C)
 
 # User Flags
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Testing a commit in PIC to fix millisecond precision log timestamp display

*Why was it changed?*
The millisecond timestamp portion had 6 digits adding a timestamp which is confusing. This fixes the timestamp portion to be 3 digits only to be accurate

*How was it changed?*
Change made in PIC to assign only 3 digits space in buffer.

*What testing was done for the changes?*
Checking if the log lines in the CI include this fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
