### PR TITLE
Add missing NULL check for session token

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -760,7 +760,7 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
 #endif
 
     pSessionToken = GETENV(SESSION_TOKEN_ENV_VAR);
-    if (IS_EMPTY_STRING(pSessionToken)) {
+    if (pSessionToken != NULL && IS_EMPTY_STRING(pSessionToken)) {
         DLOGW("Session token is set but its value is empty. Ignoring.");
         pSessionToken = NULL;
     }


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Adding a missing null check before checking anything related to the string

*Why was it changed?*
If that check is missing and the env var is not set, the sample segfaults

*How was it changed?*
It was changed by adding a null check before checking anything related to the string

*What testing was done for the changes?*
Tested locally that even if the value is not, the sample does not segfault

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
