### PR TITLE
GCC CI Build Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,21 +197,358 @@ jobs:
   # memory-sanitizer:
   #   runs-on: ubuntu-18.04
   #   env:
-  #     CC: clang-7
-  #     CXX: clang++-7
   #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Build repository
+  #       run: |
+  #         brew unlink openssl
+  #         mkdir build && cd build
+  #         sh -c 'cmake .. -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++;cmake .. -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
+  #         make
+  # static-build-mac:
+  #   runs-on: macos-11
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #     LDFLAGS: -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+  #     CPATH: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
+  #         make
+  #     - name: Run tests
+  #       run:  |
+  #         cd build
+  #         ./tst/webrtc_client_test
+  # linux-gcc-code-coverage:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Build repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
+  #         make
+  #         ulimit -c unlimited -S
+  #     - name: Run tests
+  #       run:  |
+  #         cd build
+  #         timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  #     - name: Code coverage
+  #       run: |
+  #         for test_file in $(find CMakeFiles/kvsWebrtcClient.dir CMakeFiles/kvsWebrtcSignalingClient.dir -name '*.gcno'); do gcov $test_file; done
+  #         bash <(curl -s https://codecov.io/bash)
+  # address-sanitizer:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     ASAN_OPTIONS: detect_odr_violation=0:detect_leaks=1
+  #     LSAN_OPTIONS: suppressions=../tst/suppressions/LSAN.supp
+  #     CC: clang
+  #     CXX: clang++
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install clang
+  #     - name: Build repository
+  #       run: |
+  #         # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
+  #         make
+  #         ulimit -c unlimited -S
+  #     - name: Run tests
+  #       run:  |
+  #         cd build
+  #         timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  # undefined-behavior-sanitizer:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+  #     CC: clang
+  #     CXX: clang++
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install clang
+  #     - name: Build repository
+  #       run: |
+  #         # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
+  #         make
+  #         ulimit -c unlimited -S
+  #     - name: Run tests
+  #       run:  |
+  #         cd build
+  #         timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  # # memory-sanitizer:
+  # #   runs-on: ubuntu-18.04
+  # #   env:
+  # #     CC: clang-7
+  # #     CXX: clang++-7
+  # #     AWS_KVS_LOG_LEVEL: 2
+  # #   steps:
+  # #     - name: Clone repository
+  # #       uses: actions/checkout@v3
+  # #     - name: Install dependencies
+  # #       run: |
+  # #         sudo apt clean && sudo apt update
+  # #         sudo apt-get -y install clang-7
+  # #     - name: Build repository
+  # #       run: |
+  # #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  # #         mkdir build && cd build
+  # #         cmake .. -DMEMORY_SANITIZER=TRUE -DBUILD_TEST=TRUE
+  # #         make
+  # #         ulimit -c unlimited -S
+  # #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
+  # thread-sanitizer:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
+  #     CC: clang
+  #     CXX: clang++
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install clang
+  #     - name: Build repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
+  #         make
+  #         ulimit -c unlimited -S
+  #     - name: Run tests
+  #       run:  |
+  #         cd build
+  #         timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  # linux-gcc-4_4:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #     CC: gcc-4.4
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Install deps
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  #         sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+  #         sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+  #         sudo apt-get -q update
+  #         sudo apt-get -y install gcc-4.4
+  #         sudo apt-get -y install gdb
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE
+  #         make
+  #         ulimit -c unlimited -S
+  #     - name: Run tests
+  #       run:  |
+  #         cd build
+  #         timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  # static-build-linux:
+  #   runs-on: ubuntu-20.04
+  #   container:
+  #     image: alpine:3.15.4
+  #   env:
+  #     CC: gcc
+  #     CXX: g++
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
   #   steps:
   #     - name: Clone repository
   #       uses: actions/checkout@v4
   #     - name: Install dependencies
   #       run: |
+  #         apk update
+  #         apk upgrade
+  #         apk add alpine-sdk cmake clang linux-headers perl bash openssl-dev
+  #     - name: Build Repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
+  #         make
+  # mbedtls-ubuntu-gcc:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Install deps
+  #       run: |
   #         sudo apt clean && sudo apt update
-  #         sudo apt-get -y install clang-7
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  #         sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+  #         sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+  #         sudo apt-get -q update
+  #         sudo apt-get -y install gcc-4.4
+  #         sudo apt-get -y install gdb
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+  #         make
+  #         ulimit -c unlimited -S
+  #     - name: Run tests
+  #       run:  |
+  #         cd build
+  #         timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+
+  # mbedtls-ubuntu-gcc-11:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Install deps
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  #         sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
+  #         sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
+  #         sudo apt-get -q update
+  #     - name: Build repository
+  #       run: |
+  #         mkdir build && cd build
+  #         cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+  #         make
+  #         ulimit -c unlimited -S
+  #     - name: Run tests
+  #       run:  |
+  #         cd build
+  #         timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  # mbedtls-ubuntu-clang:
+  #   runs-on: ubuntu-20.04
+  #   env:
+  #     CC: clang
+  #     CXX: clang++
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v3
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v2
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+  #         aws-region: ${{ secrets.AWS_REGION }}
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install clang
   #     - name: Build repository
   #       run: |
   #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
   #         mkdir build && cd build
-  #         cmake .. -DMEMORY_SANITIZER=TRUE -DBUILD_TEST=TRUE
+  #         cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
   #         make
   #         ulimit -c unlimited -S
   #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
@@ -612,17 +949,18 @@ jobs:
   # windows-msvc-mbedtls:
   #   runs-on: windows-2022
   #   env:
-  #     AWS_KVS_LOG_LEVEL: 7
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   permissions:
+  #     id-token: write
+  #     contents: read
   #   steps:
   #     - name: Clone repository
   #       uses: actions/checkout@v4
   #     - name: Move cloned repo
   #       shell: powershell
   #       run: |
-  #         mkdir D:\a\webrtc
-  #         Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "D:\a\webrtc"
-  #         cd D:\a\webrtc
-  #         dir
+  #         mkdir C:\webrtc
+  #         Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "C:\webrtc"
   #     - name: Install dependencies
   #       shell: powershell
   #       run: |
@@ -631,10 +969,23 @@ jobs:
   #         curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
   #         mkdir C:\tools\pthreads-w32-2-9-1-release\
   #         Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
+  #     # - name: Build libwebsockets from source
+  #     #   shell: powershell
+  #     #   run: |
+  #     #     $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\lib\x64;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\include'
+  #     #     git config --system core.longpaths true
+  #     #     cd C:\tools\
+  #     #     git clone https://github.com/warmcat/libwebsockets.git
+  #     #     git checkout v4.2.2
+  #     #     cd libwebsockets
+  #     #     mkdir build
+  #     #     cd build
+  #     #     cmake .. -DLWS_HAVE_PTHREAD_H=1 -DLWS_EXT_PTHREAD_INCLUDE_DIR="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\include" -DLWS_EXT_PTHREAD_LIBRARIES="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\lib\\x64\\libpthreadGC2.a" -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_OPENSSL_INCLUDE_DIRS="C:\\Program Files\\OpenSSL\\include" -DLWS_OPENSSL_LIBRARIES="C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib"
+  #     #     cmake --build . --config DEBUG
   #     - name: Build repository
   #       shell: powershell
   #       run: |
-  #         cd D:\a\webrtc
+  #         cd C:\webrtc
   #         git config --system core.longpaths true
   #         .github\build_windows_mbedtls.bat
   arm64-cross-compilation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
   mac-os-build-gcc:
     runs-on: macos-11
     env:
-      CC: gcc
-      CXX: g++
+      CC: /usr/local/bin/gcc-13
+      CXX: /usr/local/bin/g++-13
       AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,8 +446,8 @@ if (WIN32)
 endif()
 
 if(COMPILER_WARNINGS)
-  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -Wextra -Wno-unknown-warning-option)
-  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -Wextra -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -Wpedantic -Wextra -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -Wpedantic -Wextra -Wno-unknown-warning-option)
 endif()
 
 install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,16 +108,16 @@ if(ADD_MUCLIBC)
 endif()
 
 
-message(STATUS "Kinesis Video WebRTC Client path is ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}")
-message(STATUS "dependencies install path is ${OPEN_SRC_INSTALL_PREFIX}")
+# message(STATUS "Kinesis Video WebRTC Client path is ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}")
+# message(STATUS "dependencies install path is ${OPEN_SRC_INSTALL_PREFIX}")
 
-# pass ca cert location to sdk
-add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")
-add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
+# # pass ca cert location to sdk
+# add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")
+# add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
 
-if (ENABLE_KVS_THREADPOOL)
-  add_definitions(-DENABLE_KVS_THREADPOOL)
-endif()
+# if (ENABLE_KVS_THREADPOOL)
+#   add_definitions(-DENABLE_KVS_THREADPOOL)
+# endif()
 
 if(USE_OPENSSL)
   add_definitions(-DKVS_USE_OPENSSL)
@@ -142,10 +142,31 @@ elseif(USE_MBEDTLS)
 endif()
 
 
-if(BUILD_DEPENDENCIES)
-  if(NOT EXISTS ${OPEN_SRC_INSTALL_PREFIX})
-    file(MAKE_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX})
-  endif()
+#   if(WIN32)
+#     set(OPENSSL_INCLUDE_DIRS "${OPEN_SRC_INSTALL_PREFIX}/include/")
+#     set(OPENSSL_CRYPTO_LIBRARY "${OPEN_SRC_INSTALL_PREFIX}/lib/libcrypto.lib")
+#     set(OPENSSL_SSL_LIBRARY "${OPEN_SRC_INSTALL_PREFIX}/lib/libssl.lib")
+#     set(OPENSSL_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
+#     string(REPLACE ";" "|" OPENSSL_LIBRARIES_ALT_SEP "${OPENSSL_LIBRARIES}")
+#     set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
+#                   -DUSE_OPENSSL=${USE_OPENSSL}
+#                   -DUSE_MBEDTLS=${USE_MBEDTLS} 
+#                   -DLWS_EXT_PTHREAD_INCLUDE_DIR=${EXT_PTHREAD_INCLUDE_DIR}
+#                   -DLWS_EXT_PTHREAD_LIBRARIES=${EXT_PTHREAD_LIBRARIES}
+#                   -DLWS_OPENSSL_INCLUDE_DIRS=${OPENSSL_INCLUDE_DIRS}
+#                   -DLWS_OPENSSL_LIBRARIES=${OPENSSL_LIBRARIES_ALT_SEP}
+#                   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+#   else()
+#     set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
+#                   -DOPENSSL_DIR=${OPEN_SRC_INSTALL_PREFIX}
+#                   -DUSE_OPENSSL=${USE_OPENSSL}
+#                   -DUSE_MBEDTLS=${USE_MBEDTLS}
+#                   -DLWS_OPENSSL_CRYPTO_LIBRARY=${OPENSSL_CRYPTO_LIBRARY}
+#                   -DLWS_OPENSSL_SSL_LIBRARY=${OPENSSL_SSL_LIBRARY}
+#                   -DLWS_OPENSSL_INCLUDE_DIRS=${OPENSSL_INCLUDE_DIR}
+#                   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+#   endif()
+#   build_dependency(websockets ${BUILD_ARGS})
 
   set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${OPEN_SRC_INSTALL_PREFIX}/lib/pkgconfig")
   set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${OPEN_SRC_INSTALL_PREFIX})
@@ -238,15 +259,15 @@ if(BUILD_DEPENDENCIES)
 
   endif()
 
-  if(BUILD_BENCHMARK)
-    build_dependency(benchmark)
-  endif()
+#   if(BUILD_BENCHMARK)
+#     build_dependency(benchmark)
+#   endif()
 
-  if (LINK_PROFILER)
-    build_dependency(gperftools)
-  endif()
-  message(STATUS "Finished building dependencies.")
-endif()
+#   if (LINK_PROFILER)
+#     build_dependency(gperftools)
+#   endif()
+#   message(STATUS "Finished building dependencies.")
+# endif()
 
 # building kvsCommonLws also builds kvspic
 set(BUILD_ARGS
@@ -259,45 +280,45 @@ build_dependency(kvsCommonLws ${BUILD_ARGS})
 
 ############# find dependent libraries ############
 
-find_package(Threads)
-find_package(PkgConfig REQUIRED)
-if (USE_OPENSSL)
-  find_package(OpenSSL REQUIRED)
-  set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
-else()
-  find_package(MbedTLS REQUIRED)
-  set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${MBEDTLS_INCLUDE_DIRS})
-endif()
+# find_package(Threads)
+# find_package(PkgConfig REQUIRED)
+# if (USE_OPENSSL)
+#   find_package(OpenSSL REQUIRED)
+#   set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
+# else()
+#   find_package(MbedTLS REQUIRED)
+#   set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${MBEDTLS_INCLUDE_DIRS})
+# endif()
 
-if (OPEN_SRC_INSTALL_PREFIX)
-  find_library(SRTP_LIBRARIES srtp2 REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+# if (OPEN_SRC_INSTALL_PREFIX)
+#   find_library(SRTP_LIBRARIES srtp2 REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
 
-  if (LINK_PROFILER)
-    find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
-    find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
-  endif()
-else()
-  find_library(SRTP_LIBRARIES srtp2 REQUIRED )
-  if (LINK_PROFILER)
-    find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED)
-    find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED)
-  endif()
-endif()
+#   if (LINK_PROFILER)
+#     find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+#     find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+#   endif()
+# else()
+#   find_library(SRTP_LIBRARIES srtp2 REQUIRED )
+#   if (LINK_PROFILER)
+#     find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED)
+#     find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED)
+#   endif()
+# endif()
 
-if (WIN32)
-  SET(LIBWEBSOCKETS_LIBRARIES "websockets.lib")
-else()
-  pkg_check_modules(LIBWEBSOCKETS REQUIRED libwebsockets)
-endif()
+# if (WIN32)
+#   SET(LIBWEBSOCKETS_LIBRARIES "websockets.lib")
+# else()
+#   pkg_check_modules(LIBWEBSOCKETS REQUIRED libwebsockets)
+# endif()
 
 # usrsctp dont support pkgconfig yet
-find_library(
-  Usrsctp
-  NAMES ${USRSCTP_LIBNAME} usrsctp REQUIRED
-  PATHS ${OPEN_SRC_INSTALL_PREFIX}/lib ${OPEN_SRC_INSTALL_PREFIX}/lib64)
+# find_library(
+#   Usrsctp
+#   NAMES ${USRSCTP_LIBNAME} usrsctp REQUIRED
+#   PATHS ${OPEN_SRC_INSTALL_PREFIX}/lib ${OPEN_SRC_INSTALL_PREFIX}/lib64)
 
-set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${LIBSRTP_INCLUDE_DIRS}
-                          ${CURL_INCLUDE_DIRS} ${LIBWEBSOCKETS_INCLUDE_DIRS})
+# set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${LIBSRTP_INCLUDE_DIRS}
+#                           ${CURL_INCLUDE_DIRS} ${LIBWEBSOCKETS_INCLUDE_DIRS})
 
 link_directories(${LIBSRTP_LIBRARY_DIRS})
 link_directories(${LIBWEBSOCKETS_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,8 +446,8 @@ if (WIN32)
 endif()
 
 if(COMPILER_WARNINGS)
-  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -Wpedantic -Wextra -Wno-unknown-warning-option)
-  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -Wpedantic -Wextra -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option -Wno-error=pedantic)
+  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option -Wno-error=pedantic)
 endif()
 
 install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,8 +446,8 @@ if (WIN32)
 endif()
 
 if(COMPILER_WARNINGS)
-  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)
-  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -Wextra -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -Wextra -Wno-unknown-warning-option)
 endif()
 
 install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,16 +108,16 @@ if(ADD_MUCLIBC)
 endif()
 
 
-# message(STATUS "Kinesis Video WebRTC Client path is ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}")
-# message(STATUS "dependencies install path is ${OPEN_SRC_INSTALL_PREFIX}")
+message(STATUS "Kinesis Video WebRTC Client path is ${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}")
+message(STATUS "dependencies install path is ${OPEN_SRC_INSTALL_PREFIX}")
 
-# # pass ca cert location to sdk
-# add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")
-# add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
+# pass ca cert location to sdk
+add_definitions(-DKVS_CA_CERT_PATH="${CMAKE_SOURCE_DIR}/certs/cert.pem")
+add_definitions(-DCMAKE_DETECTED_CACERT_PATH)
 
-# if (ENABLE_KVS_THREADPOOL)
-#   add_definitions(-DENABLE_KVS_THREADPOOL)
-# endif()
+if (ENABLE_KVS_THREADPOOL)
+  add_definitions(-DENABLE_KVS_THREADPOOL)
+endif()
 
 if(USE_OPENSSL)
   add_definitions(-DKVS_USE_OPENSSL)
@@ -132,6 +132,8 @@ elseif(USE_MBEDTLS)
     message(STATUS "Detected gcc")
     set(CMAKE_C_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE=\"<config_mbedtls.h>\" ${CMAKE_C_FLAGS}")
     set(CMAKE_CXX_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE=\"<config_mbedtls.h>\" ${CMAKE_CXX_FLAGS}")
+    # set(CMAKE_C_FLAGS "-Wno-error=stringop-overflow -I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE=\"<config_mbedtls.h>\" ${CMAKE_C_FLAGS}")
+    # set(CMAKE_CXX_FLAGS "-Wno-error=stringop-overflow -I${CMAKE_CURRENT_SOURCE_DIR}/configs -DMBEDTLS_USER_CONFIG_FILE=\"<config_mbedtls.h>\" ${CMAKE_CXX_FLAGS}")
     if(CMAKE_C_COMPILER_VERSION VERSION_GREATER "7.0")
       set(CMAKE_C_FLAGS "-Wno-error=stringop-overflow ${CMAKE_C_FLAGS}")
       set(CMAKE_CXX_FLAGS "-Wno-error=stringop-overflow ${CMAKE_CXX_FLAGS}")
@@ -141,32 +143,31 @@ elseif(USE_MBEDTLS)
   endif()
 endif()
 
-
-#   if(WIN32)
-#     set(OPENSSL_INCLUDE_DIRS "${OPEN_SRC_INSTALL_PREFIX}/include/")
-#     set(OPENSSL_CRYPTO_LIBRARY "${OPEN_SRC_INSTALL_PREFIX}/lib/libcrypto.lib")
-#     set(OPENSSL_SSL_LIBRARY "${OPEN_SRC_INSTALL_PREFIX}/lib/libssl.lib")
-#     set(OPENSSL_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
-#     string(REPLACE ";" "|" OPENSSL_LIBRARIES_ALT_SEP "${OPENSSL_LIBRARIES}")
-#     set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
-#                   -DUSE_OPENSSL=${USE_OPENSSL}
-#                   -DUSE_MBEDTLS=${USE_MBEDTLS} 
-#                   -DLWS_EXT_PTHREAD_INCLUDE_DIR=${EXT_PTHREAD_INCLUDE_DIR}
-#                   -DLWS_EXT_PTHREAD_LIBRARIES=${EXT_PTHREAD_LIBRARIES}
-#                   -DLWS_OPENSSL_INCLUDE_DIRS=${OPENSSL_INCLUDE_DIRS}
-#                   -DLWS_OPENSSL_LIBRARIES=${OPENSSL_LIBRARIES_ALT_SEP}
-#                   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
-#   else()
-#     set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
-#                   -DOPENSSL_DIR=${OPEN_SRC_INSTALL_PREFIX}
-#                   -DUSE_OPENSSL=${USE_OPENSSL}
-#                   -DUSE_MBEDTLS=${USE_MBEDTLS}
-#                   -DLWS_OPENSSL_CRYPTO_LIBRARY=${OPENSSL_CRYPTO_LIBRARY}
-#                   -DLWS_OPENSSL_SSL_LIBRARY=${OPENSSL_SSL_LIBRARY}
-#                   -DLWS_OPENSSL_INCLUDE_DIRS=${OPENSSL_INCLUDE_DIR}
-#                   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
-#   endif()
-#   build_dependency(websockets ${BUILD_ARGS})
+  if(WIN32)
+    set(OPENSSL_INCLUDE_DIRS "${OPEN_SRC_INSTALL_PREFIX}/include/")
+    set(OPENSSL_CRYPTO_LIBRARY "${OPEN_SRC_INSTALL_PREFIX}/lib/libcrypto.lib")
+    set(OPENSSL_SSL_LIBRARY "${OPEN_SRC_INSTALL_PREFIX}/lib/libssl.lib")
+    set(OPENSSL_LIBRARIES ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
+    string(REPLACE ";" "|" OPENSSL_LIBRARIES_ALT_SEP "${OPENSSL_LIBRARIES}")
+    set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
+                  -DUSE_OPENSSL=${USE_OPENSSL}
+                  -DUSE_MBEDTLS=${USE_MBEDTLS} 
+                  -DLWS_EXT_PTHREAD_INCLUDE_DIR=${EXT_PTHREAD_INCLUDE_DIR}
+                  -DLWS_EXT_PTHREAD_LIBRARIES=${EXT_PTHREAD_LIBRARIES}
+                  -DLWS_OPENSSL_INCLUDE_DIRS=${OPENSSL_INCLUDE_DIRS}
+                  -DLWS_OPENSSL_LIBRARIES=${OPENSSL_LIBRARIES_ALT_SEP}
+                  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+  else()
+    set(BUILD_ARGS -DBUILD_STATIC_LIBS=${BUILD_STATIC_LIBS}
+                  -DOPENSSL_DIR=${OPEN_SRC_INSTALL_PREFIX}
+                  -DUSE_OPENSSL=${USE_OPENSSL}
+                  -DUSE_MBEDTLS=${USE_MBEDTLS}
+                  -DLWS_OPENSSL_CRYPTO_LIBRARY=${OPENSSL_CRYPTO_LIBRARY}
+                  -DLWS_OPENSSL_SSL_LIBRARY=${OPENSSL_SSL_LIBRARY}
+                  -DLWS_OPENSSL_INCLUDE_DIRS=${OPENSSL_INCLUDE_DIR}
+                  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS})
+  endif()
+  build_dependency(websockets ${BUILD_ARGS})
 
   set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${OPEN_SRC_INSTALL_PREFIX}/lib/pkgconfig")
   set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${OPEN_SRC_INSTALL_PREFIX})
@@ -259,15 +260,15 @@ endif()
 
   endif()
 
-#   if(BUILD_BENCHMARK)
-#     build_dependency(benchmark)
-#   endif()
+  if(BUILD_BENCHMARK)
+    build_dependency(benchmark)
+  endif()
 
-#   if (LINK_PROFILER)
-#     build_dependency(gperftools)
-#   endif()
-#   message(STATUS "Finished building dependencies.")
-# endif()
+  if (LINK_PROFILER)
+    build_dependency(gperftools)
+  endif()
+  message(STATUS "Finished building dependencies.")
+endif()
 
 # building kvsCommonLws also builds kvspic
 set(BUILD_ARGS
@@ -280,45 +281,45 @@ build_dependency(kvsCommonLws ${BUILD_ARGS})
 
 ############# find dependent libraries ############
 
-# find_package(Threads)
-# find_package(PkgConfig REQUIRED)
-# if (USE_OPENSSL)
-#   find_package(OpenSSL REQUIRED)
-#   set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
-# else()
-#   find_package(MbedTLS REQUIRED)
-#   set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${MBEDTLS_INCLUDE_DIRS})
-# endif()
+find_package(Threads)
+find_package(PkgConfig REQUIRED)
+if (USE_OPENSSL)
+  find_package(OpenSSL REQUIRED)
+  set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
+else()
+  find_package(MbedTLS REQUIRED)
+  set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${MBEDTLS_INCLUDE_DIRS})
+endif()
 
-# if (OPEN_SRC_INSTALL_PREFIX)
-#   find_library(SRTP_LIBRARIES srtp2 REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+if (OPEN_SRC_INSTALL_PREFIX)
+  find_library(SRTP_LIBRARIES srtp2 REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
 
-#   if (LINK_PROFILER)
-#     find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
-#     find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
-#   endif()
-# else()
-#   find_library(SRTP_LIBRARIES srtp2 REQUIRED )
-#   if (LINK_PROFILER)
-#     find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED)
-#     find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED)
-#   endif()
-# endif()
+  if (LINK_PROFILER)
+    find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+    find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED PATHS ${OPEN_SRC_INSTALL_PREFIX})
+  endif()
+else()
+  find_library(SRTP_LIBRARIES srtp2 REQUIRED )
+  if (LINK_PROFILER)
+    find_library(GPERFTOOLS_MALLOC_LIBRARIES tcmalloc REQUIRED)
+    find_library(GPERFTOOLS_PROFILER_LIBRARIES profiler REQUIRED)
+  endif()
+endif()
 
-# if (WIN32)
-#   SET(LIBWEBSOCKETS_LIBRARIES "websockets.lib")
-# else()
-#   pkg_check_modules(LIBWEBSOCKETS REQUIRED libwebsockets)
-# endif()
+if (WIN32)
+  SET(LIBWEBSOCKETS_LIBRARIES "websockets.lib")
+else()
+  pkg_check_modules(LIBWEBSOCKETS REQUIRED libwebsockets)
+endif()
 
 # usrsctp dont support pkgconfig yet
-# find_library(
-#   Usrsctp
-#   NAMES ${USRSCTP_LIBNAME} usrsctp REQUIRED
-#   PATHS ${OPEN_SRC_INSTALL_PREFIX}/lib ${OPEN_SRC_INSTALL_PREFIX}/lib64)
+find_library(
+  Usrsctp
+  NAMES ${USRSCTP_LIBNAME} usrsctp REQUIRED
+  PATHS ${OPEN_SRC_INSTALL_PREFIX}/lib ${OPEN_SRC_INSTALL_PREFIX}/lib64)
 
-# set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${LIBSRTP_INCLUDE_DIRS}
-#                           ${CURL_INCLUDE_DIRS} ${LIBWEBSOCKETS_INCLUDE_DIRS})
+set(OPEN_SRC_INCLUDE_DIRS ${OPEN_SRC_INCLUDE_DIRS} ${LIBSRTP_INCLUDE_DIRS}
+                          ${CURL_INCLUDE_DIRS} ${LIBWEBSOCKETS_INCLUDE_DIRS})
 
 link_directories(${LIBSRTP_LIBRARY_DIRS})
 link_directories(${LIBWEBSOCKETS_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,8 +385,9 @@ endif()
 
 file(GLOB WEBRTC_SIGNALING_CLIENT_SOURCE_FILES "src/source/Signaling/*.c")
 
-include_directories(${OPEN_SRC_INCLUDE_DIRS})
-include_directories(${OPEN_SRC_INSTALL_PREFIX}/include)
+
+include_directories(SYSTEM ${OPEN_SRC_INCLUDE_DIRS})
+include_directories(SYSTEM ${OPEN_SRC_INSTALL_PREFIX}/include)
 include_directories(${KINESIS_VIDEO_WEBRTC_CLIENT_SRC}/src/include)
 # include sdp_config.h
 include_directories(src/source/Sdp/kvssdp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,8 +446,8 @@ if (WIN32)
 endif()
 
 if(COMPILER_WARNINGS)
-  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option -Wno-error=pedantic)
-  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option -Wno-error=pedantic)
+  target_compile_options(kvsWebrtcClient PUBLIC -Wall -Werror -Wextra -Wno-unknown-warning-option)
+  target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -Wextra -Wno-unknown-warning-option)
 endif()
 
 install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient

--- a/src/source/Crypto/Tls_openssl.c
+++ b/src/source/Crypto/Tls_openssl.c
@@ -214,7 +214,9 @@ STATUS tlsSessionPutApplicationData(PTlsSession pTlsSession, PBYTE pData, UINT32
     }
 
     wBioGetMemDataRet = BIO_get_mem_data(SSL_get_wbio(pTlsSession->pSsl), &wBioBuffer);
-    CHK_ERR(wBioGetMemDataRet >= 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed");
+    CHK_ERR(wBioGetMemDataRet != 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed with: no BIO was connected to the SSL object.");
+    CHK_ERR(wBioGetMemDataRet > 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed");
+    
     wBioDataLen = (SIZE_T) wBioGetMemDataRet;
 
     if (wBioDataLen > 0) {

--- a/src/source/Crypto/Tls_openssl.c
+++ b/src/source/Crypto/Tls_openssl.c
@@ -216,7 +216,7 @@ STATUS tlsSessionPutApplicationData(PTlsSession pTlsSession, PBYTE pData, UINT32
     wBioGetMemDataRet = BIO_get_mem_data(SSL_get_wbio(pTlsSession->pSsl), &wBioBuffer);
     CHK_ERR(wBioGetMemDataRet != 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed with: no BIO was connected to the SSL object.");
     CHK_ERR(wBioGetMemDataRet > 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed");
-    
+
     wBioDataLen = (SIZE_T) wBioGetMemDataRet;
 
     if (wBioDataLen > 0) {

--- a/src/source/Crypto/Tls_openssl.c
+++ b/src/source/Crypto/Tls_openssl.c
@@ -188,6 +188,7 @@ STATUS tlsSessionPutApplicationData(PTlsSession pTlsSession, PBYTE pData, UINT32
 
     SIZE_T wBioDataLen = 0;
     PCHAR wBioBuffer = NULL;
+    LONG wBioGetMemDataRet = 0;
 
     CHK(pTlsSession != NULL, STATUS_NULL_ARG);
 
@@ -212,8 +213,9 @@ STATUS tlsSessionPutApplicationData(PTlsSession pTlsSession, PBYTE pData, UINT32
         }
     }
 
-    wBioDataLen = (SIZE_T) BIO_get_mem_data(SSL_get_wbio(pTlsSession->pSsl), &wBioBuffer);
-    CHK_ERR(wBioDataLen >= 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed");
+    wBioGetMemDataRet = BIO_get_mem_data(SSL_get_wbio(pTlsSession->pSsl), &wBioBuffer);
+    CHK_ERR(wBioGetMemDataRet >= 0, STATUS_SEND_DATA_FAILED, "BIO_get_mem_data failed");
+    wBioDataLen = (SIZE_T) wBioGetMemDataRet;
 
     if (wBioDataLen > 0) {
         retStatus =

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1580,7 +1580,7 @@ STATUS iceAgentCheckCandidatePairConnection(PIceAgent pIceAgent)
             switch (pIceCandidatePair->state) {
                 case ICE_CANDIDATE_PAIR_STATE_WAITING:
                     pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_IN_PROGRESS;
-                    // NOTE: Explicit fall-through
+                    // explicit fall-through
                 case ICE_CANDIDATE_PAIR_STATE_IN_PROGRESS:
                     CHK_STATUS(iceCandidatePairCheckConnection(pIceAgent->pBindingRequest, pIceAgent, pIceCandidatePair));
                     break;

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1580,7 +1580,7 @@ STATUS iceAgentCheckCandidatePairConnection(PIceAgent pIceAgent)
             switch (pIceCandidatePair->state) {
                 case ICE_CANDIDATE_PAIR_STATE_WAITING:
                     pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_IN_PROGRESS;
-                    // explicit fall-through
+                    /* FALLTHRU */
                 case ICE_CANDIDATE_PAIR_STATE_IN_PROGRESS:
                     CHK_STATUS(iceCandidatePairCheckConnection(pIceAgent->pBindingRequest, pIceAgent, pIceCandidatePair));
                     break;

--- a/src/source/Ice/NatBehaviorDiscovery.c
+++ b/src/source/Ice/NatBehaviorDiscovery.c
@@ -9,7 +9,6 @@ STATUS natTestIncomingDataHandler(UINT64 customData, PSocketConnection pSocketCo
     UNUSED_PARAM(pSrc);
     UNUSED_PARAM(pDest);
 
-    STATUS retStatus = STATUS_SUCCESS;
     PNatTestData pNatTestData = (PNatTestData) customData;
     PStunPacket pStunPacket = NULL;
 

--- a/src/source/Ice/NatBehaviorDiscovery.c
+++ b/src/source/Ice/NatBehaviorDiscovery.c
@@ -380,5 +380,8 @@ PCHAR getNatBehaviorStr(NAT_BEHAVIOR natBehavior)
             return NAT_BEHAVIOR_ADDRESS_DEPENDENT_STR;
         case NAT_BEHAVIOR_PORT_DEPENDENT:
             return NAT_BEHAVIOR_PORT_DEPENDENT_STR;
+        default:
+            // NOTE: This should be properly handled with something like "NAT_BEHAVIOR_UNDEFINED"
+            return NAT_BEHAVIOR_NONE_STR;
     }
 }

--- a/src/source/Ice/NatBehaviorDiscovery.c
+++ b/src/source/Ice/NatBehaviorDiscovery.c
@@ -9,6 +9,7 @@ STATUS natTestIncomingDataHandler(UINT64 customData, PSocketConnection pSocketCo
     UNUSED_PARAM(pSrc);
     UNUSED_PARAM(pDest);
 
+    STATUS retStatus = STATUS_SUCCESS;
     PNatTestData pNatTestData = (PNatTestData) customData;
     PStunPacket pStunPacket = NULL;
 

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -338,7 +338,7 @@ CleanUp:
 BOOL isIpAddr(PCHAR hostname, UINT16 length)
 {
     BOOL status = TRUE;
-    UINT32 ip_1, ip_2, ip_3, ip_4, ip_5, ip_6, ip_7, ip_8;
+    INT16 ip_1, ip_2, ip_3, ip_4, ip_5, ip_6, ip_7, ip_8;
     if (hostname == NULL || length > MAX_ICE_CONFIG_URI_LEN) {
         DLOGW("Provided NULL hostname");
         status = FALSE;

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -338,7 +338,7 @@ CleanUp:
 BOOL isIpAddr(PCHAR hostname, UINT16 length)
 {
     BOOL status = TRUE;
-    INT16 ip_1, ip_2, ip_3, ip_4, ip_5, ip_6, ip_7, ip_8;
+    INT32 ip_1, ip_2, ip_3, ip_4, ip_5, ip_6, ip_7, ip_8;
     if (hostname == NULL || length > MAX_ICE_CONFIG_URI_LEN) {
         DLOGW("Provided NULL hostname");
         status = FALSE;

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -1027,7 +1027,7 @@ BOOL turnConnectionGetRelayAddress(PTurnConnection pTurnConnection, PKvsIpAddres
 
 STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
 {
-    STATUS retStatus = STATUS_SUCCESS, sendStatus = STATUS_SUCCESS;
+    STATUS retStatus = STATUS_SUCCESS;
     PTurnPeer pTurnPeer = NULL;
     PStunAttributeAddress pStunAttributeAddress = NULL;
     PStunAttributeChannelNumber pStunAttributeChannelNumber = NULL;
@@ -1054,7 +1054,7 @@ STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
 
             CHK(pTurnPeer->pTransactionIdStore != NULL, STATUS_INVALID_OPERATION);
             transactionIdStoreInsert(pTurnPeer->pTransactionIdStore, pTurnConnection->pTurnCreatePermissionPacket->header.transactionId);
-            sendStatus = iceUtilsSendStunPacket(pTurnConnection->pTurnCreatePermissionPacket, pTurnConnection->longTermKey,
+            iceUtilsSendStunPacket(pTurnConnection->pTurnCreatePermissionPacket, pTurnConnection->longTermKey,
                                                 ARRAY_SIZE(pTurnConnection->longTermKey), &pTurnConnection->turnServer.ipAddress,
                                                 pTurnConnection->pControlChannel, NULL, FALSE);
 
@@ -1080,7 +1080,7 @@ STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
 
             CHK(pTurnPeer->pTransactionIdStore != NULL, STATUS_INVALID_OPERATION);
             transactionIdStoreInsert(pTurnPeer->pTransactionIdStore, pTurnConnection->pTurnChannelBindPacket->header.transactionId);
-            sendStatus = iceUtilsSendStunPacket(pTurnConnection->pTurnChannelBindPacket, pTurnConnection->longTermKey,
+            iceUtilsSendStunPacket(pTurnConnection->pTurnChannelBindPacket, pTurnConnection->longTermKey,
                                                 ARRAY_SIZE(pTurnConnection->longTermKey), &pTurnConnection->turnServer.ipAddress,
                                                 pTurnConnection->pControlChannel, NULL, FALSE);
         }

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -1055,8 +1055,8 @@ STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
             CHK(pTurnPeer->pTransactionIdStore != NULL, STATUS_INVALID_OPERATION);
             transactionIdStoreInsert(pTurnPeer->pTransactionIdStore, pTurnConnection->pTurnCreatePermissionPacket->header.transactionId);
             iceUtilsSendStunPacket(pTurnConnection->pTurnCreatePermissionPacket, pTurnConnection->longTermKey,
-                                                ARRAY_SIZE(pTurnConnection->longTermKey), &pTurnConnection->turnServer.ipAddress,
-                                                pTurnConnection->pControlChannel, NULL, FALSE);
+                                   ARRAY_SIZE(pTurnConnection->longTermKey), &pTurnConnection->turnServer.ipAddress, pTurnConnection->pControlChannel,
+                                   NULL, FALSE);
 
         } else if (pTurnPeer->connectionState == TURN_PEER_CONN_STATE_BIND_CHANNEL) {
             if (pTurnPeer->firstTimeBindChannelReq) {
@@ -1080,9 +1080,8 @@ STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
 
             CHK(pTurnPeer->pTransactionIdStore != NULL, STATUS_INVALID_OPERATION);
             transactionIdStoreInsert(pTurnPeer->pTransactionIdStore, pTurnConnection->pTurnChannelBindPacket->header.transactionId);
-            iceUtilsSendStunPacket(pTurnConnection->pTurnChannelBindPacket, pTurnConnection->longTermKey,
-                                                ARRAY_SIZE(pTurnConnection->longTermKey), &pTurnConnection->turnServer.ipAddress,
-                                                pTurnConnection->pControlChannel, NULL, FALSE);
+            iceUtilsSendStunPacket(pTurnConnection->pTurnChannelBindPacket, pTurnConnection->longTermKey, ARRAY_SIZE(pTurnConnection->longTermKey),
+                                   &pTurnConnection->turnServer.ipAddress, pTurnConnection->pControlChannel, NULL, FALSE);
         }
     }
 

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -133,10 +133,10 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     MUTEX_UNLOCK(pTransceiver->statsLock);
 
     // Cast to void to avoid "set but not used" warning
-    (void)senderSSRC;
-    (void)cumulativeLost;
-    (void)extHiSeqNumReceived;
-    (void)interarrivalJitter;
+    UNUSED_PARAM(senderSSRC);
+    UNUSED_PARAM(cumulativeLost);
+    UNUSED_PARAM(extHiSeqNumReceived);
+    UNUSED_PARAM(interarrivalJitter);
 
 CleanUp:
 

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -132,6 +132,12 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     pTransceiver->remoteInboundStats.roundTripTime = rttPropDelayMsec;
     MUTEX_UNLOCK(pTransceiver->statsLock);
 
+    // Cast to void to avoid "set but not used" warning
+    (void)senderSSRC;
+    (void)cumulativeLost;
+    (void)extHiSeqNumReceived;
+    (void)interarrivalJitter;
+
 CleanUp:
 
     return retStatus;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -403,7 +403,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     UINT64 payloadType, rtxPayloadType;
     BOOL containRtx = FALSE;
     BOOL directionFound = FALSE;
-    UINT32 i, remoteAttributeCount, attributeCount = 0;
+    UINT32 i, remoteAttributeCount, attributeCount, attributeNameBuffLen, amountWritten = 0;
     PRtcMediaStreamTrack pRtcMediaStreamTrack = &(pKvsRtpTransceiver->sender.track);
     PSdpMediaDescription pSdpMediaDescriptionRemote;
     PCHAR currentFmtp = NULL, rtpMapValue = NULL;
@@ -450,7 +450,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     CHK_STATUS(iceAgentPopulateSdpMediaDescriptionCandidates(pKvsPeerConnection->pIceAgent, pSdpMediaDescription, MAX_SDP_ATTRIBUTE_VALUE_LENGTH,
                                                              &attributeCount));
 
-    // TODO: Verify full string fit into buffer for each of the SNPRINTFs below.
+    attributeNameBuffLen = SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName);
     if (containRtx) {
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "msid");
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
@@ -805,12 +805,6 @@ STATUS populateSessionDescriptionDataChannel(PKvsPeerConnection pKvsPeerConnecti
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "ice-pwd");
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, pKvsPeerConnection->localIcePwd);
     attributeCount++;
-
-    if (pKvsPeerConnection->canTrickleIce.value) {
-        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "ice-options");
-        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "trickle");
-        attributeCount++;
-    }
 
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "fingerprint");
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "sha-256 ");

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -806,6 +806,12 @@ STATUS populateSessionDescriptionDataChannel(PKvsPeerConnection pKvsPeerConnecti
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, pKvsPeerConnection->localIcePwd);
     attributeCount++;
 
+    if (pKvsPeerConnection->canTrickleIce.value) {
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "ice-options");
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "trickle");
+        attributeCount++;
+    }
+
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "fingerprint");
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "sha-256 ");
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue + 8, pCertificateFingerprint);

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -450,6 +450,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     CHK_STATUS(iceAgentPopulateSdpMediaDescriptionCandidates(pKvsPeerConnection->pIceAgent, pSdpMediaDescription, MAX_SDP_ATTRIBUTE_VALUE_LENGTH,
                                                              &attributeCount));
 
+    // TODO: Verify full string fit into buffer for each of the SNPRINTFs below.
     if (containRtx) {
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "msid");
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,

--- a/src/source/Rtcp/RtcpPacket.c
+++ b/src/source/Rtcp/RtcpPacket.c
@@ -15,7 +15,7 @@ STATUS setRtcpPacketFromBytes(PBYTE pRawPacket, UINT32 pRawPacketsLen, PRtcpPack
     // We don't assert exact length since this may be a compound packet, it
     // is the callers responsibility to parse subsequent entries
     packetLen = getInt16(*(PUINT16) (pRawPacket + RTCP_PACKET_LEN_OFFSET));
-    CHK((packetLen + 1) * RTCP_PACKET_LEN_WORD_SIZE <= pRawPacketsLen, STATUS_RTCP_INPUT_PARTIAL_PACKET);
+    CHK((packetLen + 1) * ((UINT16) RTCP_PACKET_LEN_WORD_SIZE) <= pRawPacketsLen, STATUS_RTCP_INPUT_PARTIAL_PACKET);
 
     pRtcpPacket->header.version = (pRawPacket[0] >> VERSION_SHIFT) & VERSION_MASK;
     CHK(pRtcpPacket->header.version == RTCP_PACKET_VERSION_VAL, STATUS_RTCP_INPUT_PACKET_INVALID_VERSION);

--- a/src/source/Rtcp/RtcpPacket.c
+++ b/src/source/Rtcp/RtcpPacket.c
@@ -15,7 +15,7 @@ STATUS setRtcpPacketFromBytes(PBYTE pRawPacket, UINT32 pRawPacketsLen, PRtcpPack
     // We don't assert exact length since this may be a compound packet, it
     // is the callers responsibility to parse subsequent entries
     packetLen = getInt16(*(PUINT16) (pRawPacket + RTCP_PACKET_LEN_OFFSET));
-    CHK((packetLen + 1) * ((UINT16) RTCP_PACKET_LEN_WORD_SIZE) <= pRawPacketsLen, STATUS_RTCP_INPUT_PARTIAL_PACKET);
+    CHK((UINT16)((packetLen + 1) * RTCP_PACKET_LEN_WORD_SIZE) <= pRawPacketsLen, STATUS_RTCP_INPUT_PARTIAL_PACKET);
 
     pRtcpPacket->header.version = (pRawPacket[0] >> VERSION_SHIFT) & VERSION_MASK;
     CHK(pRtcpPacket->header.version == RTCP_PACKET_VERSION_VAL, STATUS_RTCP_INPUT_PACKET_INVALID_VERSION);

--- a/src/source/Rtcp/RtcpPacket.c
+++ b/src/source/Rtcp/RtcpPacket.c
@@ -15,7 +15,7 @@ STATUS setRtcpPacketFromBytes(PBYTE pRawPacket, UINT32 pRawPacketsLen, PRtcpPack
     // We don't assert exact length since this may be a compound packet, it
     // is the callers responsibility to parse subsequent entries
     packetLen = getInt16(*(PUINT16) (pRawPacket + RTCP_PACKET_LEN_OFFSET));
-    CHK((UINT16)((packetLen + 1) * RTCP_PACKET_LEN_WORD_SIZE) <= pRawPacketsLen, STATUS_RTCP_INPUT_PARTIAL_PACKET);
+    CHK((UINT16) ((packetLen + 1) * RTCP_PACKET_LEN_WORD_SIZE) <= pRawPacketsLen, STATUS_RTCP_INPUT_PARTIAL_PACKET);
 
     pRtcpPacket->header.version = (pRawPacket[0] >> VERSION_SHIFT) & VERSION_MASK;
     CHK(pRtcpPacket->header.version == RTCP_PACKET_VERSION_VAL, STATUS_RTCP_INPUT_PACKET_INVALID_VERSION);

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -333,6 +333,7 @@ INT32 onSctpInboundPacket(struct socket* sock, union sctp_sockstore addr, PVOID 
     UNUSED_PARAM(sock);
     UNUSED_PARAM(addr);
     UNUSED_PARAM(flags);
+    STATUS retStatus = STATUS_SUCCESS;
     PSctpSession pSctpSession = (PSctpSession) ulp_info;
     BOOL isBinary = FALSE;
 

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -358,6 +358,8 @@ INT32 onSctpInboundPacket(struct socket* sock, union sctp_sockstore addr, PVOID 
 
 CleanUp:
 
+    UNUSED_PARAM(retStatus);
+    
     /*
      * IMPORTANT!!! The allocation is done in the sctp library using default allocator
      * so we need to use the default free API.

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -359,7 +359,7 @@ INT32 onSctpInboundPacket(struct socket* sock, union sctp_sockstore addr, PVOID 
 CleanUp:
 
     UNUSED_PARAM(retStatus);
-    
+
     /*
      * IMPORTANT!!! The allocation is done in the sctp library using default allocator
      * so we need to use the default free API.

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -208,13 +208,13 @@ CleanUp:
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //     |         Label Length          |       Protocol Length         |
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//     \                                                               /
+//     |                                                               |
 //     |                             Label                             |
-//     /                                                               \
+//     |                                                               |
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//     \                                                               /
+//     |                                                               |
 //     |                            Protocol                           |
-//     /                                                               \
+//     |                                                               |
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 STATUS sctpSessionWriteDcep(PSctpSession pSctpSession, UINT32 streamId, PCHAR pChannelName, UINT32 pChannelNameLen,
                             PRtcDataChannelInit pRtcDataChannelInit)
@@ -246,10 +246,10 @@ STATUS sctpSessionWriteDcep(PSctpSession pSctpSession, UINT32 streamId, PCHAR pC
     if (!pRtcDataChannelInit->ordered) {
         pSctpSession->packet[1] |= DCEP_DATA_CHANNEL_RELIABLE_UNORDERED;
     }
-    if (pRtcDataChannelInit->maxRetransmits.value >= 0 && pRtcDataChannelInit->maxRetransmits.isNull == FALSE) {
+    if (pRtcDataChannelInit->maxRetransmits.isNull == FALSE) {
         pSctpSession->packet[1] |= DCEP_DATA_CHANNEL_REXMIT;
         putUnalignedInt32BigEndian(pSctpSession->packet + SIZEOF(UINT32), pRtcDataChannelInit->maxRetransmits.value);
-    } else if (pRtcDataChannelInit->maxPacketLifeTime.value >= 0 && pRtcDataChannelInit->maxPacketLifeTime.isNull == FALSE) {
+    } else if (pRtcDataChannelInit->maxPacketLifeTime.isNull == FALSE) {
         pSctpSession->packet[1] |= DCEP_DATA_CHANNEL_TIMED;
         putUnalignedInt32BigEndian(pSctpSession->packet + SIZEOF(UINT32), pRtcDataChannelInit->maxPacketLifeTime.value);
     }
@@ -315,7 +315,7 @@ STATUS handleDcepPacket(PSctpSession pSctpSession, UINT32 streamId, PBYTE data, 
     putInt16((PINT16) &labelLength, labelLength);
     putInt16((PINT16) &protocolLength, protocolLength);
 
-    CHK((labelLength + protocolLength + SCTP_DCEP_HEADER_LENGTH) >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
+    CHK((UINT16) (labelLength + protocolLength + SCTP_DCEP_HEADER_LENGTH) >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
 
     CHK(SCTP_MAX_ALLOWABLE_PACKET_LENGTH >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
 
@@ -333,7 +333,6 @@ INT32 onSctpInboundPacket(struct socket* sock, union sctp_sockstore addr, PVOID 
     UNUSED_PARAM(sock);
     UNUSED_PARAM(addr);
     UNUSED_PARAM(flags);
-    STATUS retStatus = STATUS_SUCCESS;
     PSctpSession pSctpSession = (PSctpSession) ulp_info;
     BOOL isBinary = FALSE;
 

--- a/src/source/Stun/Stun.c
+++ b/src/source/Stun/Stun.c
@@ -555,7 +555,7 @@ STATUS deserializeStunPacket(PBYTE pStunBuffer, UINT32 bufferSize, PBYTE passwor
     magicCookie = (UINT32) getInt32(*(PUINT32) ((PBYTE) pStunHeader + STUN_HEADER_TYPE_LEN + STUN_HEADER_DATA_LEN));
 
     // Validate the specified size
-    CHK(bufferSize >= (UINT16)(messageLength + STUN_HEADER_LEN), STATUS_INVALID_ARG);
+    CHK(bufferSize >= (UINT16) (messageLength + STUN_HEADER_LEN), STATUS_INVALID_ARG);
 
     // Validate the magic cookie
     CHK(magicCookie == STUN_HEADER_MAGIC_COOKIE, STATUS_STUN_MAGIC_COOKIE_MISMATCH);

--- a/src/source/Stun/Stun.c
+++ b/src/source/Stun/Stun.c
@@ -555,7 +555,7 @@ STATUS deserializeStunPacket(PBYTE pStunBuffer, UINT32 bufferSize, PBYTE passwor
     magicCookie = (UINT32) getInt32(*(PUINT32) ((PBYTE) pStunHeader + STUN_HEADER_TYPE_LEN + STUN_HEADER_DATA_LEN));
 
     // Validate the specified size
-    CHK(bufferSize >= messageLength + STUN_HEADER_LEN, STATUS_INVALID_ARG);
+    CHK(bufferSize >= (UINT16)(messageLength + STUN_HEADER_LEN), STATUS_INVALID_ARG);
 
     // Validate the magic cookie
     CHK(magicCookie == STUN_HEADER_MAGIC_COOKIE, STATUS_STUN_MAGIC_COOKIE_MISMATCH);


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Updated the GCC path set in the Mac GCC CI build.

*Why was it changed?*
"gcc" is mapped to CLANG on Mac, so the build was using CLANG rather than GCC compiler.

*How was it changed?*
The full path to the GCC and G++ compiler was identified, and it replaced the "gcc" and "g++" in the respective environment variables.

*What testing was done for the changes?*
The CI is to run to verify that the correct compiler is used and that the test is passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
