### PR TITLE
Ensure remote description does not live in memory for viewer duration

### DIFF
--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -85,7 +85,7 @@ typedef struct {
 
     PSctpSession pSctpSession;
 
-    SessionDescription remoteSessionDescription;
+    PSessionDescription pRemoteSessionDescription;
     PDoubleList pTransceivers;
     PDoubleList pFakeTransceivers;
     PDoubleList pAnswerTransceivers;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -413,9 +413,10 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         CHK_STATUS(hashTableGet(pUnknownCodecPayloadTypesTable, unknownCodecHashTableKey, &payloadType));
     } else {
         CHK_STATUS(hashTableGet(pKvsPeerConnection->pCodecTable, pRtcMediaStreamTrack->codec, &payloadType));
-        currentFmtp = fmtpForPayloadType(payloadType, &(pKvsPeerConnection->remoteSessionDescription));
+        if (!pKvsPeerConnection->isOffer) {
+            currentFmtp = fmtpForPayloadType(payloadType, pRemoteSessionDescription);
+        }
     }
-
     if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
         if (pRtcMediaStreamTrack->codec == RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE) {
             retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE,
@@ -555,11 +556,14 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     attributeCount++;
 
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "mid");
-    // check all session attribute lines to see if a line with mid is present. If it is present, copy its content and break
-    for (i = 0; i < pRemoteSessionDescription->mediaDescriptions[mediaSectionId].mediaAttributesCount; i++) {
-        if (STRCMP(pRemoteSessionDescription->mediaDescriptions[mediaSectionId].sdpAttributes[i].attributeName, MID_KEY) == 0) {
-            STRCPY(remoteSdpAttributeValue, pRemoteSessionDescription->mediaDescriptions[mediaSectionId].sdpAttributes[i].attributeValue);
-            break;
+
+    if (!pKvsPeerConnection->isOffer) {
+        // check all session attribute lines to see if a line with mid is present. If it is present, copy its content and break
+        for (i = 0; i < pRemoteSessionDescription->mediaDescriptions[mediaSectionId].mediaAttributesCount; i++) {
+            if (STRCMP(pRemoteSessionDescription->mediaDescriptions[mediaSectionId].sdpAttributes[i].attributeName, MID_KEY) == 0) {
+                STRCPY(remoteSdpAttributeValue, pRemoteSessionDescription->mediaDescriptions[mediaSectionId].sdpAttributes[i].attributeValue);
+                break;
+            }
         }
     }
 
@@ -620,7 +624,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
 
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-mux");
     attributeCount++;
-
+    DLOGI("Here");
     if (mediaSectionId != 0) {
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-rsize");
         attributeCount++;
@@ -888,10 +892,8 @@ STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PS
     UINT32 unknownCodecHashTableKey = 0;
 
     CHK_STATUS(dtlsSessionGetLocalCertificateFingerprint(pKvsPeerConnection->pDtlsSession, certificateFingerprint, CERTIFICATE_FINGERPRINT_LENGTH));
-
     if (pKvsPeerConnection->isOffer) {
         pDtlsRole = DTLS_ROLE_ACTPASS;
-
         CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
         while (pCurNode != NULL) {
             CHK_STATUS(doubleListGetNodeData(pCurNode, &data));
@@ -899,7 +901,6 @@ STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PS
             pKvsRtpTransceiver = (PKvsRtpTransceiver) data;
             if (pKvsRtpTransceiver != NULL) {
                 CHK(pLocalSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT);
-
                 // If generating answer, need to check if Local Description is present in remote -- if not, we don't need to create a local
                 // description for it or else our Answer will have an extra m-line, for offer the local is the offer itself, don't care about remote
                 CHK_STATUS(populateSingleMediaSection(
@@ -912,12 +913,10 @@ STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PS
         pDtlsRole = DTLS_ROLE_ACTIVE;
         CHK_STATUS(hashTableCreate(&pUnknownCodecPayloadTypesTable));
         CHK_STATUS(hashTableCreate(&pUnknownCodecRtpmapTable));
-
         // this function creates a list of transceivers corresponding to each m-line and adds it answerTransceivers
         // if an m-line does not have a corresponding transceiver created by the user, we create a fake transceiver
         CHK_STATUS(findTransceiversByRemoteDescription(pKvsPeerConnection, pRemoteSessionDescription, pUnknownCodecPayloadTypesTable,
                                                        pUnknownCodecRtpmapTable));
-
         // pAnswerTransceivers contains transceivers created by the user as well as fake transceivers
         CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pAnswerTransceivers, &pCurNode));
         while (pCurNode != NULL) {
@@ -984,12 +983,14 @@ STATUS populateSessionDescription(PKvsPeerConnection pKvsPeerConnection, PSessio
     UINT32 i, sizeRemaining;
     INT32 charsCopied;
 
-    CHK(pKvsPeerConnection != NULL && pLocalSessionDescription != NULL && pRemoteSessionDescription != NULL, STATUS_NULL_ARG);
+    CHK(pKvsPeerConnection != NULL && pLocalSessionDescription != NULL, STATUS_NULL_ARG);
+    if (!pKvsPeerConnection->isOffer) {
+        CHK(pRemoteSessionDescription != NULL, STATUS_NULL_ARG);
+    }
     CHK_STATUS(populateSessionDescriptionMedia(pKvsPeerConnection, pRemoteSessionDescription, pLocalSessionDescription));
     MEMSET(bundleValue, 0, MAX_SDP_ATTRIBUTE_VALUE_LENGTH);
     MEMSET(wmsValue, 0, MAX_SDP_ATTRIBUTE_VALUE_LENGTH);
     MEMSET(remoteSdpAttributeValue, 0, MAX_SDP_ATTRIBUTE_VALUE_LENGTH);
-
     STRCPY(pLocalSessionDescription->sdpOrigin.userName, "-");
     pLocalSessionDescription->sdpOrigin.sessionId = RAND();
     pLocalSessionDescription->sdpOrigin.sessionVersion = 2;
@@ -1006,7 +1007,6 @@ STATUS populateSessionDescription(PKvsPeerConnection pKvsPeerConnection, PSessio
     STRCPY(pLocalSessionDescription->sdpAttributes[0].attributeName, "group");
     STRCPY(pLocalSessionDescription->sdpAttributes[0].attributeValue, BUNDLE_KEY);
     pLocalSessionDescription->sessionAttributesCount++;
-
     if (pKvsPeerConnection->canTrickleIce.value) {
         STRCPY(pLocalSessionDescription->sdpAttributes[pLocalSessionDescription->sessionAttributesCount].attributeName, "ice-options");
         STRCPY(pLocalSessionDescription->sdpAttributes[pLocalSessionDescription->sessionAttributesCount].attributeValue, "trickle");
@@ -1014,10 +1014,12 @@ STATUS populateSessionDescription(PKvsPeerConnection pKvsPeerConnection, PSessio
     }
 
     // check all session attribute lines to see if a line with BUNDLE is present. If it is present, copy its content and break
-    for (i = 0; i < pRemoteSessionDescription->sessionAttributesCount; i++) {
-        if (STRSTR(pRemoteSessionDescription->sdpAttributes[i].attributeValue, BUNDLE_KEY) != NULL) {
-            STRCPY(remoteSdpAttributeValue, pRemoteSessionDescription->sdpAttributes[i].attributeValue + ARRAY_SIZE(BUNDLE_KEY) - 1);
-            break;
+    if (!pKvsPeerConnection->isOffer) {
+        for (i = 0; i < pRemoteSessionDescription->sessionAttributesCount; i++) {
+            if (STRSTR(pRemoteSessionDescription->sdpAttributes[i].attributeValue, BUNDLE_KEY) != NULL) {
+                STRCPY(remoteSdpAttributeValue, pRemoteSessionDescription->sdpAttributes[i].attributeValue + ARRAY_SIZE(BUNDLE_KEY) - 1);
+                break;
+            }
         }
     }
 

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -624,7 +624,6 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
 
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-mux");
     attributeCount++;
-    DLOGI("Here");
     if (mediaSectionId != 0) {
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-rsize");
         attributeCount++;


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Fixed the code where the SDK allocates remoteDescription member along with peer connection object, causing it to live in memory for the duration of the peer connection

*Why was it changed?*
- The SDP object takes up 800KB of memory to store a remote/local description. This leads to unnecessary memory usage, when the remote description is not required to remain in memory once the answer is generated. In the future, say the SDK resends the answer suspecting the viewer did not receive it, the SDK would not regenerate the answer, but would resend the same answer. A reconstruction would not be required and is not expected. 

*How was it changed?*
- Switched the peer connection member from : `SessionDescription remoteSessionDescription;` to `PSessionDescription pRemoteSessionDescription;` to allocate remote description separately. 
- Ensured the internal logic was fixed to perform certain checks only if the SDK is acting as a viewer.

Doing so ensures the ~800 KB of memory lives in memory for a short time.

Following are the graphs showing the persistent memory allocation in the viewer run duration.

Before this change: As seen, 832KiB persists till viewer disconnects
<img width="679" alt="Screenshot 2024-02-08 at 12 00 04 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/assets/22107309/34bf61b2-44e5-4d5d-8505-899d6f6d2576">

After this change: Only 1.5KiB of memory resides till viewer disconnects
<img width="679" alt="Screenshot 2024-02-08 at 12 05 13 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/assets/22107309/c93b5391-4382-453d-b485-29deb6b6cc62">


*What testing was done for the changes?*
- Tested master sample with viewer JS to confirm successful peer connection
- Tested viewer sample with master JS to confirm successful peer connection
- CI run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
