### PR TITLE
Allow using channel names different than the thing name

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,13 +260,13 @@ Then choose Start Viewer to start live video streaming of the sample H264/Opus f
             "kinesisvideo:GetIceServerConfig",
             "kinesisvideo:ConnectAsMaster"
           ],
-          "Resource":"arn:aws:kinesisvideo:*:*:channel/${credentials-iot:ThingName}/*"
+          "Resource":"arn:aws:kinesisvideo:*:*:channel/*/*"
       }
    ]
 }
 ```
 
-Note: "kinesisvideo:CreateSignalingChannel" can be removed if you are running with existing KVS signaling channels. Viewer sample requires "kinesisvideo:ConnectAsViewer" permission. Integration test requires both "kinesisvideo:ConnectAsViewer" and "kinesisvideo:DeleteSignalingChannel" permission.
+Note: "kinesisvideo:CreateSignalingChannel" can be removed if you are running with existing KVS signaling channels. Viewer sample requires "kinesisvideo:ConnectAsViewer" permission. Integration test requires both "kinesisvideo:ConnectAsViewer" and "kinesisvideo:DeleteSignalingChannel" permission. The resource allows accessing any KVS signaling channel. It might be set to "arn:aws:kinesisvideo:*:*:channel/${credentials-iot:ThingName}/*", in order to allow the IoT thing to access only to the signaling channel which has the same name with the IoT thing.
 
 * With the IoT certificate, IoT credentials provider endpoint (Note: it is not the endpoint on IoT AWS Console!), public key and private key ready, you can replace the static credentials provider createStaticCredentialProvider() and freeStaticCredentialProvider() with IoT credentials provider like below, the credentials provider for [samples](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/samples/Common.c) is in createSampleConfiguration():
 
@@ -277,7 +277,7 @@ createLwsIotCredentialProvider(
             "/Users/username/Downloads/iot-signaling/private.pem.key", // path to iot private key
             "/Users/username/Downloads/iot-signaling/cacert.pem", // path to CA cert
             "KinesisVideoSignalingCameraIoTRoleAlias", // IoT role alias
-            channelName, // iot thing name, recommended to be same as your channel name
+            "IoTThingName", // iot thing name
             &pSampleConfiguration->pCredentialProvider));
 
 freeIotCredentialProvider(&pSampleConfiguration->pCredentialProvider);

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -747,12 +747,13 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
     CHK(NULL != (pSampleConfiguration = (PSampleConfiguration) MEMCALLOC(1, SIZEOF(SampleConfiguration))), STATUS_NOT_ENOUGH_MEMORY);
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    PCHAR pIotCoreCredentialEndPoint, pIotCoreCert, pIotCorePrivateKey, pIotCoreRoleAlias, pIotCoreCertificateId;
+    PCHAR pIotCoreCredentialEndPoint, pIotCoreCert, pIotCorePrivateKey, pIotCoreRoleAlias, pIotCoreCertificateId, pIotCoreThingName;
     CHK_ERR((pIotCoreCredentialEndPoint = getenv(IOT_CORE_CREDENTIAL_ENDPOINT)) != NULL, STATUS_INVALID_OPERATION,
             "AWS_IOT_CORE_CREDENTIAL_ENDPOINT must be set");
     CHK_ERR((pIotCoreCert = getenv(IOT_CORE_CERT)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_CERT must be set");
     CHK_ERR((pIotCorePrivateKey = getenv(IOT_CORE_PRIVATE_KEY)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_PRIVATE_KEY must be set");
     CHK_ERR((pIotCoreRoleAlias = getenv(IOT_CORE_ROLE_ALIAS)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_ROLE_ALIAS must be set");
+    CHK_ERR((pIotCoreThingName = getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
 #else
     CHK_ERR((pAccessKey = getenv(ACCESS_KEY_ENV_VAR)) != NULL, STATUS_INVALID_OPERATION, "AWS_ACCESS_KEY_ID must be set");
     CHK_ERR((pSecretKey = getenv(SECRET_KEY_ENV_VAR)) != NULL, STATUS_INVALID_OPERATION, "AWS_SECRET_ACCESS_KEY must be set");
@@ -790,7 +791,7 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
     CHK_STATUS(createLwsIotCredentialProvider(pIotCoreCredentialEndPoint, pIotCoreCert, pIotCorePrivateKey, pSampleConfiguration->pCaCertPath,
-                                              pIotCoreRoleAlias, channelName, &pSampleConfiguration->pCredentialProvider));
+                                              pIotCoreRoleAlias, pIotCoreThingName, &pSampleConfiguration->pCredentialProvider));
 #else
     CHK_STATUS(
         createStaticCredentialProvider(pAccessKey, 0, pSecretKey, 0, pSessionToken, 0, MAX_UINT64, &pSampleConfiguration->pCredentialProvider));

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -18,11 +18,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     signal(SIGINT, sigintHandler);
 #endif
 
-#ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_ERR((pChannelName = getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
-#else
     pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
-#endif
 
     CHK_STATUS(createSampleConfiguration(pChannelName, SIGNALING_CHANNEL_ROLE_TYPE_MASTER, TRUE, TRUE, logLevel, &pSampleConfiguration));
 

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -50,11 +50,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     signal(SIGINT, sigintHandler);
 #endif
 
-#ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_ERR((pChannelName = getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
-#else
     pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
-#endif
 
     CHK_STATUS(createSampleConfiguration(pChannelName, SIGNALING_CHANNEL_ROLE_TYPE_VIEWER, TRUE, TRUE, logLevel, &pSampleConfiguration));
 

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -395,11 +395,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     signal(SIGINT, sigintHandler);
 
-#ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_ERR((pChannelName = getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
-#else
     pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
-#endif
 
     CHK_STATUS(createSampleConfiguration(pChannelName, SIGNALING_CHANNEL_ROLE_TYPE_MASTER, TRUE, TRUE, logLevel, &pSampleConfiguration));
 

--- a/scripts/generate-iot-credential.sh
+++ b/scripts/generate-iot-credential.sh
@@ -50,7 +50,7 @@ echo '{
                 "kinesisvideo:ConnectAsMaster",
                 "kinesisvideo:ConnectAsViewer"
             ],
-            "Resource": "arn:aws:kinesisvideo:*:*:channel/${credentials-iot:ThingName}/*"
+            "Resource": "arn:aws:kinesisvideo:*:*:channel/*/*"
         }
     ]
 }' > iam-permission-document.json


### PR DESCRIPTION
*Issue #, if available:* [#1818](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1818)

*What was changed?*
The sample code has been modified to allow using signaling channel names different than the thing name when using IoT credentials. There are also modifications in the scripts/generate-iot-credential.sh and README.md files to allow using any channel name.

*How was it changed?*
When calling createLwsIotCredentialProvider, pIotCoreThingName is set as the thingName instead of channelName. pIotCoreThingName is set by using AWS_IOT_CORE_THING_NAME environment variable which is set by the generate-iot-credential.sh script. The IAM role generated by the script allows any signaling channel (arn:aws:kinesisvideo:*:*:channel/*/*). README file has been modified to explain how to limit the access to thing name, if necessary.

*What testing was done for the changes?*
The samples have been built and run in KVS successfully. I used generate-iot-credentials.sh script to generate the credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
