### PR TITLE
Remove tp unused

### DIFF
--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -37,10 +37,6 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     CHK_STATUS(createValidateChannelInfo(pChannelInfo, &pSignalingClient->pChannelInfo));
     CHK_STATUS(validateSignalingCallbacks(pSignalingClient, pCallbacks));
     CHK_STATUS(validateSignalingClientInfo(pSignalingClient, pClientInfo));
-#ifdef KVS_USE_SIGNALING_CHANNEL_THREADPOOL
-    CHK_STATUS(threadpoolCreate(&pSignalingClient->pThreadpool, pClientInfo->signalingClientInfo.signalingMessagesMinimumThreads,
-                                pClientInfo->signalingClientInfo.signalingMessagesMaximumThreads));
-#endif
     pSignalingClient->version = SIGNALING_CLIENT_CURRENT_VERSION;
     // Set invalid call times
     pSignalingClient->describeTime = INVALID_TIMESTAMP_VALUE;

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -373,10 +373,6 @@ typedef struct {
     UINT64 connectTime;
     UINT64 describeMediaTime;
     UINT64 answerTime;
-
-#ifdef KVS_USE_SIGNALING_CHANNEL_THREADPOOL
-    PThreadpool pThreadpool;
-#endif
     UINT64 offerReceivedTime;
     UINT64 offerSentTime;
 


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Removed threadpool create in signaling since the common threadpool is used

*Why was it changed?*
- To ensure code is clean of unused functions

*How was it changed?*
- Simple delete of the code portions with SIGNALING specific threadpool

*What testing was done for the changes?*
- Ensured clean build
- Ran sample
- Allow unit test to pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
