### PR TITLE
Change ice server count value

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2838,7 +2838,7 @@ STATUS getIceAgentStats(PIceAgent pIceAgent, PKvsIceAgentMetrics pKvsIceAgentMet
     pKvsIceAgentMetrics->kvsIceAgentStats.hostCandidateSetUpTime = pIceAgent->iceAgentProfileDiagnostics.hostCandidateSetUpTime;
     pKvsIceAgentMetrics->kvsIceAgentStats.srflxCandidateSetUpTime = pIceAgent->iceAgentProfileDiagnostics.srflxCandidateSetUpTime;
     pKvsIceAgentMetrics->kvsIceAgentStats.relayCandidateSetUpTime = pIceAgent->iceAgentProfileDiagnostics.relayCandidateSetUpTime;
-    for (i = 0; i < MAX_ICE_SERVERS_COUNT; i++) {
+    for (i = 0; i < pIceAgent->iceServersCount; i++) {
         pKvsIceAgentMetrics->kvsIceAgentStats.iceServerParsingTime += pIceAgent->iceAgentProfileDiagnostics.iceServerParsingTime[i];
     }
     pKvsIceAgentMetrics->kvsIceAgentStats.iceCandidatePairNominationTime = pIceAgent->iceAgentProfileDiagnostics.iceCandidatePairNominationTime;


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Fix the loop for ICE server parsing time to run only for the number of ICE servers checked instead of total allowable

*Why was it changed?*
To ensure we do not unnecessarily loop over non existent indices

*How was it changed?*
Change in the loop count variable

*What testing was done for the changes?*
Verified the correct value is reported when looping through the ICE servers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
