### PR TITLE
Fix signal cache operation on windows

### DIFF
--- a/src/source/Signaling/FileCache.c
+++ b/src/source/Signaling/FileCache.c
@@ -147,7 +147,7 @@ STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, SIGNALING_CHA
         /* +1 for null terminator */
         fileBuffer = MEMCALLOC(1, (fileSize + 1) * SIZEOF(CHAR));
         CHK(fileBuffer != NULL, STATUS_NOT_ENOUGH_MEMORY);
-        CHK_STATUS(readFile(cacheFilePath, FALSE, (PBYTE) fileBuffer, &fileSize));
+        CHK_STATUS(readFile(cacheFilePath, TRUE, (PBYTE) fileBuffer, &fileSize));
 
         CHK_STATUS(deserializeSignalingCacheEntries(fileBuffer, fileSize, entries, &entryCount, cacheFilePath));
 


### PR DESCRIPTION
If the signal cache is read on windows, it is always marked as being unreadable. Read in ASCII mode to prevent this.

*Issue #, if available:*

*What was changed?*

Read signal cache in ascii rather than binary.

*Why was it changed?*

On windows, reading the file in binary results in an unparsable signal cache.

*How was it changed?*

Change file read from binary to ascii.

*What testing was done for the changes?*

Verified correct operation on Windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
