### PR TITLE
Fix regression in value

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -846,6 +846,7 @@ PVOID resolveStunIceServerIp(PVOID args)
 
                 SNPRINTF(pWebRtcClientContext->pStunIpAddrCtx->hostname, SIZEOF(pWebRtcClientContext->pStunIpAddrCtx->hostname),
                          KINESIS_VIDEO_STUN_URL_WITHOUT_PORT, pRegion, pHostnamePostfix);
+                stunDnsResolutionStartTime = GETTIME();
                 if (getStunAddr(pWebRtcClientContext->pStunIpAddrCtx) == STATUS_SUCCESS) {
                     getIpAddrStr(&pWebRtcClientContext->pStunIpAddrCtx->kvsIpAddr, addressResolved, ARRAY_SIZE(addressResolved));
                     DLOGI("ICE Server address for %s with getaddrinfo: %s", pWebRtcClientContext->pStunIpAddrCtx->hostname, addressResolved);


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Rebased led to start time not being recorded for STUN DNS resolution

*Why was it changed?*
There was a metric added to record STUN DNS resolution time taken in an earlier PR and due to a faulty rebase, the start time was not recorded leadnig to large timestamp values being recorded as the time taken.

*How was it changed?*
Recording start time before getaddrinfo

*What testing was done for the changes?*
Local testing to confirm a valid value is printed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
