### PR TITLE
Create a CMake flag to enable KVS Threadpool

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           178109a5dbfc5288ba5cf7fab1dc1afd5e2e182b
+    GIT_TAG           75d53abcbac214e19d14afcb61dbf533056b560c
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           75d53abcbac214e19d14afcb61dbf533056b560c
+    GIT_TAG           fd562a16e41b1972df14c230b6be7a7d3f75bc6b
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        
       -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(BUILD_LIBSRTP_HOST_PLATFORM "If buildng LibSRTP what is the current platf
 option(BUILD_LIBSRTP_DESTINATION_PLATFORM "If buildng LibSRTP what is the destination platform" OFF)
 option(BUILD_SAMPLE "Build available samples" ON)
 option(ENABLE_DATA_CHANNEL "Enable support for data channel" ON)
-option(ENABLE_KVS_SIGNALING_THREADPOOL "Enable support for KVS thread pool in signaling" ON)
+option(ENABLE_KVS_THREADPOOL "Enable support for KVS thread pool in signaling" ON)
 option(INSTRUMENTED_ALLOCATORS "Enable memory instrumentation" OFF)
 
 # Developer Flags
@@ -99,8 +99,8 @@ message(STATUS "dependencies install path is ${OPEN_SRC_INSTALL_PREFIX}")
 add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")
 add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
 
-if (ENABLE_KVS_SIGNALING_THREADPOOL)
-  add_definitions(-DENABLE_KVS_SIGNALING_THREADPOOL)
+if (ENABLE_KVS_THREADPOOL)
+  add_definitions(-DENABLE_KVS_THREADPOOL)
 endif()
 
 if(USE_OPENSSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(BUILD_LIBSRTP_HOST_PLATFORM "If buildng LibSRTP what is the current platf
 option(BUILD_LIBSRTP_DESTINATION_PLATFORM "If buildng LibSRTP what is the destination platform" OFF)
 option(BUILD_SAMPLE "Build available samples" ON)
 option(ENABLE_DATA_CHANNEL "Enable support for data channel" ON)
-option(ENABLE_KVS_THREADPOOL "Enable support thread pool" ON)
+option(ENABLE_KVS_THREADPOOL "Enable support for KVS thread pool" ON)
 option(INSTRUMENTED_ALLOCATORS "Enable memory instrumentation" OFF)
 
 # Developer Flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(BUILD_LIBSRTP_HOST_PLATFORM "If buildng LibSRTP what is the current platf
 option(BUILD_LIBSRTP_DESTINATION_PLATFORM "If buildng LibSRTP what is the destination platform" OFF)
 option(BUILD_SAMPLE "Build available samples" ON)
 option(ENABLE_DATA_CHANNEL "Enable support for data channel" ON)
+option(ENABLE_KVS_THREADPOOL "Enable support thread pool" ON)
 option(INSTRUMENTED_ALLOCATORS "Enable memory instrumentation" OFF)
 
 # Developer Flags
@@ -97,6 +98,10 @@ message(STATUS "dependencies install path is ${OPEN_SRC_INSTALL_PREFIX}")
 # pass ca cert location to sdk
 add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")
 add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
+
+if (ENABLE_KVS_THREADPOOL)
+  add_definitions(-DENABLE_KVS_THREADPOOL)
+endif()
 
 if(USE_OPENSSL)
   add_definitions(-DKVS_USE_OPENSSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(BUILD_LIBSRTP_HOST_PLATFORM "If buildng LibSRTP what is the current platf
 option(BUILD_LIBSRTP_DESTINATION_PLATFORM "If buildng LibSRTP what is the destination platform" OFF)
 option(BUILD_SAMPLE "Build available samples" ON)
 option(ENABLE_DATA_CHANNEL "Enable support for data channel" ON)
-option(ENABLE_KVS_THREADPOOL "Enable support for KVS thread pool" ON)
+option(ENABLE_KVS_SIGNALING_THREADPOOL "Enable support for KVS thread pool in signaling" ON)
 option(INSTRUMENTED_ALLOCATORS "Enable memory instrumentation" OFF)
 
 # Developer Flags
@@ -99,8 +99,8 @@ message(STATUS "dependencies install path is ${OPEN_SRC_INSTALL_PREFIX}")
 add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")
 add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
 
-if (ENABLE_KVS_THREADPOOL)
-  add_definitions(-DENABLE_KVS_THREADPOOL)
+if (ENABLE_KVS_SIGNALING_THREADPOOL)
+  add_definitions(-DENABLE_KVS_SIGNALING_THREADPOOL)
 endif()
 
 if(USE_OPENSSL)

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ To build on a 32-bit Raspbian GNU/Linux 11 on 64-bit hardware, the OpenSSL libra
 
 ### Threadpool for Signaling Channel messages
 The threadpool is enabled by default, and starts with 3 threads that it can increase up to 5 if all 3 are actively in use. To change these values to better match the resources of your use case
-please edit samples/Samples.h defines `KVS_SIGNALING_THREADPOOL_MIN` and `KVS_SIGNALING_THREADPOOL_MAX`. You can also disable the threadpool to instead create and detach each thread to handle signaling messages by disabling the flag `-DENABLE_KVS_SIGNALING_THREADPOOL` while building with cmake.
+please edit samples/Samples.h defines `KVS_SIGNALING_THREADPOOL_MIN` and `KVS_SIGNALING_THREADPOOL_MAX`. You can also disable the threadpool to instead create and detach each thread to handle signaling messages by disabling the flag `-DENABLE_KVS_THREADPOOL` while building with cmake.
 
 ## Documentation
 All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ To build on a 32-bit Raspbian GNU/Linux 11 on 64-bit hardware, the OpenSSL libra
 
 ### Threadpool for Signaling Channel messages
 The threadpool is enabled by default, and starts with 3 threads that it can increase up to 5 if all 3 are actively in use. To change these values to better match the resources of your use case
-please edit samples/Samples.h defines `KVS_SIGNALING_THREADPOOL_MIN` and `KVS_SIGNALING_THREADPOOL_MAX`. You can also disable the threadpool to instead create and detach each thread to handle signaling messages by disabling the flag `-DENABLE_KVS_THREADPOOL` while building with cmake.
+please edit samples/Samples.h defines `KVS_SIGNALING_THREADPOOL_MIN` and `KVS_SIGNALING_THREADPOOL_MAX`. You can also disable the threadpool to instead create and detach each thread to handle signaling messages by disabling the flag `-DENABLE_KVS_SIGNALING_THREADPOOL` while building with cmake.
 
 ## Documentation
 All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.

--- a/README.md
+++ b/README.md
@@ -360,8 +360,7 @@ To build on a 32-bit Raspbian GNU/Linux 11 on 64-bit hardware, the OpenSSL libra
 
 ### Threadpool for Signaling Channel messages
 The threadpool is enabled by default, and starts with 3 threads that it can increase up to 5 if all 3 are actively in use. To change these values to better match the resources of your use case
-please edit samples/Samples.h defines `KVS_SIGNALING_THREADPOOL_MIN` and `KVS_SIGNALING_THREADPOOL_MAX`. You can also disable the threadpool to instead create and detach each thread
-to handle signaling messages by commenting out `KVS_USE_SIGNALING_CHANNEL_THREADPOOL`.
+please edit samples/Samples.h defines `KVS_SIGNALING_THREADPOOL_MIN` and `KVS_SIGNALING_THREADPOOL_MAX`. You can also disable the threadpool to instead create and detach each thread to handle signaling messages by disabling the flag `-DENABLE_KVS_THREADPOOL` while building with cmake.
 
 ## Documentation
 All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -56,9 +56,6 @@ extern "C" {
 #define KVS_SIGNALING_THREADPOOL_MIN 3
 #define KVS_SIGNALING_THREADPOOL_MAX 5
 
-// comment out this line to disable the feature
-#define KVS_USE_SIGNALING_CHANNEL_THREADPOOL 1
-
 /* Uncomment the following line in order to enable IoT credentials checks in the provided samples */
 // #define IOT_CORE_ENABLE_CREDENTIALS  1
 

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -2011,7 +2011,7 @@ STATUS receiveLwsMessage(PSignalingClient pSignalingClient, PCHAR pMessage, UINT
         DLOGW("Failed to validate the ICE server configuration received with an Offer");
     }
 
-#ifdef ENABLE_KVS_SIGNALING_THREADPOOL
+#ifdef ENABLE_KVS_THREADPOOL
     CHK_STATUS(threadpoolPush(pSignalingClient->pThreadpool, receiveLwsMessageWrapper, (PVOID) pSignalingMessageWrapper));
 #else
     // Issue the callback on a separate thread

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -2011,7 +2011,7 @@ STATUS receiveLwsMessage(PSignalingClient pSignalingClient, PCHAR pMessage, UINT
         DLOGW("Failed to validate the ICE server configuration received with an Offer");
     }
 
-#ifdef KVS_USE_SIGNALING_CHANNEL_THREADPOOL
+#ifdef ENABLE_KVS_THREADPOOL
     CHK_STATUS(threadpoolPush(pSignalingClient->pThreadpool, receiveLwsMessageWrapper, (PVOID) pSignalingMessageWrapper));
 #else
     // Issue the callback on a separate thread

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -2011,7 +2011,7 @@ STATUS receiveLwsMessage(PSignalingClient pSignalingClient, PCHAR pMessage, UINT
         DLOGW("Failed to validate the ICE server configuration received with an Offer");
     }
 
-#ifdef ENABLE_KVS_THREADPOOL
+#ifdef ENABLE_KVS_SIGNALING_THREADPOOL
     CHK_STATUS(threadpoolPush(pSignalingClient->pThreadpool, receiveLwsMessageWrapper, (PVOID) pSignalingMessageWrapper));
 #else
     // Issue the callback on a separate thread

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -225,7 +225,7 @@ STATUS freeSignaling(PSignalingClient* ppSignalingClient)
 
     hashTableFree(pSignalingClient->diagnostics.pEndpointToClockSkewHashMap);
 
-#ifdef USE_KVS_THREADPOOL
+#ifdef ENABLE_KVS_THREADPOOL
     threadpoolFree(pSignalingClient->pThreadpool);
 #endif
 

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -38,8 +38,10 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     CHK_STATUS(validateSignalingCallbacks(pSignalingClient, pCallbacks));
     CHK_STATUS(validateSignalingClientInfo(pSignalingClient, pClientInfo));
 #ifdef ENABLE_KVS_THREADPOOL
+    DLOGD("Going to crate the threadpool for signaling");
     CHK_STATUS(threadpoolCreate(&pSignalingClient->pThreadpool, pClientInfo->signalingClientInfo.signalingMessagesMinimumThreads,
                                 pClientInfo->signalingClientInfo.signalingMessagesMaximumThreads));
+    DLOGD("Successfully created the threadpool for signaling");
 #endif
 
     pSignalingClient->version = SIGNALING_CLIENT_CURRENT_VERSION;

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -37,7 +37,7 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     CHK_STATUS(createValidateChannelInfo(pChannelInfo, &pSignalingClient->pChannelInfo));
     CHK_STATUS(validateSignalingCallbacks(pSignalingClient, pCallbacks));
     CHK_STATUS(validateSignalingClientInfo(pSignalingClient, pClientInfo));
-#ifdef KVS_USE_SIGNALING_CHANNEL_THREADPOOL
+#ifdef ENABLE_KVS_THREADPOOL
     CHK_STATUS(threadpoolCreate(&pSignalingClient->pThreadpool, pClientInfo->signalingClientInfo.signalingMessagesMinimumThreads,
                                 pClientInfo->signalingClientInfo.signalingMessagesMaximumThreads));
 #endif
@@ -225,7 +225,7 @@ STATUS freeSignaling(PSignalingClient* ppSignalingClient)
 
     hashTableFree(pSignalingClient->diagnostics.pEndpointToClockSkewHashMap);
 
-#ifdef KVS_USE_SIGNALING_CHANNEL_THREADPOOL
+#ifdef USE_KVS_THREADPOOL
     threadpoolFree(pSignalingClient->pThreadpool);
 #endif
 

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -37,7 +37,7 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     CHK_STATUS(createValidateChannelInfo(pChannelInfo, &pSignalingClient->pChannelInfo));
     CHK_STATUS(validateSignalingCallbacks(pSignalingClient, pCallbacks));
     CHK_STATUS(validateSignalingClientInfo(pSignalingClient, pClientInfo));
-#ifdef ENABLE_KVS_THREADPOOL
+#ifdef ENABLE_KVS_SIGNALING_THREADPOOL
     DLOGD("Going to crate the threadpool for signaling");
     CHK_STATUS(threadpoolCreate(&pSignalingClient->pThreadpool, pClientInfo->signalingClientInfo.signalingMessagesMinimumThreads,
                                 pClientInfo->signalingClientInfo.signalingMessagesMaximumThreads));
@@ -227,7 +227,7 @@ STATUS freeSignaling(PSignalingClient* ppSignalingClient)
 
     hashTableFree(pSignalingClient->diagnostics.pEndpointToClockSkewHashMap);
 
-#ifdef ENABLE_KVS_THREADPOOL
+#ifdef ENABLE_KVS_SIGNALING_THREADPOOL
     threadpoolFree(pSignalingClient->pThreadpool);
 #endif
 

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -37,7 +37,7 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     CHK_STATUS(createValidateChannelInfo(pChannelInfo, &pSignalingClient->pChannelInfo));
     CHK_STATUS(validateSignalingCallbacks(pSignalingClient, pCallbacks));
     CHK_STATUS(validateSignalingClientInfo(pSignalingClient, pClientInfo));
-#ifdef ENABLE_KVS_SIGNALING_THREADPOOL
+#ifdef ENABLE_KVS_THREADPOOL
     DLOGD("Going to crate the threadpool for signaling");
     CHK_STATUS(threadpoolCreate(&pSignalingClient->pThreadpool, pClientInfo->signalingClientInfo.signalingMessagesMinimumThreads,
                                 pClientInfo->signalingClientInfo.signalingMessagesMaximumThreads));
@@ -227,7 +227,7 @@ STATUS freeSignaling(PSignalingClient* ppSignalingClient)
 
     hashTableFree(pSignalingClient->diagnostics.pEndpointToClockSkewHashMap);
 
-#ifdef ENABLE_KVS_SIGNALING_THREADPOOL
+#ifdef ENABLE_KVS_THREADPOOL
     threadpoolFree(pSignalingClient->pThreadpool);
 #endif
 

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -339,7 +339,7 @@ typedef struct {
     UINT64 deleteTime;
     UINT64 connectTime;
 
-#ifdef ENABLE_KVS_SIGNALING_THREADPOOL
+#ifdef ENABLE_KVS_THREADPOOL
     PThreadpool pThreadpool;
 #endif
     UINT64 offerTime;

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -339,7 +339,7 @@ typedef struct {
     UINT64 deleteTime;
     UINT64 connectTime;
 
-#ifdef ENABLE_KVS_THREADPOOL
+#ifdef ENABLE_KVS_SIGNALING_THREADPOOL
     PThreadpool pThreadpool;
 #endif
     UINT64 offerTime;

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -339,7 +339,7 @@ typedef struct {
     UINT64 deleteTime;
     UINT64 connectTime;
 
-#ifdef KVS_USE_SIGNALING_CHANNEL_THREADPOOL
+#ifdef ENABLE_KVS_THREADPOOL
     PThreadpool pThreadpool;
 #endif
     UINT64 offerTime;

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -941,6 +941,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedVariatio
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
 
@@ -1204,6 +1206,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedVariations)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
 
@@ -1469,6 +1473,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedAuthExpi
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
 
@@ -1590,6 +1596,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedAuthExpirat
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
 
@@ -1714,6 +1722,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.hookCustomData = (UINT64) this;
     clientInfoInternal.getIceConfigPreHookFn = getIceConfigPreHook;
@@ -1829,6 +1839,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.hookCustomData = (UINT64) this;
     clientInfoInternal.getIceConfigPreHookFn = getIceConfigPreHook;
@@ -1946,6 +1958,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.hookCustomData = (UINT64) this;
     clientInfoInternal.getIceConfigPreHookFn = getIceConfigPreHook;
@@ -2059,6 +2073,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.hookCustomData = (UINT64) this;
     clientInfoInternal.getIceConfigPreHookFn = getIceConfigPreHook;
@@ -2175,6 +2191,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithBadA
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
 
@@ -2295,6 +2313,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithBadAuth
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
 
@@ -2594,6 +2614,8 @@ TEST_F(SignalingApiFunctionalityTest, connectTimeoutEmulation)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.connectTimeout = 1 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
@@ -2713,6 +2735,8 @@ TEST_F(SignalingApiFunctionalityTest, channelInfoArnSkipDescribe)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.connectTimeout = 0;
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
@@ -2845,6 +2869,8 @@ TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedWithArn)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.connectTimeout = 0;
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
@@ -2976,6 +3002,8 @@ TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedAuthExpiration)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.connectTimeout = 0;
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
@@ -3131,6 +3159,8 @@ TEST_F(SignalingApiFunctionalityTest, cachingWithFaultInjection)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.hookCustomData = (UINT64) this;
     clientInfoInternal.connectPreHookFn = connectPreHook;
@@ -3269,6 +3299,8 @@ TEST_F(SignalingApiFunctionalityTest, fileCachingTest)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfoInternal.hookCustomData = (UINT64) this;
     clientInfoInternal.connectPreHookFn = connectPreHook;
@@ -3524,6 +3556,8 @@ TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfoInternal);
 
@@ -3710,6 +3744,8 @@ TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer_SlowClockSkew)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
@@ -3900,6 +3936,8 @@ TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer_FastClockSkew)
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));
@@ -4092,6 +4130,8 @@ TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer_FastClockSkew_Veri
 
     clientInfoInternal.signalingClientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfoInternal.signalingClientInfo.loggingLevel = mLogLevel;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfoInternal.signalingClientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfoInternal.signalingClientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
 
     MEMSET(&channelInfo, 0x00, SIZEOF(ChannelInfo));

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -270,6 +270,8 @@ TEST_F(SignalingApiFunctionalityTest, basicCreateConnectFree)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, basicCreateWithRetries)
@@ -301,6 +303,8 @@ TEST_F(SignalingApiFunctionalityTest, basicCreateWithRetries)
     EXPECT_EQ(STATUS_NULL_ARG,
               createSignalingClientSync(&clientInfo, NULL, &signalingClientCallbacks, (PAwsCredentialProvider) mTestCredentialProvider,
                                         &signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, mockMaster)
@@ -442,6 +446,8 @@ TEST_F(SignalingApiFunctionalityTest, mockMaster)
     // Free again
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, mockViewer)
@@ -558,6 +564,8 @@ TEST_F(SignalingApiFunctionalityTest, mockViewer)
     // Free again
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
@@ -829,6 +837,8 @@ TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
@@ -916,6 +926,8 @@ TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedVariations)
@@ -1181,6 +1193,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedVariatio
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedVariations)
@@ -1448,6 +1462,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedVariations)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedAuthExpiration)
@@ -1571,6 +1587,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedAuthExpi
     EXPECT_EQ(STATUS_SIGNALING_ICE_CONFIG_REFRESH_FAILED, errStatus);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedAuthExpiration)
@@ -1697,6 +1715,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedAuthExpirat
     EXPECT_EQ(STATUS_SIGNALING_ICE_CONFIG_REFRESH_FAILED, errStatus);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaultInjectionRecovered)
@@ -1814,6 +1834,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultInjectionRecovered)
@@ -1933,6 +1955,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaultInjectionNotRecovered)
@@ -2048,6 +2072,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultInjectionNot1669)
@@ -2166,6 +2192,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithBadAuth)
@@ -2287,6 +2315,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithBadA
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithBadAuth)
@@ -2412,6 +2442,8 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithBadAuth
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
@@ -2498,6 +2530,8 @@ TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
@@ -2588,6 +2622,8 @@ TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, connectTimeoutEmulation)
@@ -2711,6 +2747,8 @@ TEST_F(SignalingApiFunctionalityTest, connectTimeoutEmulation)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, channelInfoArnSkipDescribe)
@@ -2845,6 +2883,8 @@ TEST_F(SignalingApiFunctionalityTest, channelInfoArnSkipDescribe)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedWithArn)
@@ -2979,6 +3019,8 @@ TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedWithArn)
     EXPECT_EQ(STATUS_SUCCESS, signalingClientDeleteSync(signalingHandle));
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedAuthExpiration)
@@ -3092,6 +3134,8 @@ TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedAuthExpiration)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, signalingClientDisconnectSyncVariations)
@@ -3136,6 +3180,8 @@ TEST_F(SignalingApiFunctionalityTest, signalingClientDisconnectSyncVariations)
     EXPECT_EQ(STATUS_SUCCESS, signalingClientSendMessageSync(mSignalingClientHandle, &message));
 
     deinitializeSignalingClient();
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, cachingWithFaultInjection)
@@ -3272,6 +3318,8 @@ TEST_F(SignalingApiFunctionalityTest, cachingWithFaultInjection)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, fileCachingTest)
@@ -3377,6 +3425,8 @@ TEST_F(SignalingApiFunctionalityTest, fileCachingTest)
     /* describeCount and getEndpointCount should only increase by 2 because they are cached for all channels except one and we iterate twice*/
     EXPECT_TRUE(describeCount > describeCountNoCache && (describeCount - describeCountNoCache) == 2);
     EXPECT_TRUE(getEndpointCount > getEndpointCountNoCache && (getEndpointCount - 2*getEndpointCountNoCache) == 2);
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, fileCachingUpdateCache)
@@ -3407,6 +3457,8 @@ TEST_F(SignalingApiFunctionalityTest, fileCachingUpdateCache)
     testEntry.creationTsEpochSeconds = GETTIME() / HUNDREDS_OF_NANOS_IN_A_SECOND;
     /* update first cache entry*/
     EXPECT_EQ(STATUS_SUCCESS, signalingCacheSaveToFile(&testEntry, DEFAULT_CACHE_FILE_PATH));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, fileCachingUpdateMultiChannelCache)
@@ -3478,6 +3530,8 @@ TEST_F(SignalingApiFunctionalityTest, fileCachingUpdateMultiChannelCache)
     MEMFREE(fileBuffer);
 
     FREMOVE(DEFAULT_CACHE_FILE_PATH);
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, fileCachingUpdateFullMultiChannelCache)
@@ -3531,6 +3585,8 @@ TEST_F(SignalingApiFunctionalityTest, fileCachingUpdateFullMultiChannelCache)
     EXPECT_EQ(0, STRCMP(testEntry.channelName, testChannel));
 
     FREMOVE(DEFAULT_CACHE_FILE_PATH);
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer)
@@ -3719,6 +3775,8 @@ TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer_SlowClockSkew)
@@ -3910,6 +3968,8 @@ TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer_SlowClockSkew)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 
@@ -4102,6 +4162,8 @@ TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer_FastClockSkew)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer_FastClockSkew_VerifyOffsetRemovedWhenClockFixed)
@@ -4321,6 +4383,8 @@ TEST_F(SignalingApiFunctionalityTest, receivingIceConfigOffer_FastClockSkew_Veri
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -239,6 +239,8 @@ TEST_F(SignalingApiFunctionalityTest, basicCreateConnectFree)
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
     clientInfo.cacheFilePath = NULL;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     clientInfo.signalingClientCreationMaxRetryAttempts = 0;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);
@@ -289,6 +291,8 @@ TEST_F(SignalingApiFunctionalityTest, basicCreateWithRetries)
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
     clientInfo.cacheFilePath = NULL;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     clientInfo.signalingClientCreationMaxRetryAttempts = 3;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);
@@ -329,6 +333,8 @@ TEST_F(SignalingApiFunctionalityTest, mockMaster)
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
     clientInfo.cacheFilePath = NULL;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     clientInfo.signalingClientCreationMaxRetryAttempts = 0;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);
@@ -469,6 +475,8 @@ TEST_F(SignalingApiFunctionalityTest, mockViewer)
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
     clientInfo.cacheFilePath = NULL;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     clientInfo.signalingClientCreationMaxRetryAttempts = 0;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_VIEWER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);
@@ -575,6 +583,8 @@ TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
     clientInfo.cacheFilePath = NULL;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     clientInfo.signalingClientCreationMaxRetryAttempts = 0;
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);
 
@@ -767,6 +777,8 @@ TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
 
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     clientInfo.signalingClientCreationMaxRetryAttempts = 0;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_VIEWER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);
@@ -839,6 +851,8 @@ TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
     clientInfo.cacheFilePath = NULL;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     clientInfo.signalingClientCreationMaxRetryAttempts = 0;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);
@@ -2400,6 +2414,8 @@ TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
     clientInfo.cacheFilePath = NULL;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);
 
@@ -2484,6 +2500,8 @@ TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
     clientInfo.version = SIGNALING_CLIENT_INFO_CURRENT_VERSION;
     clientInfo.loggingLevel = LOG_LEVEL_VERBOSE;
     clientInfo.cacheFilePath = NULL;
+    clientInfo.signalingMessagesMinimumThreads = 3;
+    clientInfo.signalingMessagesMaximumThreads = 5;
     clientInfo.signalingClientCreationMaxRetryAttempts = 0;
     STRCPY(clientInfo.clientId, TEST_SIGNALING_MASTER_CLIENT_ID);
     setupSignalingStateMachineRetryStrategyCallbacks(&clientInfo);

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -38,6 +38,8 @@ TEST_F(SignalingApiTest, createValidateChannelInfo)
     // Test default agent postfix
     EXPECT_PRED_FORMAT2(testing::IsSubstring, agentString, rChannelInfo->pUserAgent);
     freeChannelInfo(&rChannelInfo);
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingSendMessageSync)
@@ -81,6 +83,8 @@ TEST_F(SignalingApiTest, signalingSendMessageSync)
     EXPECT_EQ(expectedStatus, signalingClientSendMessageSync(mSignalingClientHandle, &signalingMessage));
 
     deinitializeSignalingClient();
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingSendMessageSyncFileCredsProvider)
@@ -138,6 +142,8 @@ TEST_F(SignalingApiTest, signalingSendMessageSyncFileCredsProvider)
     deinitializeSignalingClient();
 
     EXPECT_EQ(STATUS_SUCCESS, freeFileCredentialProvider(&pAwsCredentialProvider));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientConnectSync)
@@ -154,6 +160,8 @@ TEST_F(SignalingApiTest, signalingClientConnectSync)
     EXPECT_EQ(expectedStatus, signalingClientConnectSync(mSignalingClientHandle));
 
     deinitializeSignalingClient();
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientDeleteSync)
@@ -184,6 +192,8 @@ TEST_F(SignalingApiTest, signalingClientDeleteSync)
     EXPECT_EQ(expectedStatus, signalingClientSendMessageSync(mSignalingClientHandle, &signalingMessage));
 
     deinitializeSignalingClient();
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientGetIceConfigInfoCount)
@@ -204,6 +214,8 @@ TEST_F(SignalingApiTest, signalingClientGetIceConfigInfoCount)
     }
 
     deinitializeSignalingClient();
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientGetIceConfigInfo)
@@ -240,6 +252,8 @@ TEST_F(SignalingApiTest, signalingClientGetIceConfigInfo)
     }
 
     deinitializeSignalingClient();
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientGetCurrentState)
@@ -259,6 +273,8 @@ TEST_F(SignalingApiTest, signalingClientGetCurrentState)
     EXPECT_EQ(expectedState, state);
 
     deinitializeSignalingClient();
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientGetStateString)
@@ -270,11 +286,15 @@ TEST_F(SignalingApiTest, signalingClientGetStateString)
         EXPECT_EQ(STATUS_SUCCESS, signalingClientGetStateString((SIGNALING_CLIENT_STATE) i, &pStateStr));
         DLOGV("Iterating states \"%s\"", pStateStr);
     }
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientDisconnectSync)
 {
     EXPECT_NE(STATUS_SUCCESS, signalingClientDisconnectSync(INVALID_SIGNALING_CLIENT_HANDLE_VALUE));
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientGetMetrics)
@@ -365,6 +385,8 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_NE(0, metrics.signalingClientStats.dpApiCallLatency);
 
     deinitializeSignalingClient();
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
@@ -498,6 +520,8 @@ TEST_F(SignalingApiTest, signalingClientCreateWithClientInfoVariations)
 
     deinitializeSignalingClient();
     mClientInfo.cacheFilePath = NULL;
+    //wait for threads of threadpool to close
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
 } // namespace webrtcclient

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -95,7 +95,7 @@ class WebRtcClientTestBase : public ::testing::Test {
         mClientInfo.signalingRetryStrategyCallbacks.freeRetryStrategyFn = freeRetryStrategyFn;
         mClientInfo.signalingRetryStrategyCallbacks.executeRetryStrategyFn = executeRetryStrategyFn;
         mClientInfo.signalingClientCreationMaxRetryAttempts = 0;
-        mClientInfo.signalingMessagesMaximumThreads = 3;
+        mClientInfo.signalingMessagesMinimumThreads = 3;
         mClientInfo.signalingMessagesMaximumThreads = 5;
 
         MEMSET(&mChannelInfo, 0x00, SIZEOF(mChannelInfo));

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -112,7 +112,7 @@ class WebRtcClientTestBase : public ::testing::Test {
         mChannelInfo.reconnect = TRUE;
         mChannelInfo.pCertPath = mCaCertPath;
         mChannelInfo.messageTtl = TEST_SIGNALING_MESSAGE_TTL;
-        mChannelInfo.
+       
         if ((mChannelInfo.pRegion = getenv(DEFAULT_REGION_ENV_VAR)) == NULL) {
             mChannelInfo.pRegion = (PCHAR) TEST_DEFAULT_REGION;
         }

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -95,6 +95,8 @@ class WebRtcClientTestBase : public ::testing::Test {
         mClientInfo.signalingRetryStrategyCallbacks.freeRetryStrategyFn = freeRetryStrategyFn;
         mClientInfo.signalingRetryStrategyCallbacks.executeRetryStrategyFn = executeRetryStrategyFn;
         mClientInfo.signalingClientCreationMaxRetryAttempts = 0;
+        mClientInfo.signalingMessagesMaximumThreads = 3;
+        mClientInfo.signalingMessagesMaximumThreads = 5;
 
         MEMSET(&mChannelInfo, 0x00, SIZEOF(mChannelInfo));
         mChannelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
@@ -110,6 +112,7 @@ class WebRtcClientTestBase : public ::testing::Test {
         mChannelInfo.reconnect = TRUE;
         mChannelInfo.pCertPath = mCaCertPath;
         mChannelInfo.messageTtl = TEST_SIGNALING_MESSAGE_TTL;
+        mChannelInfo.
         if ((mChannelInfo.pRegion = getenv(DEFAULT_REGION_ENV_VAR)) == NULL) {
             mChannelInfo.pRegion = (PCHAR) TEST_DEFAULT_REGION;
         }

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -205,7 +205,5 @@ race:lwsListenerHandler
 # SUMMARY: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) (/home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/tst/webrtc_client_test+0x4668f6) in pthread_mutex_unlock
 # ==================
 # This is the expected behavior by the KVS Threadpool in pic
-race:threadpoolCreate
-race:threadpoolPush
-race:threadpoolFree
-race:IceAgentCandidateGatheringTest
+mutex:lock
+mutex:candidateList.lock

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -208,4 +208,4 @@ race:lwsListenerHandler
 race:threadpoolCreate
 race:threadpoolPush
 race:threadpoolFree
-race:pthread_mutex_unlock
+race:IceFunctionalityTest.IceAgentCandidateGatheringTest

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -205,4 +205,5 @@ race:lwsListenerHandler
 # SUMMARY: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) (/home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/tst/webrtc_client_test+0x4668f6) in pthread_mutex_unlock
 # ==================
 # This is the expected behavior by the KVS Threadpool in pic
-race:createSignalingClientSync
+race:threadpoolCreate
+race:threadpoolFree

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -205,6 +205,6 @@ race:lwsListenerHandler
 # SUMMARY: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) (/home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/tst/webrtc_client_test+0x4668f6) in pthread_mutex_unlock
 # ==================
 # This is the expected behavior by the KVS Threadpool in pic
-mutex:lock
-deadlock:createSignalingSync
-deadlock:iceServerConfigRefreshConnectedAuthExpiration
+#mutex:lock
+#deadlock:createSignalingSync
+#deadlock:iceServerConfigRefreshConnectedAuthExpiration

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -206,5 +206,5 @@ race:lwsListenerHandler
 # ==================
 # This is the expected behavior by the KVS Threadpool in pic
 mutex:lock
-
+deadlock:createSignalingSync
 deadlock:iceServerConfigRefreshConnectedAuthExpiration

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -208,4 +208,4 @@ race:lwsListenerHandler
 race:threadpoolCreate
 race:threadpoolPush
 race:threadpoolFree
-race:IceFunctionalityTest.IceAgentCandidateGatheringTest
+race:IceAgentCandidateGatheringTest

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -206,3 +206,5 @@ race:lwsListenerHandler
 # ==================
 # This is the expected behavior by the KVS Threadpool in pic
 mutex:lock
+
+deadlock:iceServerConfigRefreshConnectedAuthExpiration

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -205,4 +205,4 @@ race:lwsListenerHandler
 # SUMMARY: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) (/home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/tst/webrtc_client_test+0x4668f6) in pthread_mutex_unlock
 # ==================
 # This is the expected behavior by the KVS Threadpool in pic
-mutex:candidateList.lock
+mutex:lock

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -206,4 +206,5 @@ race:lwsListenerHandler
 # ==================
 # This is the expected behavior by the KVS Threadpool in pic
 race:threadpoolCreate
+race:threadpoolPush
 race:threadpoolFree

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -208,3 +208,4 @@ race:lwsListenerHandler
 race:threadpoolCreate
 race:threadpoolPush
 race:threadpoolFree
+race:pthread_mutex_unlock

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -205,5 +205,4 @@ race:lwsListenerHandler
 # SUMMARY: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) (/home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/tst/webrtc_client_test+0x4668f6) in pthread_mutex_unlock
 # ==================
 # This is the expected behavior by the KVS Threadpool in pic
-mutex:lock
 mutex:candidateList.lock

--- a/tst/suppressions/TSAN.supp
+++ b/tst/suppressions/TSAN.supp
@@ -177,34 +177,3 @@ deadlock:com::amazonaws::kinesis::video::webrtcclient::DtlsFunctionalityTest::cr
 deadlock:lwsListenerHandler
 deadlock:connectSignalingChannelLws
 race:lwsListenerHandler
-
-# ==================
-# WARNING: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) (pid=17000)
-#     #0 pthread_mutex_unlock <null> (webrtc_client_test+0x4668f6)
-#     #1 defaultUnlockMutex <null> (libkvsWebrtcClient.so+0x9dd94)
-# 
-#   Location is heap block of size 48 at 0x7b0c00001a70 allocated by main thread:
-#     #0 calloc <null> (webrtc_client_test+0x447d50)
-#     #1 defaultMemCalloc <null> (libkvsWebrtcClient.so+0x99fdc)
-#     #2 createSignalingClientSync /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Signaling/Client.c:83:21 (libkvsWebrtcSignalingClient.so+0xed0b)
-# 2023-09-13 23:48:26.175 ERROR   timerQueue
-#     #3 com::amazonaws::kinesis::video::webrtcclient::WebRtcClientTestBase::initializeSignalingClient(__AwsCredentialProvider*) /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/WebRTCClientTestFixture.h:127:21 (webrtc_client_test+0x53d564)
-#     #4 com::amazonaws::kinesis::video::webrtcclient::IceFunctionalityTest_IceAgentCandidateGatheringTest_Test::TestBody() /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/IceFunctionalityTest.cpp:665:5 (webrtc_client_test+0x53a313)
-#     #5 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (webrtc_client_test+0x767253)
-#     #6 main /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/main.cpp:68:14 (webrtc_client_test+0x714b55)
-# 
-#   Mutex M1128 (0x7b0c00001a78) created at:
-#     #0 pthread_mutex_init <null> (webrtc_client_test+0x44a91d)
-#     #1 defaultCreateMutex <null> (libkvsWebrtcClient.so+0x9dd05)
-#     #2 createSignalingClientSync /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Signaling/Client.c:83:21 (libkvsWebrtcSignalingClient.so+0xed0b)
-#     #3 com::amazonaws::kinesis::video::webrtcclient::WebRtcClientTestBase::initializeSignalingClient(__AwsCredentialProvider*) /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/WebRTCClientTestFixture.h:127:21 (webrtc_client_test+0x53d564)
-#     #4 com::amazonaws::kinesis::video::webrtcclient::IceFunctionalityTest_IceAgentCandidateGatheringTest_Test::TestBody() /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/IceFunctionalityTest.cpp:665:5 (webrtc_client_test+0x53a313)
-#     #5 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (webrtc_client_test+0x767253)
-#     #6 main /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/main.cpp:68:14 (webrtc_client_test+0x714b55)
-# 
-# SUMMARY: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread) (/home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/tst/webrtc_client_test+0x4668f6) in pthread_mutex_unlock
-# ==================
-# This is the expected behavior by the KVS Threadpool in pic
-#mutex:lock
-#deadlock:createSignalingSync
-#deadlock:iceServerConfigRefreshConnectedAuthExpiration


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1803
Additionally, previously the `KVS_SIGNALING_THREADPOOL` was not enabled due to the `#define` being in a different file. This fix makes sure that the threadpool is enabled and disabled correctly. This also fixes all the tests by adding missing initializations for min and max number of threads.

*What was changed?*
A new CMake flag `ENABLE_KVS_THREADPOOL` is available to configure this feature from the CMake

*Why was it changed?*
We do not have a way to configure this feature from CMake as correctly pointed out by the customer in the issue

*How was it changed?*
Created a new CMake flag `ENABLE_KVS_THREADPOOL` and passed it to use in the SDK with `add_definitions`

*What testing was done for the changes?*
Manually tested by adding logs to the block of code being enabled and disabled and made sure that the flag was operational in doing so

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
