### PR TITLE
Change usrsctp initialization function to not open raw sockets

### DIFF
--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -59,7 +59,7 @@ STATUS initSctpSession()
 {
     STATUS retStatus = STATUS_SUCCESS;
 
-    usrsctp_init(0, &onSctpOutboundPacket, NULL);
+    usrsctp_init_nothreads(0, &onSctpOutboundPacket, NULL);
 
     // Disable Explicit Congestion Notification
     usrsctp_sysctl_set_sctp_ecn_enable(0);


### PR DESCRIPTION
*Issue #, if available:*
Issue: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1782
PR: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/1796
*What was changed?*
Change usrsctp initialization function to not open raw sockets 

*Why was it changed?*
Port 132 is opened by the usrsctp library. However, this port is not used by WebRTC and should not be open

*How was it changed?*
Using `usrsctp_init_nothreads` instead of `usrsctp_init` to prevent those unused sockets from being created (Ref: https://github.com/sctplab/usrsctp/pull/532)

*What testing was done for the changes?*
- Manually tested by running WebRTC C SDK as master and JS SDK as viewer and sending data channel messages from master to viewer and vice versa
- Manually tested by running WebRTC C SDK as viewer and JS SDK as master and sending data channel messages from master to viewer and vice versa

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
