### PR TITLE
Add a=ice-options:trickle to session level of SDP as viewer

### DIFF
--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -78,6 +78,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     MEMSET(&offerSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
 
+    offerSessionDescriptionInit.useTrickleIce = pSampleStreamingSession->remoteCanTrickleIce;
     CHK_STATUS(setLocalDescription(pSampleStreamingSession->pPeerConnection, &offerSessionDescriptionInit));
     DLOGI("[KVS Viewer] Completed setting local description");
 

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1206,6 +1206,7 @@ typedef struct {
  */
 typedef struct {
     SDP_TYPE type;                                      //!< Indicates an offer/answer SDP type
+    BOOL useTrickleIce;                                 //!< Indicates if an offer should set trickle ice
     CHAR sdp[MAX_SESSION_DESCRIPTION_INIT_SDP_LEN + 1]; //!< SDP Data containing media capabilities, transport addresses
                                                         //!< and related metadata in a transport agnostic manner
                                                         //!<

--- a/src/source/Ice/IceUtils.c
+++ b/src/source/Ice/IceUtils.c
@@ -131,6 +131,8 @@ STATUS iceUtilsGenerateTransactionId(PBYTE pBuffer, UINT32 bufferLen)
 
 CleanUp:
 
+    CHK_LOG_ERR(retStatus);
+
     return retStatus;
 }
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -187,7 +187,7 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
     CHK(pKvsPeerConnection != NULL && pBuffer != NULL, STATUS_NULL_ARG);
     CHK(bufferLen >= MIN_HEADER_LENGTH, STATUS_INVALID_ARG);
 
-    ssrc = getInt32(*(PUINT32)(pBuffer + SSRC_OFFSET));
+    ssrc = getInt32(*(PUINT32) (pBuffer + SSRC_OFFSET));
 
     CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
     while (pCurNode != NULL) {
@@ -332,7 +332,7 @@ STATUS onFrameReadyFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex, U
     CHK(pPacket != NULL, STATUS_NULL_ARG);
     MUTEX_LOCK(pTransceiver->statsLock);
     // https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferdelay
-    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE)(GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
+    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE) (GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
     index = pTransceiver->inboundStats.jitterBufferEmittedCount;
     pTransceiver->inboundStats.jitterBufferEmittedCount++;
     if (MEDIA_STREAM_TRACK_KIND_VIDEO == pTransceiver->transceiver.receiver.track.kind) {
@@ -342,7 +342,7 @@ STATUS onFrameReadyFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex, U
 
     if (frameSize > pTransceiver->peerFrameBufferSize) {
         MEMFREE(pTransceiver->peerFrameBuffer);
-        pTransceiver->peerFrameBufferSize = (UINT32)(frameSize * PEER_FRAME_BUFFER_SIZE_INCREMENT_FACTOR);
+        pTransceiver->peerFrameBufferSize = (UINT32) (frameSize * PEER_FRAME_BUFFER_SIZE_INCREMENT_FACTOR);
         pTransceiver->peerFrameBuffer = (PBYTE) MEMALLOC(pTransceiver->peerFrameBufferSize);
         CHK(pTransceiver->peerFrameBuffer != NULL, STATUS_NOT_ENOUGH_MEMORY);
     }
@@ -386,7 +386,7 @@ STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex,
     CHK(pPacket != NULL, STATUS_NULL_ARG);
     MUTEX_LOCK(pTransceiver->statsLock);
     // https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferdelay
-    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE)(GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
+    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE) (GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
     pTransceiver->inboundStats.jitterBufferEmittedCount++;
     pTransceiver->inboundStats.received.framesDropped++;
     pTransceiver->inboundStats.received.fullFramesLost++;

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -187,7 +187,7 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
     CHK(pKvsPeerConnection != NULL && pBuffer != NULL, STATUS_NULL_ARG);
     CHK(bufferLen >= MIN_HEADER_LENGTH, STATUS_INVALID_ARG);
 
-    ssrc = getInt32(*(PUINT32) (pBuffer + SSRC_OFFSET));
+    ssrc = getInt32(*(PUINT32)(pBuffer + SSRC_OFFSET));
 
     CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
     while (pCurNode != NULL) {
@@ -332,7 +332,7 @@ STATUS onFrameReadyFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex, U
     CHK(pPacket != NULL, STATUS_NULL_ARG);
     MUTEX_LOCK(pTransceiver->statsLock);
     // https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferdelay
-    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE) (GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
+    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE)(GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
     index = pTransceiver->inboundStats.jitterBufferEmittedCount;
     pTransceiver->inboundStats.jitterBufferEmittedCount++;
     if (MEDIA_STREAM_TRACK_KIND_VIDEO == pTransceiver->transceiver.receiver.track.kind) {
@@ -342,7 +342,7 @@ STATUS onFrameReadyFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex, U
 
     if (frameSize > pTransceiver->peerFrameBufferSize) {
         MEMFREE(pTransceiver->peerFrameBuffer);
-        pTransceiver->peerFrameBufferSize = (UINT32) (frameSize * PEER_FRAME_BUFFER_SIZE_INCREMENT_FACTOR);
+        pTransceiver->peerFrameBufferSize = (UINT32)(frameSize * PEER_FRAME_BUFFER_SIZE_INCREMENT_FACTOR);
         pTransceiver->peerFrameBuffer = (PBYTE) MEMALLOC(pTransceiver->peerFrameBufferSize);
         CHK(pTransceiver->peerFrameBuffer != NULL, STATUS_NOT_ENOUGH_MEMORY);
     }
@@ -386,7 +386,7 @@ STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex,
     CHK(pPacket != NULL, STATUS_NULL_ARG);
     MUTEX_LOCK(pTransceiver->statsLock);
     // https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferdelay
-    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE) (GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
+    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE)(GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
     pTransceiver->inboundStats.jitterBufferEmittedCount++;
     pTransceiver->inboundStats.received.framesDropped++;
     pTransceiver->inboundStats.received.fullFramesLost++;
@@ -1166,6 +1166,9 @@ STATUS createOffer(PRtcPeerConnection pPeerConnection, PRtcSessionDescriptionIni
     CHK(NULL != (pSessionDescription = (PSessionDescription) MEMCALLOC(1, SIZEOF(SessionDescription))), STATUS_NOT_ENOUGH_MEMORY);
     pSessionDescriptionInit->type = SDP_TYPE_OFFER;
     pKvsPeerConnection->isOffer = TRUE;
+    if (pSessionDescriptionInit->useTrickleIce) {
+        NULLABLE_SET_VALUE(pKvsPeerConnection->canTrickleIce, TRUE);
+    }
 
 #ifdef ENABLE_DATA_CHANNEL
     pKvsPeerConnection->sctpIsEnabled = TRUE;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -23,8 +23,8 @@ STATUS serializeSessionDescriptionInit(PRtcSessionDescriptionInit pSessionDescri
     curr = pSessionDescriptionInit->sdp;
     tail = pSessionDescriptionInit->sdp + STRLEN(pSessionDescriptionInit->sdp);
 
-    while ((next = STRNCHR(curr, (UINT32)(tail - curr), '\n')) != NULL) {
-        lineLen = (UINT32)(next - curr);
+    while ((next = STRNCHR(curr, (UINT32) (tail - curr), '\n')) != NULL) {
+        lineLen = (UINT32) (next - curr);
 
         if (lineLen > 0 && curr[lineLen - 1] == '\r') {
             lineLen--;
@@ -95,7 +95,7 @@ STATUS deserializeSessionDescriptionInit(PCHAR sessionDescriptionJSON, UINT32 se
             //     \r becomes '\' and 'r'
             //     \n becomes '\' and 'n'
             while ((next = STRNSTR(curr, SESSION_DESCRIPTION_INIT_LINE_ENDING_WITHOUT_CR, tail - curr)) != NULL) {
-                lineLen = (INT32)(next - curr);
+                lineLen = (INT32) (next - curr);
 
                 // Check if the SDP format is using \r\n or \n separator.
                 // There are escape characters before \n and \r, so we need to move back 1 more character
@@ -231,7 +231,7 @@ STATUS setPayloadTypesFromOffer(PHashTable codecTable, PHashTable rtxTable, PSes
                 CHK_STATUS(STRTOUI64(end + STRLEN(RTX_CODEC_VALUE), NULL, 10, &parsedPayloadType));
                 if ((end = STRSTR(attributeValue, FMTP_VALUE)) != NULL) {
                     CHK_STATUS(STRTOUI64(end + STRLEN(FMTP_VALUE), NULL, 10, &fmtpVal));
-                    aptFmtpVals[aptFmtpValCount++] = (UINT32)((fmtpVal << 8u) & parsedPayloadType);
+                    aptFmtpVals[aptFmtpValCount++] = (UINT32) ((fmtpVal << 8u) & parsedPayloadType);
                 }
             }
         }

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -23,8 +23,8 @@ STATUS serializeSessionDescriptionInit(PRtcSessionDescriptionInit pSessionDescri
     curr = pSessionDescriptionInit->sdp;
     tail = pSessionDescriptionInit->sdp + STRLEN(pSessionDescriptionInit->sdp);
 
-    while ((next = STRNCHR(curr, (UINT32) (tail - curr), '\n')) != NULL) {
-        lineLen = (UINT32) (next - curr);
+    while ((next = STRNCHR(curr, (UINT32)(tail - curr), '\n')) != NULL) {
+        lineLen = (UINT32)(next - curr);
 
         if (lineLen > 0 && curr[lineLen - 1] == '\r') {
             lineLen--;
@@ -95,7 +95,7 @@ STATUS deserializeSessionDescriptionInit(PCHAR sessionDescriptionJSON, UINT32 se
             //     \r becomes '\' and 'r'
             //     \n becomes '\' and 'n'
             while ((next = STRNSTR(curr, SESSION_DESCRIPTION_INIT_LINE_ENDING_WITHOUT_CR, tail - curr)) != NULL) {
-                lineLen = (INT32) (next - curr);
+                lineLen = (INT32)(next - curr);
 
                 // Check if the SDP format is using \r\n or \n separator.
                 // There are escape characters before \n and \r, so we need to move back 1 more character
@@ -231,7 +231,7 @@ STATUS setPayloadTypesFromOffer(PHashTable codecTable, PHashTable rtxTable, PSes
                 CHK_STATUS(STRTOUI64(end + STRLEN(RTX_CODEC_VALUE), NULL, 10, &parsedPayloadType));
                 if ((end = STRSTR(attributeValue, FMTP_VALUE)) != NULL) {
                     CHK_STATUS(STRTOUI64(end + STRLEN(FMTP_VALUE), NULL, 10, &fmtpVal));
-                    aptFmtpVals[aptFmtpValCount++] = (UINT32) ((fmtpVal << 8u) & parsedPayloadType);
+                    aptFmtpVals[aptFmtpValCount++] = (UINT32)((fmtpVal << 8u) & parsedPayloadType);
                 }
             }
         }
@@ -877,6 +877,13 @@ STATUS populateSessionDescription(PKvsPeerConnection pKvsPeerConnection, PSessio
 
     STRCPY(pLocalSessionDescription->sdpAttributes[0].attributeName, "group");
     STRCPY(pLocalSessionDescription->sdpAttributes[0].attributeValue, BUNDLE_KEY);
+    pLocalSessionDescription->sessionAttributesCount++;
+
+    if (pKvsPeerConnection->canTrickleIce.value) {
+        STRCPY(pLocalSessionDescription->sdpAttributes[pLocalSessionDescription->sessionAttributesCount].attributeName, "ice-options");
+        STRCPY(pLocalSessionDescription->sdpAttributes[pLocalSessionDescription->sessionAttributesCount].attributeValue, "trickle");
+        pLocalSessionDescription->sessionAttributesCount++;
+    }
 
     // check all session attribute lines to see if a line with BUNDLE is present. If it is present, copy its content and break
     for (i = 0; i < pRemoteSessionDescription->sessionAttributesCount; i++) {
@@ -908,7 +915,6 @@ STATUS populateSessionDescription(PKvsPeerConnection pKvsPeerConnection, PSessio
         STRCPY(pLocalSessionDescription->mediaDescriptions[i].sdpConnectionInformation.addressType, "IP4");
         STRCPY(pLocalSessionDescription->mediaDescriptions[i].sdpConnectionInformation.connectionAddress, "127.0.0.1");
     }
-    pLocalSessionDescription->sessionAttributesCount++;
 
     STRCPY(pLocalSessionDescription->sdpAttributes[pLocalSessionDescription->sessionAttributesCount].attributeName, "msid-semantic");
     STRCPY(pLocalSessionDescription->sdpAttributes[pLocalSessionDescription->sessionAttributesCount].attributeValue, " WMS myKvsVideoStream");

--- a/src/source/Stun/Stun.c
+++ b/src/source/Stun/Stun.c
@@ -1215,6 +1215,8 @@ STATUS getStunAttribute(PStunPacket pStunPacket, STUN_ATTRIBUTE_TYPE attributeTy
 
 CleanUp:
 
+    CHK_LOG_ERR(retStatus);
+
     if (ppStunAttribute != NULL) {
         *ppStunAttribute = pTargetAttribute;
     }

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -1163,6 +1163,36 @@ TEST_F(SdpApiTest, noMediaTrickleIce) {
     freePeerConnection(&answerPc);
 }
 
+TEST_F(SdpApiTest, noMediaTrickleIceNegativeCase) {
+    PRtcPeerConnection offerPc = NULL;
+    PRtcPeerConnection answerPc = NULL;
+    RtcConfiguration configurationOffer;
+    RtcConfiguration configurationAnswer;
+    RtcSessionDescriptionInit sessionDescriptionInitViewer;
+    RtcSessionDescriptionInit sessionDescriptionInitMaster;
+
+    MEMSET(&configurationOffer, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&configurationAnswer, 0x00, SIZEOF(RtcConfiguration));
+
+    // Create peer connection
+    EXPECT_EQ(createPeerConnection(&configurationOffer, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configurationAnswer, &answerPc), STATUS_SUCCESS);
+
+    sessionDescriptionInitViewer.useTrickleIce = FALSE;
+
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInitViewer));
+    STRCPY(sessionDescriptionInitMaster.sdp, sessionDescriptionInitViewer.sdp);
+    sessionDescriptionInitMaster.type = SDP_TYPE_OFFER;
+    EXPECT_EQ(setRemoteDescription(answerPc, &sessionDescriptionInitMaster), STATUS_SUCCESS);
+    EXPECT_EQ(FALSE, canTrickleIceCandidates(answerPc).value);
+
+    closePeerConnection(offerPc);
+    freePeerConnection(&offerPc);
+
+    closePeerConnection(answerPc);
+    freePeerConnection(&answerPc);
+}
+
 TEST_F(SdpApiTest, answerMlinesOrderSameAsOfferMLinesOrder)
 {
     auto offer = std::string(R"(v=0

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -1133,6 +1133,36 @@ a=ice-options:trickle
     });
 }
 
+TEST_F(SdpApiTest, noMediaTrickleIce) {
+    PRtcPeerConnection offerPc = NULL;
+    PRtcPeerConnection answerPc = NULL;
+    RtcConfiguration configurationOffer;
+    RtcConfiguration configurationAnswer;
+    RtcSessionDescriptionInit sessionDescriptionInitViewer;
+    RtcSessionDescriptionInit sessionDescriptionInitMaster;
+
+    MEMSET(&configurationOffer, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&configurationAnswer, 0x00, SIZEOF(RtcConfiguration));
+
+    // Create peer connection
+    EXPECT_EQ(createPeerConnection(&configurationOffer, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configurationAnswer, &answerPc), STATUS_SUCCESS);
+
+    sessionDescriptionInitViewer.useTrickleIce = TRUE;
+
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInitViewer));
+    STRCPY(sessionDescriptionInitMaster.sdp, sessionDescriptionInitViewer.sdp);
+    sessionDescriptionInitMaster.type = SDP_TYPE_OFFER;
+    EXPECT_EQ(setRemoteDescription(answerPc, &sessionDescriptionInitMaster), STATUS_SUCCESS);
+    EXPECT_EQ(TRUE, canTrickleIceCandidates(answerPc).value);
+
+    closePeerConnection(offerPc);
+    freePeerConnection(&offerPc);
+
+    closePeerConnection(answerPc);
+    freePeerConnection(&answerPc);
+}
+
 TEST_F(SdpApiTest, answerMlinesOrderSameAsOfferMLinesOrder)
 {
     auto offer = std::string(R"(v=0


### PR DESCRIPTION
*What was changed?*
Viewer will now add trickle ice to the session level of the SDP.
Changed the SDPinit struct to include this flag, and changed the viewer sample to set it.

*Why was it changed?*
In cases where a media was not specified (data channel only) trickle ice was not being sent.

*How was it changed?*
Added a check for canTrickle flag in peerconncetion when setting the session description. This flag is set when creating the offer by checking the SDPInit struct.

*What testing was done for the changes?*
Added an SDPApi test that checks this value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
