### PR TITLE
Dtls handshake process optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - dtls-handshake-improvement
   pull_request:
     branches:
       - develop
@@ -170,7 +171,7 @@ jobs:
   undefined-behavior-sanitizer:
     runs-on: ubuntu-20.04
     env:
-      UBSAN_OPTIONS: halt_on_error=1
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
       CC: clang
       CXX: clang++
       AWS_KVS_LOG_LEVEL: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - master
-      - dtls-handshake-improvement
   pull_request:
     branches:
       - develop

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -19,7 +19,8 @@ INT32 main(INT32 argc, CHAR* argv[])
 #endif
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_ERR((pChannelName = argc > 1 ? argv[1] : getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
+    CHK_ERR((pChannelName = argc > 1 ? argv[1] : getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION,
+            "AWS_IOT_CORE_THING_NAME must be set");
 #else
     pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
 #endif

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -51,7 +51,8 @@ INT32 main(INT32 argc, CHAR* argv[])
 #endif
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_ERR((pChannelName = argc > 1 ? argv[1] : getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
+    CHK_ERR((pChannelName = argc > 1 ? argv[1] : getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION,
+            "AWS_IOT_CORE_THING_NAME must be set");
 #else
     pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
 #endif

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -396,7 +396,8 @@ INT32 main(INT32 argc, CHAR* argv[])
     signal(SIGINT, sigintHandler);
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS
-    CHK_ERR((pChannelName = argc > 1 ? argv[1] : getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION, "AWS_IOT_CORE_THING_NAME must be set");
+    CHK_ERR((pChannelName = argc > 1 ? argv[1] : getenv(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION,
+            "AWS_IOT_CORE_THING_NAME must be set");
 #else
     pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
 #endif

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -191,7 +191,7 @@ extern "C" {
 #define STATUS_SSL_PACKET_BEFORE_DTLS_READY               STATUS_DTLS_BASE + 0x00000004
 #define STATUS_SSL_UNKNOWN_SRTP_PROFILE                   STATUS_DTLS_BASE + 0x00000005
 #define STATUS_SSL_INVALID_CERTIFICATE_BITS               STATUS_DTLS_BASE + 0x00000006
-
+#define STATUS_DTLS_SESSION_ALREADY_FREED                 STATUS_DTLS_BASE + 0x00000007
 /*!@} */
 
 /////////////////////////////////////////////////////

--- a/src/source/Crypto/Dtls.h
+++ b/src/source/Crypto/Dtls.h
@@ -43,6 +43,13 @@ typedef enum {
     RTC_DTLS_TRANSPORT_STATE_FAILED,     /* The transport has failed as the result of an error */
 } RTC_DTLS_TRANSPORT_STATE;
 
+typedef enum {
+    DTLS_STATE_HANDSHAKE_NEW,
+    DTLS_STATE_HANDSHAKE_IN_PROGRESS,
+    DTLS_STATE_HANDSHAKE_COMPLETED,
+    DTLS_STATE_HANDSHAKE_ERROR,
+} DTLS_HANDSHAKE_STATE;
+
 /* Callback that is fired when Dtls Server wishes to send packet */
 typedef VOID (*DtlsSessionOutboundPacketFunc)(UINT64, PBYTE, UINT32);
 
@@ -98,7 +105,8 @@ typedef struct {
 typedef struct __DtlsSession DtlsSession, *PDtlsSession;
 struct __DtlsSession {
     volatile ATOMIC_BOOL isStarted;
-    volatile ATOMIC_BOOL shutdown;
+    volatile ATOMIC_BOOL isShutdown;
+    volatile ATOMIC_BOOL isCleanUp;
     UINT32 certificateCount;
     DtlsSessionCallbacks dtlsSessionCallbacks;
     TIMER_QUEUE_HANDLE timerQueueHandle;
@@ -106,10 +114,13 @@ struct __DtlsSession {
     UINT64 dtlsSessionStartTime;
     UINT64 dtlsSessionSetupTime;
     RTC_DTLS_TRANSPORT_STATE state;
+    DTLS_HANDSHAKE_STATE handshakeState;
     MUTEX sslLock;
 
 #ifdef KVS_USE_OPENSSL
     volatile ATOMIC_BOOL sslInitFinished;
+    volatile SIZE_T objRefCount;
+    CVAR receivePacketCvar;
     // dtls message must fit into a UDP packet
     BYTE outgoingDataBuffer[MAX_UDP_PACKET_SIZE];
     UINT32 outgoingDataLen;
@@ -168,6 +179,7 @@ STATUS dtlsSessionShutdown(PDtlsSession);
 
 STATUS dtlsSessionOnOutBoundData(PDtlsSession, UINT64, DtlsSessionOutboundPacketFunc);
 STATUS dtlsSessionOnStateChange(PDtlsSession, UINT64, DtlsSessionOnStateChange);
+STATUS dtlsSessionHandshakeInThread(PDtlsSession, BOOL);
 
 /******** Internal Functions **********/
 STATUS dtlsValidateRtcCertificates(PRtcCertificate, PUINT32);

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -248,6 +248,12 @@ INT32 dtlsSessionKeyDerivationCallback(PVOID customData, const unsigned char* pM
     return 0;
 }
 
+STATUS dtlsSessionHandshakeInThread(PDtlsSession pDtlsSession, BOOL isServer)
+{
+    DLOGI("Threadpool based DTLS handshake not supported for mbedtls");
+    return STATUS_SUCCESS;
+}
+
 STATUS dtlsSessionStart(PDtlsSession pDtlsSession, BOOL isServer)
 {
     ENTERS();

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -983,7 +983,6 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
 #ifdef ENABLE_DATA_CHANNEL
     CHK_LOG_ERR(freeSctpSession(&pKvsPeerConnection->pSctpSession));
 #endif
-    CHK_LOG_ERR(freeIceAgent(&pKvsPeerConnection->pIceAgent));
 
     // free transceivers
     CHK_LOG_ERR(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -439,7 +439,11 @@ CleanUp:
 PVOID dtlsSessionStartThread(PVOID args)
 {
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) args;
-    dtlsSessionHandshakeInThread(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->dtlsIsServer);
+    if (pKvsPeerConnection != NULL) {
+        dtlsSessionHandshakeInThread(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->dtlsIsServer);
+    } else {
+        DLOGE("Peer connection object NULL, cannot start DTLS handshake");
+    }
     return NULL;
 }
 
@@ -496,12 +500,8 @@ VOID onIceConnectionStateChange(UINT64 customData, UINT64 connectionState)
             // wait until DTLS state changes to CONNECTED.
             //
             // Reference: https://w3c.github.io/webrtc-pc/#rtcpeerconnectionstate-enum
-#ifdef ENABLE_KVS_THREADPOOL
-#ifdef KVS_USE_OPENSSL
+#if defined(ENABLE_KVS_THREADPOOL) && defined(KVS_USE_OPENSSL)
             CHK_STATUS(threadpoolContextPush(dtlsSessionStartThread, (PVOID) pKvsPeerConnection));
-#else
-            CHK_STATUS(dtlsSessionStart(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->dtlsIsServer));
-#endif
 #else
             CHK_STATUS(dtlsSessionStart(pKvsPeerConnection->pDtlsSession, pKvsPeerConnection->dtlsIsServer));
 #endif

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -86,7 +86,7 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSessi
 
     CHK(ppSctpSession != NULL && pSctpSessionCallbacks != NULL, STATUS_NULL_ARG);
 
-    pSctpSession = (PSctpSession) MEMALLOC(SIZEOF(SctpSession));
+    pSctpSession = (PSctpSession) MEMCALLOC(1, SIZEOF(SctpSession));
     CHK(pSctpSession != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
     MEMSET(&params, 0x00, SIZEOF(struct sctp_paddrparams));
@@ -318,7 +318,6 @@ STATUS handleDcepPacket(PSctpSession pSctpSession, UINT32 streamId, PBYTE data, 
     CHK((labelLength + protocolLength + SCTP_DCEP_HEADER_LENGTH) >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
 
     CHK(SCTP_MAX_ALLOWABLE_PACKET_LENGTH >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
-    MEMCPY(pSctpSession->packet, data, length);
 
     pSctpSession->sctpSessionCallbacks.dataChannelOpenFunc(pSctpSession->sctpSessionCallbacks.customData, streamId, data + SCTP_DCEP_HEADER_LENGTH,
                                                            labelLength);

--- a/tst/DtlsApiTest.cpp
+++ b/tst/DtlsApiTest.cpp
@@ -24,6 +24,43 @@ TEST_F(DtlsApiTest, createCertificateAndKey_Returns_Success)
     EXPECT_EQ(pKey, nullptr);
 }
 
+TEST_F(DtlsApiTest, dtlsSessionIsInitFinished_Null_Check)
+{
+     PDtlsSession pClient = NULL;
+     BOOL isDtlsConnected = FALSE;
+     EXPECT_EQ(STATUS_NULL_ARG, dtlsSessionIsInitFinished(pClient, &isDtlsConnected));
+     EXPECT_EQ(FALSE, isDtlsConnected);
+}
+
+TEST_F(DtlsApiTest, dtlsSessionCreated_RefCount)
+{
+    DtlsSessionCallbacks callbacks;
+    PDtlsSession pClient = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, createDtlsSession(&callbacks, timerQueueHandle, 0, FALSE, NULL, &pClient));
+    EXPECT_EQ(0, pClient->objRefCount);
+    freeDtlsSession(&pClient);
+    EXPECT_EQ(NULL, pClient);
+    timerQueueFree(&timerQueueHandle);
+}
+
+TEST_F(DtlsApiTest, dtlsProcessPacket_Api_Check)
+{
+    DtlsSessionCallbacks callbacks;
+    PDtlsSession pClient = NULL;
+    BOOL isDtlsConnected = FALSE;
+    INT32 length;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    EXPECT_EQ(STATUS_NULL_ARG, dtlsSessionProcessPacket(pClient, NULL, &length));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, createDtlsSession(&callbacks, timerQueueHandle, 0, FALSE, NULL, &pClient));
+    EXPECT_EQ(STATUS_NULL_ARG, dtlsSessionProcessPacket(pClient, NULL, NULL));
+    EXPECT_EQ(STATUS_SSL_PACKET_BEFORE_DTLS_READY, dtlsSessionProcessPacket(pClient, NULL, &length));
+    freeDtlsSession(&pClient);
+    timerQueueFree(&timerQueueHandle);
+}
+
 #elif KVS_USE_MBEDTLS
 TEST_F(DtlsApiTest, createCertificateAndKey_Returns_Success)
 {

--- a/tst/DtlsApiTest.cpp
+++ b/tst/DtlsApiTest.cpp
@@ -26,10 +26,19 @@ TEST_F(DtlsApiTest, createCertificateAndKey_Returns_Success)
 
 TEST_F(DtlsApiTest, dtlsSessionIsInitFinished_Null_Check)
 {
-     PDtlsSession pClient = NULL;
-     BOOL isDtlsConnected = FALSE;
-     EXPECT_EQ(STATUS_NULL_ARG, dtlsSessionIsInitFinished(pClient, &isDtlsConnected));
-     EXPECT_EQ(FALSE, isDtlsConnected);
+    PDtlsSession pClient = NULL;
+    BOOL isDtlsConnected = FALSE;
+    DtlsSessionCallbacks callbacks;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_NULL_ARG, dtlsSessionIsInitFinished(pClient, &isDtlsConnected));
+    EXPECT_EQ(FALSE, isDtlsConnected);
+    EXPECT_EQ(STATUS_SUCCESS, createDtlsSession(&callbacks, timerQueueHandle, 0, FALSE, NULL, &pClient));
+    EXPECT_EQ(STATUS_NULL_ARG, dtlsSessionIsInitFinished(pClient, NULL));
+    freeDtlsSession(&pClient);
+    EXPECT_EQ(NULL, pClient);
+    timerQueueFree(&timerQueueHandle);
+
 }
 
 TEST_F(DtlsApiTest, dtlsSessionCreated_RefCount)
@@ -49,7 +58,6 @@ TEST_F(DtlsApiTest, dtlsProcessPacket_Api_Check)
 {
     DtlsSessionCallbacks callbacks;
     PDtlsSession pClient = NULL;
-    BOOL isDtlsConnected = FALSE;
     INT32 length;
     TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
     EXPECT_EQ(STATUS_NULL_ARG, dtlsSessionProcessPacket(pClient, NULL, &length));

--- a/tst/DtlsFunctionalityTest.cpp
+++ b/tst/DtlsFunctionalityTest.cpp
@@ -8,7 +8,7 @@ namespace webrtcclient {
 
 class DtlsFunctionalityTest : public WebRtcClientTestBase {
   public:
-    STATUS createAndConnect(TIMER_QUEUE_HANDLE timerQueueHandle, PDtlsSession* ppClient, PDtlsSession* ppServer)
+    STATUS createAndConnect(TIMER_QUEUE_HANDLE timerQueueHandle, PDtlsSession* ppClient, PDtlsSession* ppServer, BOOL useThread)
     {
         struct Context {
             std::mutex mtx;
@@ -20,6 +20,7 @@ class DtlsFunctionalityTest : public WebRtcClientTestBase {
         PDtlsSession pClient = NULL, pServer = NULL;
         UINT64 sleepDelay = 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
         Context clientCtx, serverCtx;
+        std::thread dtlsClientThread, dtlsServerThread;
 
         MEMSET(&callbacks, 0, SIZEOF(callbacks));
         callbacks.stateChangeFn = [](UINT64 customData, RTC_DTLS_TRANSPORT_STATE state) {
@@ -68,8 +69,19 @@ class DtlsFunctionalityTest : public WebRtcClientTestBase {
         CHK_STATUS(dtlsSessionOnOutBoundData(pServer, (UINT64) &clientCtx, outboundPacketFn));
         CHK_STATUS(dtlsSessionOnOutBoundData(pClient, (UINT64) &serverCtx, outboundPacketFn));
 
-        CHK_STATUS(dtlsSessionStart(pServer, FALSE));
+        // In case of mbedtls it will be a black return of SUCCESS
+#ifdef KVS_USE_OPENSSL
+        if(useThread) {
+            dtlsClientThread = std::thread(dtlsSessionHandshakeInThread, pClient, TRUE);
+            dtlsServerThread = std::thread(dtlsSessionHandshakeInThread, pServer, FALSE);
+        } else {
+            CHK_STATUS(dtlsSessionStart(pClient, TRUE));
+            CHK_STATUS(dtlsSessionStart(pServer, FALSE));
+        }
+#else
         CHK_STATUS(dtlsSessionStart(pClient, TRUE));
+        CHK_STATUS(dtlsSessionStart(pServer, FALSE));
+#endif
 
         for (UINT64 duration = 0; duration < MAX_TEST_AWAIT_DURATION && ATOMIC_LOAD(&connectedCount) != 2; duration += sleepDelay) {
             CHK_STATUS(consumeMessages(&serverCtx, pServer));
@@ -81,6 +93,13 @@ class DtlsFunctionalityTest : public WebRtcClientTestBase {
 
         *ppClient = pClient;
         *ppServer = pServer;
+
+#ifdef KVS_USE_OPENSSL
+        if(useThread) {
+            dtlsClientThread.join();
+            dtlsServerThread.join();
+        }
+#endif
 
     CleanUp:
 
@@ -117,7 +136,7 @@ TEST_F(DtlsFunctionalityTest, putApplicationDataWithVariedSizes)
     };
 
     EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
-    EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer));
+    EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer, FALSE));
 
     EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
     EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
@@ -148,7 +167,7 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizes)
     INT32 readDataSize;
 
     EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
-    EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer));
+    EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer, FALSE));
 
     EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
     EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
@@ -166,6 +185,69 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizes)
     timerQueueFree(&timerQueueHandle);
     MEMFREE(pData);
 }
+
+TEST_F(DtlsFunctionalityTest, putApplicationDataWithVariedSizesInThread)
+{
+    PDtlsSession pClient = NULL, pServer = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    PBYTE pData = NULL;
+    INT32 dataSizes[] = {
+            4,                      // very small packet
+            DEFAULT_MTU_SIZE - 200, // small packet but should be still under mtu
+            DEFAULT_MTU_SIZE + 200, // big packet and bigger than even a jumbo frame
+    };
+
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer, TRUE));
+
+    EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
+    EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
+
+    for (int i = 0; i < (INT32) ARRAY_SIZE(dataSizes); i++) {
+        pData = (PBYTE) MEMREALLOC(pData, dataSizes[i]);
+        ASSERT_TRUE(pData != NULL);
+        MEMSET(pData, 0x11, dataSizes[i]);
+        EXPECT_EQ(STATUS_SUCCESS, dtlsSessionPutApplicationData(pClient, pData, dataSizes[i]));
+    }
+
+    freeDtlsSession(&pClient);
+    freeDtlsSession(&pServer);
+    timerQueueFree(&timerQueueHandle);
+MEMFREE(pData);
+}
+
+TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizesInThread)
+{
+    PDtlsSession pClient = NULL, pServer = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    PBYTE pData = NULL;
+    INT32 dataSizes[] = {
+            4,                      // very small packet
+            DEFAULT_MTU_SIZE - 200, // small packet but should be still under mtu
+            DEFAULT_MTU_SIZE + 200, // big packet and bigger than even a jumbo frame
+    };
+    INT32 readDataSize;
+
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer, TRUE));
+    EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
+    EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
+
+
+    for (int i = 0; i < (INT32) ARRAY_SIZE(dataSizes); i++) {
+        pData = (PBYTE) MEMREALLOC(pData, dataSizes[i]);
+        readDataSize = dataSizes[i];
+        ASSERT_TRUE(pData != NULL);
+        MEMSET(pData, 0x11, dataSizes[i]);
+        EXPECT_EQ(STATUS_SUCCESS, dtlsSessionProcessPacket(pServer, pData, &readDataSize));
+    }
+
+    freeDtlsSession(&pClient);
+    freeDtlsSession(&pServer);
+timerQueueFree(&timerQueueHandle);
+MEMFREE(pData);
+}
+
 
 } // namespace webrtcclient
 } // namespace video

--- a/tst/DtlsFunctionalityTest.cpp
+++ b/tst/DtlsFunctionalityTest.cpp
@@ -244,8 +244,8 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizesInThread)
 
     freeDtlsSession(&pClient);
     freeDtlsSession(&pServer);
-timerQueueFree(&timerQueueHandle);
-MEMFREE(pData);
+    timerQueueFree(&timerQueueHandle);
+    MEMFREE(pData);
 }
 
 

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -194,6 +194,7 @@ TEST_F(PeerConnectionApiTest, connectionState)
     EXPECT_EQ(RTC_PEER_CONNECTION_STATE_DISCONNECTED, fromIceAgentState(pc, ICE_AGENT_STATE_DISCONNECTED));
     EXPECT_EQ(RTC_PEER_CONNECTION_STATE_FAILED, fromIceAgentState(pc, ICE_AGENT_STATE_FAILED));
 
+    closePeerConnection(pc);
     freePeerConnection(&pc);
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- The PR focusses on improving DTLS handshake time by moving to a state transition based approach to be more responsive to the incoming DTLS handshake messages instead of waiting 200 milliseconds to respond. (based on the timer implementation)

*Why was it changed?*
- DTLS over Openssl inherently takes some time based on the cryptographic suite chosen. The PR focusses on improving the existing DTLS handshake design to reduce latency from the SDK end so that the true latency is from the actual handshake process. We use the threadpool to perform the DTLS handshake and the optimization can be enabled by enabling THREADPOOL usage for the WebRTC SDK.

*How was it changed?*
- Start DTLS handshake on the threadpool based on the `ENABLE_KVS_THREADPOOL` flag. 
- Start DTLS handshake **ONLY AFTER** ICE agent has nominated the data sending candidate pair. This helps in avoiding missed DTLS packets that increasing handshake time
- Using a CVAR based signaling mechanism when an incoming DTLS packet is received. 
- Using refcounting to track access to the DTLS session object to ensure we do not delete the heap allocated objects until all references to the DTLS object are returned. 

*What testing was done for the changes?*
- Added new unit tests to test out the new piece. Used the new unit test to also verify the DTLS handshake timing optimization

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
