### PR TITLE
Change usrsctp initialization function to not open raw sockets #1782

### DIFF
--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -59,7 +59,7 @@ STATUS initSctpSession()
 {
     STATUS retStatus = STATUS_SUCCESS;
 
-    usrsctp_init(0, &onSctpOutboundPacket, NULL);
+    usrsctp_init_nothreads(0, &onSctpOutboundPacket, NULL);
 
     // Disable Explicit Congestion Notification
     usrsctp_sysctl_set_sctp_ecn_enable(0);


### PR DESCRIPTION
*Issue #, if available:*

Description of changes:
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1782

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.