### PR TITLE
Use KVS stun host in discoverNatBehavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,7 +447,9 @@ endif()
 
 if(BUILD_TEST)
   # adding ZLIB because aws sdk static link seems to be broken when zlib is needed
-  find_package(ZLIB REQUIRED)
+  if(NOT WIN32)
+    find_package(ZLIB REQUIRED)
+  endif()
   add_subdirectory(tst)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -409,6 +409,19 @@ Similar to the heap profile, you only need to specify the following environment 
 
 More information about what environment variables you can configure can be found [here](https://gperftools.github.io/gperftools/cpuprofile.html)
 
+### WebRTC Network Compatibility Checker
+
+This program allows you to understand the network compatibility for WebRTC usage. By providing necessary parameters, it detects NAT behavior and filtering behavior and tells you if you can work with a particular STUN server or not. By default, it uses the STUN server from your environment variable `AWS_DEFAULT_REGION` if present. If not, it uses the STUN server from `us-west-2`.
+#### How to Use
+
+1. **Parameters**:
+   - `-i network-interface-name`: Specify the network interface name.
+   - `-s stun-hostname`: Specify the STUN server hostname.
+
+2. **Example**:
+   ```bash
+   ./discoverNatBehavior -i eth0 -s stun.example.com
+
 ### Filtering network interfaces
 
 This is useful to reduce candidate gathering time when it is known for certain network interfaces to not work well. A sample callback is available in `Common.c`. The `iceSetInterfaceFilterFunc` in `KvsRtcConfiguration` must be set to the required callback. In the sample, it can be done this way in `initializePeerConnection()`: 

--- a/samples/discoverNatBehavior.c
+++ b/samples/discoverNatBehavior.c
@@ -54,8 +54,8 @@ INT32 main(INT32 argc, CHAR** argv)
             pHostnamePostfix = KINESIS_VIDEO_STUN_URL_POSTFIX_CN;
         }
         defaultStunHostName = (PCHAR) MEMALLOC((MAX_ICE_CONFIG_URI_LEN + 1) * SIZEOF(CHAR));
+        SNPRINTF(defaultStunHostName, MAX_ICE_CONFIG_URI_LEN + 1, KINESIS_VIDEO_STUN_URL, pRegion, pHostnamePostfix);
         stunHostname = defaultStunHostName;
-        SNPRINTF(stunHostname, MAX_ICE_CONFIG_URI_LEN + 1, KINESIS_VIDEO_STUN_URL, pRegion, pHostnamePostfix);
     }
 
     DLOGI("Using stun host: %s, local network interface %s.", stunHostname, interfaceName);

--- a/samples/discoverNatBehavior.c
+++ b/samples/discoverNatBehavior.c
@@ -2,12 +2,12 @@
 
 #define NETWORK_INTERFACE_NAME_PARAM "-i"
 #define STUN_HOSTNAME_PARAM          "-s"
-#define DEFAULT_STUN_HOST            "stun:stun.sipgate.net:3478"
+#define DEFAULT_STUN_HOST            "stun:stun.kinesisvideo.us-west-2.amazonaws.com:443"
 
 BOOL filterFunc(UINT64 data, PCHAR name)
 {
     CHAR* desiredInterface = (CHAR*) data;
-    if (desiredInterface == NULL || STRCMP(name, desiredInterface) == 0) {
+    if (desiredInterface == NULL || STRNCMP(name, desiredInterface, STRLEN(name)) == 0) {
         return TRUE;
     }
     return FALSE;

--- a/samples/discoverNatBehavior.c
+++ b/samples/discoverNatBehavior.c
@@ -1,12 +1,13 @@
 #include <com/amazonaws/kinesis/video/webrtcclient/Include.h>
 
-#define NETWORK_INTERFACE_NAME_PARAM "-i"
-#define STUN_HOSTNAME_PARAM          "-s"
+#define NETWORK_INTERFACE_NAME_PARAM   "-i"
+#define STUN_HOSTNAME_PARAM            "-s"
+#define MAX_LEN_NETWORK_INTERFACE_NAME 15
 
 BOOL filterFunc(UINT64 data, PCHAR name)
 {
     CHAR* desiredInterface = (CHAR*) data;
-    if (desiredInterface == NULL || STRNCMP(name, desiredInterface, STRLEN(name)) == 0) {
+    if (desiredInterface == NULL || STRNCMP(name, desiredInterface, STRNLEN(name, MAX_LEN_NETWORK_INTERFACE_NAME)) == 0) {
         return TRUE;
     }
     return FALSE;
@@ -45,10 +46,10 @@ INT32 main(INT32 argc, CHAR** argv)
     SNPRINTF(stunHostname, MAX_ICE_CONFIG_URI_LEN + 1, KINESIS_VIDEO_STUN_URL, pRegion, pHostnamePostfix);
 
     for (i = 1; i < argc; ++i) {
-        if (STRNCMP(argv[i], NETWORK_INTERFACE_NAME_PARAM, STRLEN(argv[i])) == 0) {
+        if (STRNCMP(argv[i], NETWORK_INTERFACE_NAME_PARAM, STRNLEN(argv[i], MAX_LEN_NETWORK_INTERFACE_NAME)) == 0) {
             interfaceName = argv[++i];
             i++;
-        } else if (STRNCMP(argv[i], STUN_HOSTNAME_PARAM, STRLEN(argv[i])) == 0) {
+        } else if (STRNCMP(argv[i], STUN_HOSTNAME_PARAM, STRNLEN(argv[i], MAX_ICE_CONFIG_URI_LEN + 1)) == 0) {
             stunHostname = argv[++i];
             i++;
         } else {

--- a/samples/discoverNatBehavior.c
+++ b/samples/discoverNatBehavior.c
@@ -24,10 +24,10 @@ INT32 main(INT32 argc, CHAR** argv)
     CHAR* logLevelStr = NULL;
 
     for (i = 1; i < argc; ++i) {
-        if (STRCMP(argv[i], NETWORK_INTERFACE_NAME_PARAM) == 0) {
+        if (STRNCMP(argv[i], NETWORK_INTERFACE_NAME_PARAM, STRLEN(argv[i])) == 0) {
             interfaceName = argv[++i];
             i++;
-        } else if (STRCMP(argv[i], STUN_HOSTNAME_PARAM) == 0) {
+        } else if (STRNCMP(argv[i], STUN_HOSTNAME_PARAM, STRLEN(argv[i])) == 0) {
             stunHostname = argv[++i];
             i++;
         } else {

--- a/samples/discoverNatBehavior.c
+++ b/samples/discoverNatBehavior.c
@@ -31,7 +31,7 @@ INT32 main(INT32 argc, CHAR** argv)
     if (STRSTR(pRegion, "cn-")) {
         pHostnamePostfix = KINESIS_VIDEO_STUN_URL_POSTFIX_CN;
     }
-    stunHostname = (PCHAR) MEMALLOC ((MAX_ICE_CONFIG_URI_LEN + 1) * SIZEOF(CHAR));
+    stunHostname = (PCHAR) MEMALLOC((MAX_ICE_CONFIG_URI_LEN + 1) * SIZEOF(CHAR));
     SNPRINTF(stunHostname, MAX_ICE_CONFIG_URI_LEN + 1, KINESIS_VIDEO_STUN_URL, pRegion, pHostnamePostfix);
 
     for (i = 1; i < argc; ++i) {


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Use a KVS STUN host instead of `stun:stun.sipgate.net:3478`

*Why was it changed?*
Using a KVS STUN host will help customers use discoverNatBehavior to understand their network and its interaction with KVS STUN better

*How was it changed?*
Modified the string for the host name to use a KVS STUN from PDX

*What testing was done for the changes?*
STUN
```
niyatim@88665a374cf5 build % ./samples/discoverNatBehavior
Usage: ./discoverNatBehavior -i network-interface-name -s stun-hostname
Using stun host: stun:stun.kinesisvideo.us-west-2.amazonaws.com:443, local network interface (null).
2024-02-08 13:29:18.091 INFO    getIpWithHostName(): ICE SERVER Hostname received: stun.kinesisvideo.us-west-2.amazonaws.com
2024-02-08 13:29:18.093 WARN    getIpAddrFromDnsHostname(): Received unexpected hostname format: stun.kinesisvideo.us-west-2.amazonaws.com
2024-02-08 13:29:18.093 WARN    getIpWithHostName(): Parsing for address failed for stun.kinesisvideo.us-west-2.amazonaws.com, fallback to getaddrinfo
2024-02-08 13:29:18.260 INFO    resolveStunIceServerIp(): ICE Server address for stun.kinesisvideo.us-west-2.amazonaws.com with getaddrinfo: 54.200.157.178
2024-02-08 13:29:18.260 PROFILE parseIceServer(): ICE Server address for stun.kinesisvideo.us-west-2.amazonaws.com: 54.200.157.178
2024-02-08 13:29:18.260 PROFILE resolveStunIceServerIp(): [STUN DNS resolution time taken] Time taken: 168 ms
2024-02-08 13:29:18.260 DEBUG   resolveStunIceServerIp(): Exiting from stun server IP resolution thread
2024-02-08 13:29:18.260 DEBUG   createSocketConnection(): create socket with ip: 192.168.0.104:55061. family:1
2024-02-08 13:29:18.260 DEBUG   discoverNatBehavior(): Start NAT mapping behavior test.
2024-02-08 13:29:18.260 DEBUG   discoverNatMappingBehavior(): Running mapping behavior test I. Send binding request
2024-02-08 13:29:18.260 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:54.200.157.178, port:443
2024-02-08 13:29:18.527 ERROR   discoverNatMappingBehavior(): Expect binding response to have other address or changed address attribute
2024-02-08 13:29:18.527 DEBUG   socketConnectionClosed(): Close socket 6
2024-02-08 13:29:18.737 DEBUG   freeSocketConnection(): close socket with ip: 192.168.0.104:55061. family:1
2024-02-08 13:29:18.737 DEBUG   freeSocketConnection(): close socket connected with ip: 0000:0000:0000:0000:0000:0000:0000:0000:0. family:0
2024-02-08 13:29:18.737 DEBUG   createSocketConnection(): create socket with ip: 192.168.0.104:63270. family:1
2024-02-08 13:29:18.737 DEBUG   discoverNatBehavior(): Start NAT filtering behavior test.
2024-02-08 13:29:18.737 DEBUG   discoverNatFilteringBehavior(): Running filtering behavior test I. Send binding request
2024-02-08 13:29:18.737 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:54.200.157.178, port:443
2024-02-08 13:29:18.998 DEBUG   discoverNatFilteringBehavior(): Running filtering behavior test II. Send binding request with change ip and change port flag
2024-02-08 13:29:18.998 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:54.200.157.178, port:443
2024-02-08 13:29:19.260 DEBUG   socketConnectionClosed(): Close socket 6
2024-02-08 13:29:19.260 DEBUG   freeSocketConnection(): close socket with ip: 192.168.0.104:63270. family:1
2024-02-08 13:29:19.260 DEBUG   freeSocketConnection(): close socket connected with ip: 0000:0000:0000:0000:0000:0000:0000:0000:0. family:0
Detected NAT mapping behavior NONE
Failed to detect NAT mapping behavior
Detected NAT filtering behavior ENDPOINT_INDEPENDENT
Host's NAT allows to receive UDP packet from any external address. STUN is usable.
2024-02-08 13:29:19.260 DEBUG   cleanupWebRtcClientInstance(): Releasing webrtc client context instance from cleanupWebRtcClientInstance
2024-02-08 13:29:19.260 INFO    cleanupWebRtcClientInstance(): Destroyed STUN IP object
2024-02-08 13:29:19.260 INFO    cleanupWebRtcClientInstance(): Destroyed WebRtc client context
2024-02-08 13:29:19.265 INFO    deinitKvsWebRtc(): Destroyed threadpool
```

TURN
```
niyatim@88665a374cf5 build % ./samples/discoverNatBehavior
Usage: ./discoverNatBehavior -i network-interface-name -s stun-hostname
Using stun host: stun:stun.kinesisvideo.us-west-2.amazonaws.com:443, local network interface (null).
2024-02-08 13:29:28.816 INFO    getIpWithHostName(): ICE SERVER Hostname received: stun.kinesisvideo.us-west-2.amazonaws.com
2024-02-08 13:29:28.817 WARN    getIpAddrFromDnsHostname(): Received unexpected hostname format: stun.kinesisvideo.us-west-2.amazonaws.com
2024-02-08 13:29:28.817 WARN    getIpWithHostName(): Parsing for address failed for stun.kinesisvideo.us-west-2.amazonaws.com, fallback to getaddrinfo
2024-02-08 13:29:29.063 PROFILE parseIceServer(): ICE Server address for stun.kinesisvideo.us-west-2.amazonaws.com: 54.200.157.178
2024-02-08 13:29:29.063 INFO    resolveStunIceServerIp(): ICE Server address for stun.kinesisvideo.us-west-2.amazonaws.com with getaddrinfo: 54.200.157.178
2024-02-08 13:29:29.063 PROFILE resolveStunIceServerIp(): [STUN DNS resolution time taken] Time taken: 246 ms
2024-02-08 13:29:29.063 DEBUG   resolveStunIceServerIp(): Exiting from stun server IP resolution thread
2024-02-08 13:29:29.063 DEBUG   createSocketConnection(): create socket with ip: 192.168.0.104:59268. family:1
2024-02-08 13:29:29.063 DEBUG   discoverNatBehavior(): Start NAT mapping behavior test.
2024-02-08 13:29:29.063 DEBUG   discoverNatMappingBehavior(): Running mapping behavior test I. Send binding request
2024-02-08 13:29:29.063 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:54.200.157.178, port:443
2024-02-08 13:29:29.567 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:54.200.157.178, port:443
2024-02-08 13:29:30.070 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:54.200.157.178, port:443
2024-02-08 13:29:30.575 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:54.200.157.178, port:443
2024-02-08 13:29:31.077 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:54.200.157.178, port:443
2024-02-08 13:29:31.578 DEBUG   socketConnectionClosed(): Close socket 6
2024-02-08 13:29:31.578 DEBUG   freeSocketConnection(): close socket with ip: 192.168.0.104:59268. family:1
2024-02-08 13:29:31.578 DEBUG   freeSocketConnection(): close socket connected with ip: 0000:0000:0000:0000:0000:0000:0000:0000:0. family:0
Detected NAT mapping behavior NO_UDP_CONNECTIVITY
Host does not have any UDP connectivity. STUN is not usable. Can only connect using TCP relay
Detected NAT filtering behavior NO_UDP_CONNECTIVITY
Host does not have any UDP connectivity. STUN is not usable. Can only connect using TCP relay
2024-02-08 13:29:31.579 DEBUG   cleanupWebRtcClientInstance(): Releasing webrtc client context instance from cleanupWebRtcClientInstance
2024-02-08 13:29:31.579 INFO    cleanupWebRtcClientInstance(): Destroyed STUN IP object
2024-02-08 13:29:31.579 INFO    cleanupWebRtcClientInstance(): Destroyed WebRtc client context
2024-02-08 13:29:31.585 INFO    deinitKvsWebRtc(): Destroyed threadpool
niyatim@88665a374cf5 build % 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
