### PR TITLE
No more detaching threads in tests

### DIFF
--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -91,6 +91,8 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersWithDelay)
     answer.client = this;
 
     auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
+        UNUSED_PARAM(customData);
+        UNUSED_PARAM(candidateStr);
     };
 
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) &answer, onICECandidateHdlr));
@@ -705,6 +707,8 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
     answer.client = this;
 
     auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
+        UNUSED_PARAM(customData);
+        UNUSED_PARAM(candidateStr);
     };
 
     auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -90,6 +90,9 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersWithDelay)
     answer.pc = answerPc;
     answer.client = this;
 
+    auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
+    };
+
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) &answer, onICECandidateHdlr));
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) &offer, onICECandidateHdlr));
 
@@ -126,6 +129,9 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersWithDelay)
     this->threads.clear();
     this->noNewThreads = TRUE;
     this->lock.unlock();
+
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) 0, onICECandidateHdlrDone));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) 0, onICECandidateHdlrDone));
 
     closePeerConnection(offerPc);
     closePeerConnection(answerPc);
@@ -698,6 +704,9 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
     answer.pc = answerPc;
     answer.client = this;
 
+    auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
+    };
+
     auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
         UNUSED_PARAM(pFrame);
         if (pFrame->frameData[0] == 1) {
@@ -751,6 +760,9 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
     this->threads.clear();
     this->noNewThreads = TRUE;
     this->lock.unlock();
+
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) 0, onICECandidateHdlrDone));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) 0, onICECandidateHdlrDone));
 
     MEMFREE(videoFrame.frameData);
     closePeerConnection(offerPc);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -71,6 +71,7 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersWithDelay)
     auto onICECandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
         PPeerContainer container = (PPeerContainer)customData;
         if (candidateStr != NULL) {
+            container->client->lock.lock();
             container->client->threads.push_back(std::thread(
                 [container](std::string candidate) {
                     RtcIceCandidateInit iceCandidate;
@@ -78,6 +79,7 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersWithDelay)
                     EXPECT_EQ(STATUS_SUCCESS, addIceCandidate((PRtcPeerConnection) container->pc, iceCandidate.candidate));
                 },
                 std::string(candidateStr)));
+            container->client->lock.unlock();
         }
     };
 
@@ -672,6 +674,7 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
     auto onICECandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
         PPeerContainer container = (PPeerContainer)customData;
         if (candidateStr != NULL) {
+            container->client->lock.lock();
             container->client->threads.push_back(std::thread(
                 [container](std::string candidate) {
                     RtcIceCandidateInit iceCandidate;
@@ -679,6 +682,7 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
                     EXPECT_EQ(STATUS_SUCCESS, addIceCandidate((PRtcPeerConnection) container->pc, iceCandidate.candidate));
                 },
                 std::string(candidateStr)));
+            container->client->lock.unlock();
         }
     };
 

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -88,6 +88,7 @@ void WebRtcClientTestBase::SetUp()
     mDroppedFrameIndex = 0;
     mExpectedFrameCount = 0;
     mExpectedDroppedFrameCount = 0;
+    noNewThreads = FALSE;
 
     SET_INSTRUMENTED_ALLOCATORS();
 
@@ -218,6 +219,7 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
     RtcSessionDescriptionInit sdp;
     PeerContainer offer;
     PeerContainer answer;
+    this->noNewThreads = FALSE;
 
     auto onICECandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
         PPeerContainer container = (PPeerContainer)customData;
@@ -290,6 +292,7 @@ bool WebRtcClientTestBase::connectTwoPeersAsyncIce(PRtcPeerConnection offerPc, P
     RtcSessionDescriptionInit sdp;
     PeerContainer offer;
     PeerContainer answer;
+    this->noNewThreads = FALSE;
 
     auto onICECandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
         PPeerContainer container = (PPeerContainer)customData;

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -222,6 +222,7 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
     auto onICECandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
         PPeerContainer container = (PPeerContainer)customData;
         if (candidateStr != NULL) {
+            container->client->lock.lock();
             container->client->threads.push_back(std::thread(
                 [container](std::string candidate) {
                     RtcIceCandidateInit iceCandidate;
@@ -229,7 +230,9 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
                     EXPECT_EQ(STATUS_SUCCESS, addIceCandidate((PRtcPeerConnection) container->pc, iceCandidate.candidate));
                 },
                 std::string(candidateStr)));
+            container->client->lock.unlock();
         }
+
     };
 
     offer.pc = offerPc;
@@ -286,6 +289,7 @@ bool WebRtcClientTestBase::connectTwoPeersAsyncIce(PRtcPeerConnection offerPc, P
     auto onICECandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
         PPeerContainer container = (PPeerContainer)customData;
         if (candidateStr != NULL) {
+            container->client->lock.lock();
             container->client->threads.push_back(std::thread(
                 [container](std::string candidate) {
                     RtcIceCandidateInit iceCandidate;
@@ -293,6 +297,7 @@ bool WebRtcClientTestBase::connectTwoPeersAsyncIce(PRtcPeerConnection offerPc, P
                     EXPECT_EQ(STATUS_SUCCESS, addIceCandidate((PRtcPeerConnection) container->pc, iceCandidate.candidate));
                 },
                 std::string(candidateStr)));
+            container->client->lock.unlock();
         }
     };
 

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -239,6 +239,9 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
 
     };
 
+    auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
+    };
+
     offer.pc = offerPc;
     offer.client = this;
     answer.pc = answerPc;
@@ -283,6 +286,10 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
     this->noNewThreads = TRUE;
     this->lock.unlock();
 
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) 0, onICECandidateHdlrDone));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) 0, onICECandidateHdlrDone));
+
+
     return ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_CONNECTED]) == 2;
 }
 
@@ -309,6 +316,9 @@ bool WebRtcClientTestBase::connectTwoPeersAsyncIce(PRtcPeerConnection offerPc, P
             }
             container->client->lock.unlock();
         }
+    };
+
+    auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
     };
 
     offer.pc = offerPc;
@@ -356,6 +366,9 @@ bool WebRtcClientTestBase::connectTwoPeersAsyncIce(PRtcPeerConnection offerPc, P
     this->threads.clear();
     this->noNewThreads = TRUE;
     this->lock.unlock();
+
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) 0, onICECandidateHdlrDone));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) 0, onICECandidateHdlrDone));
 
     return ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_CONNECTED]) == 2;
 }

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -240,6 +240,8 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
     };
 
     auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
+        UNUSED_PARAM(customData);
+        UNUSED_PARAM(candidateStr);
     };
 
     offer.pc = offerPc;
@@ -319,6 +321,8 @@ bool WebRtcClientTestBase::connectTwoPeersAsyncIce(PRtcPeerConnection offerPc, P
     };
 
     auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
+        UNUSED_PARAM(customData);
+        UNUSED_PARAM(candidateStr);
     };
 
     offer.pc = offerPc;

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -334,6 +334,9 @@ bool WebRtcClientTestBase::connectTwoPeersAsyncIce(PRtcPeerConnection offerPc, P
         THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
     }
 
+    //join all threads before leaving
+    for (auto& th : this->threads) th.join();
+
     this->threads.clear();
 
     return ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_CONNECTED]) == 2;

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -58,6 +58,7 @@ class WebRtcClientTestBase : public ::testing::Test {
     UINT32 mRtpPacketCount;
     UINT32 mUriCount = 0;
     SIGNALING_CLIENT_HANDLE mSignalingClientHandle;
+    std::vector<std::thread> threads;
 
     WebRtcClientTestBase();
 
@@ -336,6 +337,11 @@ class WebRtcClientTestBase : public ::testing::Test {
     SignalingClientInfo mClientInfo;
     Tag mTags[3];
 };
+
+typedef struct {
+    PRtcPeerConnection pc;
+    WebRtcClientTestBase* client;
+} PeerContainer, *PPeerContainer;
 
 } // namespace webrtcclient
 } // namespace video

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -59,6 +59,7 @@ class WebRtcClientTestBase : public ::testing::Test {
     UINT32 mUriCount = 0;
     SIGNALING_CLIENT_HANDLE mSignalingClientHandle;
     std::vector<std::thread> threads;
+    std::mutex lock;
 
     WebRtcClientTestBase();
 

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -60,6 +60,7 @@ class WebRtcClientTestBase : public ::testing::Test {
     SIGNALING_CLIENT_HANDLE mSignalingClientHandle;
     std::vector<std::thread> threads;
     std::mutex lock;
+    BOOL noNewThreads = FALSE;
 
     WebRtcClientTestBase();
 


### PR DESCRIPTION
*What was changed?*
Thread detach in the tests were changed to be joinable, joined, and then the callback removed at the end of the function connectTwoPeers and similar operations throughout the test.

*Why was it changed?*
CI was experiencing TSAN failures.

*How was it changed?*
Explained in "what was changed"

*What testing was done for the changes?*
CI was used to confirm the changes fixed the issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
