### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 <h4 align="center">Pure C WebRTC Client for Amazon Kinesis Video Streams </h4>
 
 <p align="center">
+  <a href="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/workflows/ci.yml"> <img src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/workflows/ci.yml/badge.svg"> </a>
+  <a href="https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c"> <img src="https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/branch/master/graph/badge.svg" alt="Coverage Status"> </a>
+</p>
+
+<p align="center">
   <a href="#key-features">Key Features</a> •
   <a href="#build">Build</a> •
   <a href="#run">Run</a> •


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?* 

Badges were added to the README file to indicate CI passing/failing status as well as code coverage percentage.  Previously this was missing.

*Why was it changed?* 

This is useful information to have on the landing page.

*How was it changed?*

Changed the README.md hyperlink to point to the correct link

*What testing was done for the changes?* 

I viewed the landing page, now it looks like this:
![Screenshot 2023-09-01 at 9 16 47 AM](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/assets/7199741/1ddaaa45-3717-456c-a93d-0bdd68fa23e3)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
