### PR TITLE
Fix packetsDiscarded tracking operation

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -293,7 +293,7 @@ CleanUp:
         pTransceiver->inboundStats.headerBytesReceived += headerBytesReceived;
         pTransceiver->inboundStats.bytesReceived += bytesReceived;
         pTransceiver->inboundStats.received.jitter = pTransceiver->pJitterBuffer->jitter / pTransceiver->pJitterBuffer->clockRate;
-        pTransceiver->inboundStats.received.packetsDiscarded = packetsDiscarded;
+        pTransceiver->inboundStats.received.packetsDiscarded += packetsDiscarded;
         MUTEX_UNLOCK(pTransceiver->statsLock);
     }
     if (!ownedByJitterBuffer) {


### PR DESCRIPTION
*Issue #, if available:*
#1899 

*What was changed?*
- Fixed the calculation of packets discarded in inbound rtp stats.

*Why was it changed?*
- We want to add up the number of packets discarded every time we receive an inbound packet to ensure the application gets the total value. 

*How was it changed?*
- Changed from `pTransceiver->inboundStats.received.packetsDiscarded = packetsDiscarded;` to `pTransceiver->inboundStats.received.packetsDiscarded += packetsDiscarded;`

*What testing was done for the changes?*
- Sample run to confirm no breaking change. 
- CI

Closes #1899 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
