### PR TITLE
Fix frame indexing in master sample to handle SRTP connection not ready yet

### DIFF
--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -169,6 +169,9 @@ PVOID sendVideoPackets(PVOID args)
                 if (status != STATUS_SUCCESS) {
                     DLOGV("writeFrame() failed with 0x%08x", status);
                 }
+            } else {
+                // Reset file index to ensure first frame sent upon SRTP ready is a key frame.
+                fileIndex = 0;
             }
         }
         MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);
@@ -232,6 +235,9 @@ PVOID sendAudioPackets(PVOID args)
                     PROFILE_WITH_START_TIME(pSampleConfiguration->sampleStreamingSessionList[i]->offerReceiveTime, "Time to first frame");
                     pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame = FALSE;
                 }
+            } else {
+                // Reset file index to stay in sync with video frames.
+                fileIndex = 0;
             }
         }
         MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -180,7 +180,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                                     pSampleConfiguration->rtspUri);
 
                     if (stringOutcome > RTSP_PIPELINE_MAX_CHAR_COUNT) {
-                        printf("[KVS GStreamer Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
+                        DLOGE("[KVS GStreamer Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
                         goto CleanUp;
                     }
                     pipeline = gst_parse_launch(rtspPipeLineBuffer, &error);
@@ -226,7 +226,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                                     pSampleConfiguration->rtspUri);
 
                     if (stringOutcome > RTSP_PIPELINE_MAX_CHAR_COUNT) {
-                        printf("[KVS GStreamer Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
+                        DLOGE("[KVS GStreamer Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
                         goto CleanUp;
                     }
                     pipeline = gst_parse_launch(rtspPipeLineBuffer, &error);
@@ -243,7 +243,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
     appsinkAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-audio");
 
     if (!(appsinkVideo != NULL || appsinkAudio != NULL)) {
-        printf("[KVS GStreamer Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n",
+        DLOGE("[KVS GStreamer Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n",
                STATUS_INTERNAL_ERROR);
         goto CleanUp;
     }
@@ -438,8 +438,8 @@ INT32 main(INT32 argc, CHAR* argv[])
         } else if (STRCMP(argv[3], "rtspsrc") == 0) {
             DLOGI("[KVS GStreamer Master] Using RTSP source in GStreamer");
             if (argc < 5) {
-                printf("[KVS GStreamer Master] No RTSP source URI included. Defaulting to device source");
-                printf("[KVS GStreamer Master] Usage: ./kvsWebrtcClientMasterGstSample <channel name> audio-video rtspsrc rtsp://<rtsp uri>\n"
+                DLOGI("[KVS GStreamer Master] No RTSP source URI included. Defaulting to device source");
+                DLOGI("[KVS GStreamer Master] Usage: ./kvsWebrtcClientMasterGstSample <channel name> audio-video rtspsrc rtsp://<rtsp uri>\n"
                        "or ./kvsWebrtcClientMasterGstSample <channel name> video-only rtspsrc <rtsp://<rtsp uri>");
                 pSampleConfiguration->srcType = DEVICE_SOURCE;
             } else {
@@ -450,7 +450,7 @@ INT32 main(INT32 argc, CHAR* argv[])
             DLOGI("[KVS Gstreamer Master] Unrecognized source type. Defaulting to device source in GStreamer");
         }
     } else {
-        printf("[KVS GStreamer Master] Using device source in GStreamer\n");
+        DLOGI("[KVS GStreamer Master] Using device source in GStreamer\n");
     }
 
     switch (pSampleConfiguration->mediaType) {

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -78,7 +78,7 @@ GstFlowReturn on_new_sample(GstElement* sink, gpointer data, UINT64 trackid)
             status = writeFrame(pRtcRtpTransceiver, &frame);
             if (status != STATUS_SRTP_NOT_READY_YET && status != STATUS_SUCCESS) {
 #ifdef VERBOSE
-                DLOGE("writeFrame() failed with 0x%08x", status);
+                DLOGE("[KVS GStreamer Master] writeFrame() failed with 0x%08x", status);
 #endif
             } else if (status == STATUS_SUCCESS && pSampleStreamingSession->firstFrame) {
                 PROFILE_WITH_START_TIME(pSampleStreamingSession->offerReceiveTime, "Time to first frame");
@@ -283,7 +283,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
 CleanUp:
 
     if (error != NULL) {
-        DLOGE("%s", error->message);
+        DLOGE("[KVS GStreamer Master] %s", error->message);
         g_clear_error(&error);
     }
 
@@ -379,7 +379,7 @@ PVOID receiveGstreamerAudioVideo(PVOID args)
 
 CleanUp:
     if (error != NULL) {
-        DLOGE("%s", error->message);
+        DLOGE("[KVS GStreamer Master] %s", error->message);
         g_clear_error(&error);
     }
 

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -83,6 +83,8 @@ GstFlowReturn on_new_sample(GstElement* sink, gpointer data, UINT64 trackid)
             } else if (status == STATUS_SUCCESS && pSampleStreamingSession->firstFrame) {
                 PROFILE_WITH_START_TIME(pSampleStreamingSession->offerReceiveTime, "Time to first frame");
                 pSampleStreamingSession->firstFrame = FALSE;
+            } else if (status == STATUS_SRTP_NOT_READY_YET) {
+                DLOGI("[KVS GStreamer Master] SRTP not ready yet, dropping frame")
             }
         }
         MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -84,7 +84,7 @@ GstFlowReturn on_new_sample(GstElement* sink, gpointer data, UINT64 trackid)
                 PROFILE_WITH_START_TIME(pSampleStreamingSession->offerReceiveTime, "Time to first frame");
                 pSampleStreamingSession->firstFrame = FALSE;
             } else if (status == STATUS_SRTP_NOT_READY_YET) {
-                DLOGI("[KVS GStreamer Master] SRTP not ready yet, dropping frame")
+                DLOGI("[KVS GStreamer Master] SRTP not ready yet, dropping frame");
             }
         }
         MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -182,7 +182,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                                     pSampleConfiguration->rtspUri);
 
                     if (stringOutcome > RTSP_PIPELINE_MAX_CHAR_COUNT) {
-                        DLOGE("[KVS GStreamer Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
+                        DLOGE("[KVS GStreamer Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT");
                         goto CleanUp;
                     }
                     pipeline = gst_parse_launch(rtspPipeLineBuffer, &error);
@@ -228,7 +228,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                                                     pSampleConfiguration->rtspUri);
 
                     if (stringOutcome > RTSP_PIPELINE_MAX_CHAR_COUNT) {
-                        DLOGE("[KVS GStreamer Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT\n");
+                        DLOGE("[KVS GStreamer Master] ERROR: rtsp uri entered exceeds maximum allowed length set by RTSP_PIPELINE_MAX_CHAR_COUNT");
                         goto CleanUp;
                     }
                     pipeline = gst_parse_launch(rtspPipeLineBuffer, &error);
@@ -245,7 +245,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
     appsinkAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-audio");
 
     if (!(appsinkVideo != NULL || appsinkAudio != NULL)) {
-        DLOGE("[KVS GStreamer Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n",
+        DLOGE("[KVS GStreamer Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x",
               STATUS_INTERNAL_ERROR);
         goto CleanUp;
     }

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -246,7 +246,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
 
     if (!(appsinkVideo != NULL || appsinkAudio != NULL)) {
         DLOGE("[KVS GStreamer Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x \n",
-               STATUS_INTERNAL_ERROR);
+              STATUS_INTERNAL_ERROR);
         goto CleanUp;
     }
 
@@ -442,7 +442,7 @@ INT32 main(INT32 argc, CHAR* argv[])
             if (argc < 5) {
                 DLOGI("[KVS GStreamer Master] No RTSP source URI included. Defaulting to device source");
                 DLOGI("[KVS GStreamer Master] Usage: ./kvsWebrtcClientMasterGstSample <channel name> audio-video rtspsrc rtsp://<rtsp uri>\n"
-                       "or ./kvsWebrtcClientMasterGstSample <channel name> video-only rtspsrc <rtsp://<rtsp uri>");
+                      "or ./kvsWebrtcClientMasterGstSample <channel name> video-only rtspsrc <rtsp://<rtsp uri>");
                 pSampleConfiguration->srcType = DEVICE_SOURCE;
             } else {
                 pSampleConfiguration->srcType = RTSP_SOURCE;

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -441,7 +441,7 @@ INT32 main(INT32 argc, CHAR* argv[])
             DLOGI("[KVS GStreamer Master] Using RTSP source in GStreamer");
             if (argc < 5) {
                 DLOGI("[KVS GStreamer Master] No RTSP source URI included. Defaulting to device source");
-                DLOGI("[KVS GStreamer Master] Usage: ./kvsWebrtcClientMasterGstSample <channel name> audio-video rtspsrc rtsp://<rtsp uri>\n"
+                DLOGI("[KVS GStreamer Master] Usage: ./kvsWebrtcClientMasterGstSample <channel name> audio-video rtspsrc rtsp://<rtsp uri>"
                       "or ./kvsWebrtcClientMasterGstSample <channel name> video-only rtspsrc <rtsp://<rtsp uri>");
                 pSampleConfiguration->srcType = DEVICE_SOURCE;
             } else {
@@ -452,7 +452,7 @@ INT32 main(INT32 argc, CHAR* argv[])
             DLOGI("[KVS Gstreamer Master] Unrecognized source type. Defaulting to device source in GStreamer");
         }
     } else {
-        DLOGI("[KVS GStreamer Master] Using device source in GStreamer\n");
+        DLOGI("[KVS GStreamer Master] Using device source in GStreamer");
     }
 
     switch (pSampleConfiguration->mediaType) {

--- a/samples/kvsWebrtcClientMasterGstSample.c
+++ b/samples/kvsWebrtcClientMasterGstSample.c
@@ -245,8 +245,7 @@ PVOID sendGstreamerAudioVideo(PVOID args)
     appsinkAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsink-audio");
 
     if (!(appsinkVideo != NULL || appsinkAudio != NULL)) {
-        DLOGE("[KVS GStreamer Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x",
-              STATUS_INTERNAL_ERROR);
+        DLOGE("[KVS GStreamer Master] sendGstreamerAudioVideo(): cant find appsink, operation returned status code: 0x%08x", STATUS_INTERNAL_ERROR);
         goto CleanUp;
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
For the master sample, these changes will reset the frame file index back to the first index when the SRTP connection is not ready to ensure the first frame sent is a key frame. The master GStreamer sample has the addition of a log line to indicate that frames were dropped. Also, using a logger was added to the GStreamer sample to replace printf() calls.

*Why was it changed?*
The frame file index for the master sample is incremented for every writeFrame() call, even for writeFrame() attempts before the SRTP connection is ready. Such frames are dropped, but the index is still incremented, resulting in non keyframes being sent as the first successful frames. Logging replaced printf() calls to be more versatile and consistent with the rest of our samples.

*How was it changed?*
By updating the sample files.

*What testing was done for the changes?*
Using the existing CI tests to build and run samples.

<br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
