### PR TITLE
Rb size config

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,33 @@ Let us look into when each of these could be changed:
 3. `iceConnectionCheckTimeout`: It is useful to increase this timeout in unstable/slow network where the packet exchange takes time and hence the binding request/response. Essentially, increasing it will allow atleast one candidate pair to be tried for nomination by the other peer. 
 4. `iceConnectionCheckPollingInterval`: This value is set to a default of 50 ms per [spec](https://datatracker.ietf.org/doc/html/rfc8445#section-14.2). Changing this would change the frequency of connectivity checks and essentially, the ICE state machine transitions. Decreasing the value could help in faster connection establishment in a reliable high performant network setting with good system resources. Increasing the value could help in reducing the network load, however, the connection establishment could slow down. Unless there is a strong reasoning, it is **NOT** recommended to deviate from spec/default.
 
+
+### Controlling RTP rolling buffer capacity
+
+The SDK maintains an RTP rolling buffer to hold the RTP packets. This is useful to respond to NACKs and even in case of JitterBuffer. The rolling buffer size is controlled by 3 parameters:
+1. MTU: This is set to a default of 1200
+2. Buffer duration: This is the amount of time of media that you would like the rolling buffer to accommodate before it is overwritten due to buffer overflow. By default, the SDK sets this to 1 second
+3. Highest expected bitrate: This is the expected bitrate of the media in question. The typical bitrates could vary based on resolution and codec. By default, the SDK sets this to 5 Mbps
+
+The rolling buffer capacity is calculated as follows:
+```
+Capacity = Buffer duration * highest expected bitrate (in bps) / 8 / MTU
+
+With buffer duration = 1 second,  Highest expected bitrate = 5 MBps and MTU 1200, capacity = 546 RTP packets
+```
+
+The rolling buffer size can be configured per transceiver through the following fields:
+```
+RtcRtpTransceiverInit.rollingBufferDurationSec = <duration in seconds, must be more than 100ms (translates to 0.1 seconds)
+RtcRtpTransceiverInit.rollingBufferBitratebps = <bitrate in bits/sec, must be more than 100Kbits/sec
+```
+
+For example, if we want to set duration to 200ms and birtate to 150kbps,
+```
+RtcRtpTransceiverInit.rollingBufferDurationSec = 0.2;
+RtcRtpTransceiverInit.rollingBufferBitratebps = 150 * 1024;
+```
+
 ## Documentation
 All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ Let us look into when each of these could be changed:
 The SDK maintains an RTP rolling buffer to hold the RTP packets. This is useful to respond to NACKs and even in case of JitterBuffer. The rolling buffer size is controlled by 3 parameters:
 1. MTU: This is set to a default of 1200
 2. Buffer duration: This is the amount of time of media that you would like the rolling buffer to accommodate before it is overwritten due to buffer overflow. By default, the SDK sets this to 1 second
-3. Highest expected bitrate: This is the expected bitrate of the media in question. The typical bitrates could vary based on resolution and codec. By default, the SDK sets this to 5 Mbps
+3. Highest expected bitrate: This is the expected bitrate of the media in question. The typical bitrates could vary based on resolution and codec. By default, the SDK sets this to 5 Mbps for video and 1 Mbps for audio
 
 The rolling buffer capacity is calculated as follows:
 ```
@@ -474,8 +474,8 @@ For example, if we want to set duration to 200ms and birtate to 150kbps,
 RtcRtpTransceiverInit.rollingBufferDurationSec = 0.2;
 RtcRtpTransceiverInit.rollingBufferBitratebps = 150 * 1024;
 ```
-
 By setting these up, applications can have better control over the amount of memory that the application consumes. However, note, if the allocation is too small and the network bad leading to multiple nacks, it can lead to choppy media / dropped frames. Hence, care must be taken while deciding on the values to ensure the parameters satisfy necessary performance requirements.
+For more information, check the sample to see how these values are set up.
 
 ## Documentation
 All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Let us look into when each of these could be changed:
 ### Controlling RTP rolling buffer capacity
 
 The SDK maintains an RTP rolling buffer to hold the RTP packets. This is useful to respond to NACKs and even in case of JitterBuffer. The rolling buffer size is controlled by 3 parameters:
-1. MTU: This is set to a default of 1200
+1. MTU: This is set to a default of 1200 bytes
 2. Buffer duration: This is the amount of time of media that you would like the rolling buffer to accommodate before it is overwritten due to buffer overflow. By default, the SDK sets this to 1 second
 3. Highest expected bitrate: This is the expected bitrate of the media in question. The typical bitrates could vary based on resolution and codec. By default, the SDK sets this to 5 Mbps for video and 1 Mbps for audio
 

--- a/README.md
+++ b/README.md
@@ -454,22 +454,22 @@ Let us look into when each of these could be changed:
 The SDK maintains an RTP rolling buffer to hold the RTP packets. This is useful to respond to NACKs and even in case of JitterBuffer. The rolling buffer size is controlled by 3 parameters:
 1. MTU: This is set to a default of 1200 bytes
 2. Buffer duration: This is the amount of time of media that you would like the rolling buffer to accommodate before it is overwritten due to buffer overflow. By default, the SDK sets this to 1 second
-3. Highest expected bitrate: This is the expected bitrate of the media in question. The typical bitrates could vary based on resolution and codec. By default, the SDK sets this to 5 Mbps for video and 1 Mbps for audio
+3. Highest expected bitrate: This is the expected bitrate of the media in question. The typical bitrates could vary based on resolution and codec. By default, the SDK sets this to 5 mibps for video and 1 mibps for audio
 
 The rolling buffer capacity is calculated as follows:
 ```
 Capacity = Buffer duration * highest expected bitrate (in bps) / 8 / MTU
 
-With buffer duration = 1 second,  Highest expected bitrate = 5 MBps and MTU 1200, capacity = 546 RTP packets
+With buffer duration = 1 second,  Highest expected bitrate = 5 mibps and MTU 1200 bytes, capacity = 546 RTP packets
 ```
 
 The rolling buffer size can be configured per transceiver through the following fields:
 ```
 RtcRtpTransceiverInit.rollingBufferDurationSec = <duration in seconds, must be more than 100ms (translates to 0.1 seconds)
-RtcRtpTransceiverInit.rollingBufferBitratebps = <bitrate in bits/sec, must be more than 100kbits/sec
+RtcRtpTransceiverInit.rollingBufferBitratebps = <bitrate in bits/sec, must be more than 100kibits/sec
 ```
 
-For example, if we want to set duration to 200ms and birtate to 150kbps,
+For example, if we want to set duration to 200ms and birtate to 150kibps,
 ```
 RtcRtpTransceiverInit.rollingBufferDurationSec = 0.2;
 RtcRtpTransceiverInit.rollingBufferBitratebps = 150 * 1024;

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ With buffer duration = 1 second,  Highest expected bitrate = 5 MBps and MTU 1200
 The rolling buffer size can be configured per transceiver through the following fields:
 ```
 RtcRtpTransceiverInit.rollingBufferDurationSec = <duration in seconds, must be more than 100ms (translates to 0.1 seconds)
-RtcRtpTransceiverInit.rollingBufferBitratebps = <bitrate in bits/sec, must be more than 100Kbits/sec
+RtcRtpTransceiverInit.rollingBufferBitratebps = <bitrate in bits/sec, must be more than 100kbits/sec
 ```
 
 For example, if we want to set duration to 200ms and birtate to 150kbps,
@@ -474,6 +474,8 @@ For example, if we want to set duration to 200ms and birtate to 150kbps,
 RtcRtpTransceiverInit.rollingBufferDurationSec = 0.2;
 RtcRtpTransceiverInit.rollingBufferBitratebps = 150 * 1024;
 ```
+
+By setting these up, applications can have better control over the amount of memory that the application consumes. However, note, if the allocation is too small and the network bad leading to multiple nacks, it can lead to choppy media / dropped frames. Hence, care must be taken while deciding on the values to ensure the parameters satisfy necessary performance requirements.
 
 ## Documentation
 All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -407,6 +407,8 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
     SNPRINTF(configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, pSampleConfiguration->channelInfo.pRegion,
              pKinesisVideoStunUrlPostFix);
 
+    configuration.rollingBufferDurationInSec = 0.0f;
+    configuration.rollingBufferBitrateInMBps = 0.0f;
     // Check if we have any pregenerated certs and use them
     // NOTE: We are running under the config lock
     retStatus = stackQueueDequeue(pSampleConfiguration->pregeneratedCertificates, &data);

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -552,8 +552,6 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
     videoTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
     videoRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
-    videoRtpTransceiverInit.rollingBufferDurationSec = 1;
-    videoRtpTransceiverInit.rollingBufferBitrateInMbps = 1;
     STRCPY(videoTrack.streamId, "myKvsVideoStream");
     STRCPY(videoTrack.trackId, "myVideoTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &videoTrack, &videoRtpTransceiverInit,
@@ -566,8 +564,6 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
     audioTrack.codec = RTC_CODEC_OPUS;
     audioRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
-    audioRtpTransceiverInit.rollingBufferDurationSec = 1;
-    audioRtpTransceiverInit.rollingBufferBitrateInMbps = 1;
     STRCPY(audioTrack.streamId, "myKvsVideoStream");
     STRCPY(audioTrack.trackId, "myAudioTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &audioTrack, &audioRtpTransceiverInit,

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -552,8 +552,10 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
     videoTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
     videoRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
-    videoRtpTransceiverInit.rollingBufferDurationSec = 1;
-    videoRtpTransceiverInit.rollingBufferBitratebps = 5 * 1024 * 1024;
+    videoRtpTransceiverInit.rollingBufferDurationSec = 3;
+    // Considering 4 Mbps for 720p (which is what our samples use). This is for H.264.
+    // The value could be different for other codecs.
+    videoRtpTransceiverInit.rollingBufferBitratebps = 4 * 1024 * 1024;
     STRCPY(videoTrack.streamId, "myKvsVideoStream");
     STRCPY(videoTrack.trackId, "myVideoTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &videoTrack, &videoRtpTransceiverInit,
@@ -566,8 +568,9 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
     audioTrack.codec = RTC_CODEC_OPUS;
     audioRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
-    audioRtpTransceiverInit.rollingBufferDurationSec = 1;
-    audioRtpTransceiverInit.rollingBufferBitratebps = 5 * 1024 * 1024;
+    audioRtpTransceiverInit.rollingBufferDurationSec = 3;
+    // For opus, the bitrate could be between 6 Kbps to 510 Kbps
+    audioRtpTransceiverInit.rollingBufferBitratebps = 510 * 1024;
     STRCPY(audioTrack.streamId, "myKvsVideoStream");
     STRCPY(audioTrack.trackId, "myAudioTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &audioTrack, &audioRtpTransceiverInit,

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -552,6 +552,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
     videoTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
     videoRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+    videoRtpTransceiverInit.rollingBufferDurationSec = 1;
+    videoRtpTransceiverInit.rollingBufferBitratebps = 5 * 1024 * 1024;
     STRCPY(videoTrack.streamId, "myKvsVideoStream");
     STRCPY(videoTrack.trackId, "myVideoTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &videoTrack, &videoRtpTransceiverInit,
@@ -564,6 +566,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
     audioTrack.codec = RTC_CODEC_OPUS;
     audioRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+    audioRtpTransceiverInit.rollingBufferDurationSec = 1;
+    audioRtpTransceiverInit.rollingBufferBitratebps = 5 * 1024 * 1024;
     STRCPY(audioTrack.streamId, "myKvsVideoStream");
     STRCPY(audioTrack.trackId, "myAudioTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &audioTrack, &audioRtpTransceiverInit,

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -407,8 +407,6 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
     SNPRINTF(configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, pSampleConfiguration->channelInfo.pRegion,
              pKinesisVideoStunUrlPostFix);
 
-    configuration.rollingBufferDurationInSec = 0.0f;
-    configuration.rollingBufferBitrateInMBps = 0.0f;
     // Check if we have any pregenerated certs and use them
     // NOTE: We are running under the config lock
     retStatus = stackQueueDequeue(pSampleConfiguration->pregeneratedCertificates, &data);
@@ -554,6 +552,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
     videoTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
     videoRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+    videoRtpTransceiverInit.rollingBufferDurationSec = 1;
+    videoRtpTransceiverInit.rollingBufferBitrateInMbps = 1;
     STRCPY(videoTrack.streamId, "myKvsVideoStream");
     STRCPY(videoTrack.trackId, "myVideoTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &videoTrack, &videoRtpTransceiverInit,
@@ -566,6 +566,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
     audioTrack.codec = RTC_CODEC_OPUS;
     audioRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+    audioRtpTransceiverInit.rollingBufferDurationSec = 1;
+    audioRtpTransceiverInit.rollingBufferBitrateInMbps = 1;
     STRCPY(audioTrack.streamId, "myKvsVideoStream");
     STRCPY(audioTrack.trackId, "myAudioTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &audioTrack, &audioRtpTransceiverInit,

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -99,8 +99,8 @@ CleanUp:
     DLOGI("[KVS Master] Cleanup done");
     CHK_LOG_ERR(retStatus);
 
-    RESET_INSTRUMENTED_ALLOCATORS();
-
+    retStatus = RESET_INSTRUMENTED_ALLOCATORS();
+    DLOGI("All SDK allocations freed? %s..0x%08x", retStatus == STATUS_SUCCESS ? "Yes" : "No", retStatus);
     // https://www.gnu.org/software/libc/manual/html_node/Exit-Status.html
     // We can only return with 0 - 127. Some platforms treat exit code >= 128
     // to be a success code, which might give an unintended behaviour.

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1232,8 +1232,8 @@ typedef struct {
                                                          //!< connection to avoid a compromised client weakening the security of the new connections.
                                                          //!<
                                                          //!< NOTE: The certificates, if specified, can be freed after the peer connection create call
-    UINT32 rollingBufferDurationInSec;
-    UINT32 rollingBufferBitrateInMBps;
+    DOUBLE rollingBufferDurationInSec;
+    DOUBLE rollingBufferBitrateInMBps;
 } RtcConfiguration, *PRtcConfiguration;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1129,7 +1129,7 @@ typedef struct {
  */
 typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction
-    RtcRtpReceiver receiver; //!< RtcRtpReceiver that has track specific information
+    RtcRtpReceiver receiver;                 //!< RtcRtpReceiver that has track specific information
 } RtcRtpTransceiver, *PRtcRtpTransceiver;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1490,7 +1490,7 @@ typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction - SENDONLY, RECVONLY, SENDRECV
     DOUBLE rollingBufferDurationSec; //!< Maximum duration of media that needs to be buffered (in seconds). The lowest allowed is 0.1 seconds (100ms)
     DOUBLE rollingBufferBitratebps;  //!< Maximum expected bitrate of media (In bits/second). It is used to determine the buffer capacity. The lowest
-                                    //!< allowed is 100 Kbps
+                                     //!< allowed is 100 Kbps
 } RtcRtpTransceiverInit, *PRtcRtpTransceiverInit;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1129,8 +1129,6 @@ typedef struct {
  */
 typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction
-    UINT64 rollingBufferDurationSec;
-    UINT64 rollingBufferBitrateInBps;
     RtcRtpReceiver receiver; //!< RtcRtpReceiver that has track specific information
 } RtcRtpTransceiver, *PRtcRtpTransceiver;
 
@@ -1490,8 +1488,9 @@ typedef struct {
  */
 typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction - SENDONLY, RECVONLY, SENDRECV
-    DOUBLE rollingBufferDurationSec;
-    DOUBLE rollingBufferBitrateBps;
+    DOUBLE rollingBufferDurationSec;         //!< Duration of media that needs to be buffered (in seconds). The lowest allowed is 0.1 seconds (100ms)
+    DOUBLE rollingBufferBitratebps; //!< Expected bitrate of media (In bits/second). It is used to determine the buffer capacity. The lowest allowed
+                                    //!< is 100 Kbps
 } RtcRtpTransceiverInit, *PRtcRtpTransceiverInit;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1488,9 +1488,9 @@ typedef struct {
  */
 typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction - SENDONLY, RECVONLY, SENDRECV
-    DOUBLE rollingBufferDurationSec;         //!< Duration of media that needs to be buffered (in seconds). The lowest allowed is 0.1 seconds (100ms)
-    DOUBLE rollingBufferBitratebps; //!< Expected bitrate of media (In bits/second). It is used to determine the buffer capacity. The lowest allowed
-                                    //!< is 100 Kbps
+    DOUBLE rollingBufferDurationSec; //!< Maximum duration of media that needs to be buffered (in seconds). The lowest allowed is 0.1 seconds (100ms)
+    DOUBLE rollingBufferBitratebps;  //!< Maximum expected bitrate of media (In bits/second). It is used to determine the buffer capacity. The lowest
+                                    //!< allowed is 100 Kbps
 } RtcRtpTransceiverInit, *PRtcRtpTransceiverInit;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1232,7 +1232,8 @@ typedef struct {
                                                          //!< connection to avoid a compromised client weakening the security of the new connections.
                                                          //!<
                                                          //!< NOTE: The certificates, if specified, can be freed after the peer connection create call
-                                                         //!<
+    UINT32 rollingBufferDurationInSec;
+    UINT32 rollingBufferBitrateInMBps;
 } RtcConfiguration, *PRtcConfiguration;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1130,8 +1130,8 @@ typedef struct {
 typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction
     UINT64 rollingBufferDurationSec;
-    UINT64 rollingBufferBitrateInMbps;
-    RtcRtpReceiver receiver;                 //!< RtcRtpReceiver that has track specific information
+    UINT64 rollingBufferBitrateInBps;
+    RtcRtpReceiver receiver; //!< RtcRtpReceiver that has track specific information
 } RtcRtpTransceiver, *PRtcRtpTransceiver;
 
 /**
@@ -1490,8 +1490,8 @@ typedef struct {
  */
 typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction - SENDONLY, RECVONLY, SENDRECV
-    UINT64 rollingBufferDurationSec;
-    UINT64 rollingBufferBitrateInMbps;
+    DOUBLE rollingBufferDurationSec;
+    DOUBLE rollingBufferBitrateBps;
 } RtcRtpTransceiverInit, *PRtcRtpTransceiverInit;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1129,6 +1129,8 @@ typedef struct {
  */
 typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction
+    UINT64 rollingBufferDurationSec;
+    UINT64 rollingBufferBitrateInMbps;
     RtcRtpReceiver receiver;                 //!< RtcRtpReceiver that has track specific information
 } RtcRtpTransceiver, *PRtcRtpTransceiver;
 
@@ -1232,8 +1234,6 @@ typedef struct {
                                                          //!< connection to avoid a compromised client weakening the security of the new connections.
                                                          //!<
                                                          //!< NOTE: The certificates, if specified, can be freed after the peer connection create call
-    DOUBLE rollingBufferDurationInSec;
-    DOUBLE rollingBufferBitrateInMBps;
 } RtcConfiguration, *PRtcConfiguration;
 
 /**
@@ -1490,6 +1490,8 @@ typedef struct {
  */
 typedef struct {
     RTC_RTP_TRANSCEIVER_DIRECTION direction; //!< Transceiver direction - SENDONLY, RECVONLY, SENDRECV
+    UINT64 rollingBufferDurationSec;
+    UINT64 rollingBufferBitrateInMbps;
 } RtcRtpTransceiverInit, *PRtcRtpTransceiverInit;
 
 /**

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -31,7 +31,7 @@ STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEU
     mbedtls_ctr_drbg_set_prediction_resistance(&pDtlsSession->ctrDrbg, MBEDTLS_CTR_DRBG_PR_ON);
     CHK(mbedtls_ctr_drbg_seed(&pDtlsSession->ctrDrbg, mbedtls_entropy_func, &pDtlsSession->entropy, NULL, 0) == 0, STATUS_CREATE_SSL_FAILED);
 
-    CHK_STATUS(createIOBuffer(DEFAULT_MTU_SIZE, &pDtlsSession->pReadBuffer));
+    CHK_STATUS(createIOBuffer(DEFAULT_MTU_SIZE_BYTES, &pDtlsSession->pReadBuffer));
     pDtlsSession->timerQueueHandle = timerQueueHandle;
     pDtlsSession->timerId = MAX_UINT32;
     pDtlsSession->sslLock = MUTEX_CREATE(TRUE);
@@ -290,7 +290,7 @@ STATUS dtlsSessionStart(PDtlsSession pDtlsSession, BOOL isServer)
     mbedtls_ssl_conf_export_keys_ext_cb(&pDtlsSession->sslCtxConfig, dtlsSessionKeyDerivationCallback, pDtlsSession);
 
     CHK(mbedtls_ssl_setup(&pDtlsSession->sslCtx, &pDtlsSession->sslCtxConfig) == 0, STATUS_SSL_CTX_CREATION_FAILED);
-    mbedtls_ssl_set_mtu(&pDtlsSession->sslCtx, DEFAULT_MTU_SIZE);
+    mbedtls_ssl_set_mtu(&pDtlsSession->sslCtx, DEFAULT_MTU_SIZE_BYTES);
     mbedtls_ssl_set_bio(&pDtlsSession->sslCtx, pDtlsSession, dtlsSessionSendCallback, dtlsSessionReceiveCallback, NULL);
     mbedtls_ssl_set_timer_cb(&pDtlsSession->sslCtx, &pDtlsSession->transmissionTimer, dtlsSessionSetTimerCallback, dtlsSessionGetTimerCallback);
 

--- a/src/source/Crypto/Tls_mbedtls.c
+++ b/src/source/Crypto/Tls_mbedtls.c
@@ -15,7 +15,7 @@ STATUS createTlsSession(PTlsSessionCallbacks pCallbacks, PTlsSession* ppTlsSessi
     pTlsSession = (PTlsSession) MEMCALLOC(1, SIZEOF(TlsSession));
     CHK(pTlsSession != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
-    CHK_STATUS(createIOBuffer(DEFAULT_MTU_SIZE, &pTlsSession->pReadBuffer));
+    CHK_STATUS(createIOBuffer(DEFAULT_MTU_SIZE_BYTES, &pTlsSession->pReadBuffer));
     pTlsSession->callbacks = *pCallbacks;
     pTlsSession->state = TLS_SESSION_STATE_NEW;
 
@@ -117,7 +117,7 @@ STATUS tlsSessionStart(PTlsSession pTlsSession, BOOL isServer)
     mbedtls_ssl_conf_authmode(&pTlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_REQUIRED);
     mbedtls_ssl_conf_rng(&pTlsSession->sslCtxConfig, mbedtls_ctr_drbg_random, &pTlsSession->ctrDrbg);
     CHK(mbedtls_ssl_setup(&pTlsSession->sslCtx, &pTlsSession->sslCtxConfig) == 0, STATUS_SSL_CTX_CREATION_FAILED);
-    mbedtls_ssl_set_mtu(&pTlsSession->sslCtx, DEFAULT_MTU_SIZE);
+    mbedtls_ssl_set_mtu(&pTlsSession->sslCtx, DEFAULT_MTU_SIZE_BYTES);
     mbedtls_ssl_set_bio(&pTlsSession->sslCtx, pTlsSession, tlsSessionSendCallback, tlsSessionReceiveCallback, NULL);
 
     /* init and send handshake */

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -934,7 +934,7 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     pKvsPeerConnection->peerConnectionObjLock = MUTEX_CREATE(FALSE);
     pKvsPeerConnection->connectionState = RTC_PEER_CONNECTION_STATE_NONE;
     pKvsPeerConnection->MTU = pConfiguration->kvsRtcConfiguration.maximumTransmissionUnit == 0
-        ? DEFAULT_MTU_SIZE
+        ? DEFAULT_MTU_SIZE_BYTES
         : pConfiguration->kvsRtcConfiguration.maximumTransmissionUnit;
     ATOMIC_STORE_BOOL(&pKvsPeerConnection->sctpIsEnabled, FALSE);
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1483,7 +1483,6 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
         direction = pRtcRtpTransceiverInit->direction;
         rollingBufferDurationSec = pRtcRtpTransceiverInit->rollingBufferDurationSec;
         rollingBufferBitratebps = pRtcRtpTransceiverInit->rollingBufferBitratebps;
-        DLOGI("Received: %lf, %lf", rollingBufferDurationSec, pRtcRtpTransceiverInit->rollingBufferDurationSec);
     }
     if (direction == RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY && pRtcMediaStreamTrack == NULL) {
         MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -912,16 +912,6 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
 
     pKvsPeerConnection->peerConnection.version = PEER_CONNECTION_CURRENT_VERSION;
 
-    if (pConfiguration->rollingBufferDurationInSec == 0.0f) {
-        pKvsPeerConnection->rollingBufferDurationInSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
-    } else {
-        pKvsPeerConnection->rollingBufferDurationInSec = pConfiguration->rollingBufferDurationInSec;
-    }
-    if (pConfiguration->rollingBufferBitrateInMBps == 0.0f) {
-        pKvsPeerConnection->rollingBufferBitrateInMBps = HIGHEST_EXPECTED_BIT_RATE;
-    } else {
-        pKvsPeerConnection->rollingBufferBitrateInMBps = pConfiguration->rollingBufferBitrateInMBps * 1024 * 1024;
-    }
     CHK_STATUS(generateJSONSafeString(pKvsPeerConnection->localIceUfrag, LOCAL_ICE_UFRAG_LEN));
     CHK_STATUS(generateJSONSafeString(pKvsPeerConnection->localIcePwd, LOCAL_ICE_PWD_LEN));
     CHK_STATUS(generateJSONSafeString(pKvsPeerConnection->localCNAME, LOCAL_CNAME_LEN));
@@ -1526,8 +1516,8 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     }
 
     // TODO: Add ssrc duplicate detection here not only relying on RAND()
-    CHK_STATUS(createKvsRtpTransceiver(direction, pKvsPeerConnection, ssrc, rtxSsrc, pRtcMediaStreamTrack, NULL, pRtcMediaStreamTrack->codec,
-                                       &pKvsRtpTransceiver));
+    CHK_STATUS(createKvsRtpTransceiver(pRtcRtpTransceiverInit, pKvsPeerConnection, ssrc, rtxSsrc, pRtcMediaStreamTrack, NULL,
+                                       pRtcMediaStreamTrack->codec, &pKvsRtpTransceiver));
     CHK_STATUS(createJitterBuffer(onFrameReadyFunc, onFrameDroppedFunc, depayFunc, DEFAULT_JITTER_BUFFER_MAX_LATENCY, clockRate,
                                   (UINT64) pKvsRtpTransceiver, &pJitterBuffer));
     CHK_STATUS(kvsRtpTransceiverSetJitterBuffer(pKvsRtpTransceiver, pJitterBuffer));

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1483,8 +1483,8 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
         direction = pRtcRtpTransceiverInit->direction;
         rollingBufferDurationSec = pRtcRtpTransceiverInit->rollingBufferDurationSec;
         rollingBufferBitratebps = pRtcRtpTransceiverInit->rollingBufferBitratebps;
+        DLOGI("Received: %lf, %lf", rollingBufferDurationSec, pRtcRtpTransceiverInit->rollingBufferDurationSec);
     }
-
     if (direction == RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY && pRtcMediaStreamTrack == NULL) {
         MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
         videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1474,11 +1474,18 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     UINT32 ssrc = (UINT32) RAND(), rtxSsrc = (UINT32) RAND();
     RTC_RTP_TRANSCEIVER_DIRECTION direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
     DOUBLE rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
-    DOUBLE rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
+    DOUBLE rollingBufferBitratebps;
     RtcMediaStreamTrack videoTrack;
 
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
 
+    if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
+        rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
+    } else if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_AUDIO) {
+        rollingBufferBitratebps = DEFAULT_EXPECTED_AUDIO_BIT_RATE;
+    } else {
+        rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
+    }
     if (pRtcRtpTransceiverInit != NULL) {
         direction = pRtcRtpTransceiverInit->direction;
         rollingBufferDurationSec = pRtcRtpTransceiverInit->rollingBufferDurationSec;

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -911,6 +911,17 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     CHK_STATUS(timerQueueCreate(&pKvsPeerConnection->timerQueueHandle));
 
     pKvsPeerConnection->peerConnection.version = PEER_CONNECTION_CURRENT_VERSION;
+
+    if (pConfiguration->rollingBufferDurationInSec == 0) {
+        pKvsPeerConnection->rollingBufferDurationInSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
+    } else {
+        pKvsPeerConnection->rollingBufferDurationInSec = pConfiguration->rollingBufferDurationInSec;
+    }
+    if (pConfiguration->rollingBufferBitrateInMBps == 0) {
+        pKvsPeerConnection->rollingBufferBitrateInMBps = HIGHEST_EXPECTED_BIT_RATE;
+    } else {
+        pKvsPeerConnection->rollingBufferBitrateInMBps = pConfiguration->rollingBufferBitrateInMBps * 1024 * 1024;
+    }
     CHK_STATUS(generateJSONSafeString(pKvsPeerConnection->localIceUfrag, LOCAL_ICE_UFRAG_LEN));
     CHK_STATUS(generateJSONSafeString(pKvsPeerConnection->localIcePwd, LOCAL_ICE_PWD_LEN));
     CHK_STATUS(generateJSONSafeString(pKvsPeerConnection->localCNAME, LOCAL_CNAME_LEN));

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1474,23 +1474,29 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     UINT32 ssrc = (UINT32) RAND(), rtxSsrc = (UINT32) RAND();
     RTC_RTP_TRANSCEIVER_DIRECTION direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
     DOUBLE rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
-    DOUBLE rollingBufferBitratebps;
+    DOUBLE rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
     RtcMediaStreamTrack videoTrack;
 
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
 
-    if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
-        rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
-    } else if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_AUDIO) {
-        rollingBufferBitratebps = DEFAULT_EXPECTED_AUDIO_BIT_RATE;
-    } else {
-        rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
+    // Set defaults for audio and video track. This can be modified to values set up with pRtcRtpTransceiverInit
+    // if so.
+    if (pRtcMediaStreamTrack != NULL) {
+        if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
+            rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
+        } else if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_AUDIO) {
+            rollingBufferBitratebps = DEFAULT_EXPECTED_AUDIO_BIT_RATE;
+        } else {
+            rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
+        }
     }
+
     if (pRtcRtpTransceiverInit != NULL) {
         direction = pRtcRtpTransceiverInit->direction;
         rollingBufferDurationSec = pRtcRtpTransceiverInit->rollingBufferDurationSec;
         rollingBufferBitratebps = pRtcRtpTransceiverInit->rollingBufferBitratebps;
     }
+
     if (direction == RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY && pRtcMediaStreamTrack == NULL) {
         MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
         videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
@@ -1498,6 +1504,8 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
         STRCPY(videoTrack.streamId, "myKvsVideoStream");
         STRCPY(videoTrack.trackId, "myVideoTrack");
         pRtcMediaStreamTrack = &videoTrack;
+        // rollingBufferDurationSec will be DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS
+        // rollingBufferBitratebps will be DEFAULT_EXPECTED_VIDEO_BIT_RATE
     }
 
     switch (pRtcMediaStreamTrack->codec) {

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1474,7 +1474,7 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     UINT32 ssrc = (UINT32) RAND(), rtxSsrc = (UINT32) RAND();
     RTC_RTP_TRANSCEIVER_DIRECTION direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
     DOUBLE rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
-    DOUBLE rollingBufferBitrateBps = HIGHEST_EXPECTED_BIT_RATE;
+    DOUBLE rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
     RtcMediaStreamTrack videoTrack;
 
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
@@ -1482,7 +1482,7 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     if (pRtcRtpTransceiverInit != NULL) {
         direction = pRtcRtpTransceiverInit->direction;
         rollingBufferDurationSec = pRtcRtpTransceiverInit->rollingBufferDurationSec;
-        rollingBufferBitrateBps = pRtcRtpTransceiverInit->rollingBufferBitrateBps;
+        rollingBufferBitratebps = pRtcRtpTransceiverInit->rollingBufferBitratebps;
     }
 
     if (direction == RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY && pRtcMediaStreamTrack == NULL) {
@@ -1521,7 +1521,7 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     }
 
     // TODO: Add ssrc duplicate detection here not only relying on RAND()
-    CHK_STATUS(createKvsRtpTransceiver(direction, rollingBufferDurationSec, rollingBufferBitrateBps, pKvsPeerConnection, ssrc, rtxSsrc,
+    CHK_STATUS(createKvsRtpTransceiver(direction, rollingBufferDurationSec, rollingBufferBitratebps, pKvsPeerConnection, ssrc, rtxSsrc,
                                        pRtcMediaStreamTrack, NULL, pRtcMediaStreamTrack->codec, &pKvsRtpTransceiver));
     CHK_STATUS(createJitterBuffer(onFrameReadyFunc, onFrameDroppedFunc, depayFunc, DEFAULT_JITTER_BUFFER_MAX_LATENCY, clockRate,
                                   (UINT64) pKvsRtpTransceiver, &pJitterBuffer));

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -912,12 +912,12 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
 
     pKvsPeerConnection->peerConnection.version = PEER_CONNECTION_CURRENT_VERSION;
 
-    if (pConfiguration->rollingBufferDurationInSec == 0) {
+    if (pConfiguration->rollingBufferDurationInSec == 0.0f) {
         pKvsPeerConnection->rollingBufferDurationInSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
     } else {
         pKvsPeerConnection->rollingBufferDurationInSec = pConfiguration->rollingBufferDurationInSec;
     }
-    if (pConfiguration->rollingBufferBitrateInMBps == 0) {
+    if (pConfiguration->rollingBufferBitrateInMBps == 0.0f) {
         pKvsPeerConnection->rollingBufferBitrateInMBps = HIGHEST_EXPECTED_BIT_RATE;
     } else {
         pKvsPeerConnection->rollingBufferBitrateInMBps = pConfiguration->rollingBufferBitrateInMBps * 1024 * 1024;

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1480,7 +1480,6 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
 
     // Set defaults for audio and video track. This can be modified to values set up with pRtcRtpTransceiverInit
-    // if so.
     if (pRtcMediaStreamTrack != NULL) {
         if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
             rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1473,12 +1473,17 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     UINT32 clockRate = 0;
     UINT32 ssrc = (UINT32) RAND(), rtxSsrc = (UINT32) RAND();
     RTC_RTP_TRANSCEIVER_DIRECTION direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+    DOUBLE rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
+    DOUBLE rollingBufferBitrateBps = HIGHEST_EXPECTED_BIT_RATE;
     RtcMediaStreamTrack videoTrack;
-    if (pRtcRtpTransceiverInit != NULL) {
-        direction = pRtcRtpTransceiverInit->direction;
-    }
 
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    if (pRtcRtpTransceiverInit != NULL) {
+        direction = pRtcRtpTransceiverInit->direction;
+        rollingBufferDurationSec = pRtcRtpTransceiverInit->rollingBufferDurationSec;
+        rollingBufferBitrateBps = pRtcRtpTransceiverInit->rollingBufferBitrateBps;
+    }
 
     if (direction == RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY && pRtcMediaStreamTrack == NULL) {
         MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
@@ -1516,8 +1521,8 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     }
 
     // TODO: Add ssrc duplicate detection here not only relying on RAND()
-    CHK_STATUS(createKvsRtpTransceiver(pRtcRtpTransceiverInit, pKvsPeerConnection, ssrc, rtxSsrc, pRtcMediaStreamTrack, NULL,
-                                       pRtcMediaStreamTrack->codec, &pKvsRtpTransceiver));
+    CHK_STATUS(createKvsRtpTransceiver(direction, rollingBufferDurationSec, rollingBufferBitrateBps, pKvsPeerConnection, ssrc, rtxSsrc,
+                                       pRtcMediaStreamTrack, NULL, pRtcMediaStreamTrack->codec, &pKvsRtpTransceiver));
     CHK_STATUS(createJitterBuffer(onFrameReadyFunc, onFrameDroppedFunc, depayFunc, DEFAULT_JITTER_BUFFER_MAX_LATENCY, clockRate,
                                   (UINT64) pKvsRtpTransceiver, &pJitterBuffer));
     CHK_STATUS(kvsRtpTransceiverSetJitterBuffer(pKvsRtpTransceiver, pJitterBuffer));

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -120,8 +120,8 @@ typedef struct {
     // DataChannels keyed by streamId
     PHashTable pDataChannels;
 
-    UINT32 rollingBufferDurationInSec;
-    UINT32 rollingBufferBitrateInMBps;
+    DOUBLE rollingBufferDurationInSec;
+    DOUBLE rollingBufferBitrateInMBps;
 
     UINT64 onDataChannelCustomData;
     RtcOnDataChannel onDataChannel;

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -120,6 +120,9 @@ typedef struct {
     // DataChannels keyed by streamId
     PHashTable pDataChannels;
 
+    UINT32 rollingBufferDurationInSec;
+    UINT32 rollingBufferBitrateInMBps;
+
     UINT64 onDataChannelCustomData;
     RtcOnDataChannel onDataChannel;
 
@@ -144,6 +147,7 @@ typedef struct {
 
     UINT64 iceConnectingStartTime;
     KvsPeerConnectionDiagnostics peerConnectionDiagnostics;
+
 } KvsPeerConnection, *PKvsPeerConnection;
 
 typedef struct {

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -120,9 +120,6 @@ typedef struct {
     // DataChannels keyed by streamId
     PHashTable pDataChannels;
 
-    DOUBLE rollingBufferDurationInSec;
-    DOUBLE rollingBufferBitrateInMBps;
-
     UINT64 onDataChannelCustomData;
     RtcOnDataChannel onDataChannel;
 

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -4,7 +4,7 @@
 
 typedef STATUS (*RtpPayloadFunc)(UINT32, PBYTE, UINT32, PBYTE, PUINT32, PUINT32, PUINT32);
 
-STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION direction, DOUBLE rollingBufferDurationSec, DOUBLE rollingBufferBitrateBps,
+STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION direction, DOUBLE rollingBufferDurationSec, DOUBLE rollingBufferBitratebps,
                                PKvsPeerConnection pKvsPeerConnection, UINT32 ssrc, UINT32 rtxSsrc, PRtcMediaStreamTrack pRtcMediaStreamTrack,
                                PJitterBuffer pJitterBuffer, RTC_CODEC rtcCodec, PKvsRtpTransceiver* ppKvsRtpTransceiver)
 {
@@ -37,11 +37,11 @@ STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION direction, DOUBLE r
     } else {
         pKvsRtpTransceiver->rollingBufferDurationSec = rollingBufferDurationSec;
     }
-    if (rollingBufferBitrateBps < (0.1 * 1024 * 1024)) {
+    if (rollingBufferBitratebps < (0.1 * 1024 * 1024)) {
         DLOGW("Rolling buffer duration set to less than 100 KBps. Setting to default %d Bps", HIGHEST_EXPECTED_BIT_RATE);
-        pKvsRtpTransceiver->rollingBufferBitrateBps = HIGHEST_EXPECTED_BIT_RATE;
+        pKvsRtpTransceiver->rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
     } else {
-        pKvsRtpTransceiver->rollingBufferBitrateBps = rollingBufferBitrateBps;
+        pKvsRtpTransceiver->rollingBufferBitratebps = rollingBufferBitratebps;
     }
 
     pKvsRtpTransceiver->outboundStats.sent.rtpStream.ssrc = ssrc;

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -31,13 +31,14 @@ STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION direction, DOUBLE r
     pKvsRtpTransceiver->transceiver.receiver.track.kind = pRtcMediaStreamTrack->kind;
     pKvsRtpTransceiver->transceiver.direction = direction;
 
-    if (rollingBufferDurationSec < 0.1) {
+    DLOGI("Rolling buffer duratioN: %lf, %lf", rollingBufferDurationSec, MIN_ROLLING_BUFFER_DURATION_IN_SECONDS);
+    if (rollingBufferDurationSec < MIN_ROLLING_BUFFER_DURATION_IN_SECONDS) {
         DLOGW("Rolling buffer duration set to less than 100 ms. Setting to default %d sec", DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS);
         pKvsRtpTransceiver->rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
     } else {
         pKvsRtpTransceiver->rollingBufferDurationSec = rollingBufferDurationSec;
     }
-    if (rollingBufferBitratebps < (0.1 * 1024 * 1024)) {
+    if (rollingBufferBitratebps < MIN_EXPECTED_BIT_RATE) {
         DLOGW("Rolling buffer duration set to less than 100 KBps. Setting to default %d Bps", HIGHEST_EXPECTED_BIT_RATE);
         pKvsRtpTransceiver->rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
     } else {

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -39,13 +39,13 @@ STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION direction, DOUBLE r
     }
     if (rollingBufferBitratebps < MIN_EXPECTED_BIT_RATE) {
         if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
-            DLOGW("Rolling buffer duration set to less than 100 KBps for video. Setting to default %d Bps", DEFAULT_EXPECTED_VIDEO_BIT_RATE);
+            DLOGW("Rolling buffer duration set to less than 100 Kibps for video. Setting to default %d bps", DEFAULT_EXPECTED_VIDEO_BIT_RATE);
             pKvsRtpTransceiver->rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
         } else if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_AUDIO) {
-            DLOGW("Rolling buffer duration set to less than 100 KBps for audio. Setting to default %d Bps", DEFAULT_EXPECTED_AUDIO_BIT_RATE);
+            DLOGW("Rolling buffer duration set to less than 100 Kibps for audio. Setting to default %d bps", DEFAULT_EXPECTED_AUDIO_BIT_RATE);
             pKvsRtpTransceiver->rollingBufferBitratebps = DEFAULT_EXPECTED_AUDIO_BIT_RATE;
         } else {
-            DLOGW("Rolling buffer duration set to less than 100 KBps for unknown codec. Setting to default %d Bps", DEFAULT_EXPECTED_AUDIO_BIT_RATE);
+            DLOGW("Rolling buffer duration set to less than 100 Kibps for unknown codec. Setting to default %d bps", DEFAULT_EXPECTED_AUDIO_BIT_RATE);
             rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
         }
 

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -31,7 +31,6 @@ STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION direction, DOUBLE r
     pKvsRtpTransceiver->transceiver.receiver.track.kind = pRtcMediaStreamTrack->kind;
     pKvsRtpTransceiver->transceiver.direction = direction;
 
-    DLOGI("Rolling buffer duratioN: %lf, %lf", rollingBufferDurationSec, MIN_ROLLING_BUFFER_DURATION_IN_SECONDS);
     if (rollingBufferDurationSec < MIN_ROLLING_BUFFER_DURATION_IN_SECONDS) {
         DLOGW("Rolling buffer duration set to less than 100 ms. Setting to default %d sec", DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS);
         pKvsRtpTransceiver->rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -38,8 +38,17 @@ STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION direction, DOUBLE r
         pKvsRtpTransceiver->rollingBufferDurationSec = rollingBufferDurationSec;
     }
     if (rollingBufferBitratebps < MIN_EXPECTED_BIT_RATE) {
-        DLOGW("Rolling buffer duration set to less than 100 KBps. Setting to default %d Bps", HIGHEST_EXPECTED_BIT_RATE);
-        pKvsRtpTransceiver->rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
+        if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
+            DLOGW("Rolling buffer duration set to less than 100 KBps for video. Setting to default %d Bps", DEFAULT_EXPECTED_VIDEO_BIT_RATE);
+            pKvsRtpTransceiver->rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
+        } else if (pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_AUDIO) {
+            DLOGW("Rolling buffer duration set to less than 100 KBps for audio. Setting to default %d Bps", DEFAULT_EXPECTED_AUDIO_BIT_RATE);
+            pKvsRtpTransceiver->rollingBufferBitratebps = DEFAULT_EXPECTED_AUDIO_BIT_RATE;
+        } else {
+            DLOGW("Rolling buffer duration set to less than 100 KBps for unknown codec. Setting to default %d Bps", DEFAULT_EXPECTED_AUDIO_BIT_RATE);
+            rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
+        }
+
     } else {
         pKvsRtpTransceiver->rollingBufferBitratebps = rollingBufferBitratebps;
     }

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -30,6 +30,8 @@ STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION direction, PKvsPeer
     pKvsRtpTransceiver->transceiver.receiver.track.codec = rtcCodec;
     pKvsRtpTransceiver->transceiver.receiver.track.kind = pRtcMediaStreamTrack->kind;
     pKvsRtpTransceiver->transceiver.direction = direction;
+    pKvsRtpTransceiver->rollingBufferDurationInSec = pKvsPeerConnection->rollingBufferDurationInSec;
+    pKvsRtpTransceiver->rollingBufferBitrateInMBps = pKvsPeerConnection->rollingBufferBitrateInMBps;
 
     pKvsRtpTransceiver->outboundStats.sent.rtpStream.ssrc = ssrc;
     STRNCPY(pKvsRtpTransceiver->outboundStats.sent.rtpStream.kind, pRtcMediaStreamTrack->kind == MEDIA_STREAM_TRACK_KIND_AUDIO ? "audio" : "video",

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -49,8 +49,8 @@ typedef struct {
 
     PKvsPeerConnection pKvsPeerConnection;
 
-    DOUBLE rollingBufferDurationInSec;
-    DOUBLE rollingBufferBitrateInMBps;
+    UINT64 rollingBufferDurationSec;
+    UINT64 rollingBufferBitrateInMbps;
 
     UINT32 jitterBufferSsrc;
     PJitterBuffer pJitterBuffer;
@@ -74,7 +74,7 @@ typedef struct {
     RtcInboundRtpStreamStats inboundStats;
 } KvsRtpTransceiver, *PKvsRtpTransceiver;
 
-STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION, PKvsPeerConnection, UINT32, UINT32, PRtcMediaStreamTrack, PJitterBuffer, RTC_CODEC,
+STATUS createKvsRtpTransceiver(PRtcRtpTransceiverInit, PKvsPeerConnection, UINT32, UINT32, PRtcMediaStreamTrack, PJitterBuffer, RTC_CODEC,
                                PKvsRtpTransceiver*);
 STATUS freeKvsRtpTransceiver(PKvsRtpTransceiver*);
 

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -49,8 +49,8 @@ typedef struct {
 
     PKvsPeerConnection pKvsPeerConnection;
 
-    UINT64 rollingBufferDurationSec;
-    UINT64 rollingBufferBitrateInMbps;
+    DOUBLE rollingBufferDurationSec;
+    DOUBLE rollingBufferBitrateBps;
 
     UINT32 jitterBufferSsrc;
     PJitterBuffer pJitterBuffer;
@@ -74,8 +74,8 @@ typedef struct {
     RtcInboundRtpStreamStats inboundStats;
 } KvsRtpTransceiver, *PKvsRtpTransceiver;
 
-STATUS createKvsRtpTransceiver(PRtcRtpTransceiverInit, PKvsPeerConnection, UINT32, UINT32, PRtcMediaStreamTrack, PJitterBuffer, RTC_CODEC,
-                               PKvsRtpTransceiver*);
+STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION, DOUBLE, DOUBLE, PKvsPeerConnection, UINT32, UINT32, PRtcMediaStreamTrack, PJitterBuffer,
+                               RTC_CODEC, PKvsRtpTransceiver*);
 STATUS freeKvsRtpTransceiver(PKvsRtpTransceiver*);
 
 STATUS kvsRtpTransceiverSetJitterBuffer(PKvsRtpTransceiver, PJitterBuffer);

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -10,7 +10,7 @@ extern "C" {
 // Default MTU comes from libwebrtc
 // https://groups.google.com/forum/#!topic/discuss-webrtc/gH5ysR3SoZI
 #define DEFAULT_MTU_SIZE                           1200
-#define DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS 1
+#define DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS 3
 #define HIGHEST_EXPECTED_BIT_RATE                  (5 * 1024 * 1024)
 #define DEFAULT_SEQ_NUM_BUFFER_SIZE                1000
 #define DEFAULT_VALID_INDEX_BUFFER_SIZE            1000

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -11,13 +11,15 @@ extern "C" {
 // https://groups.google.com/forum/#!topic/discuss-webrtc/gH5ysR3SoZI
 #define DEFAULT_MTU_SIZE                           1200
 #define DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS 3
-#define HIGHEST_EXPECTED_BIT_RATE                  (5 * 1024 * 1024)
-#define DEFAULT_SEQ_NUM_BUFFER_SIZE                1000
-#define DEFAULT_VALID_INDEX_BUFFER_SIZE            1000
-#define DEFAULT_PEER_FRAME_BUFFER_SIZE             (5 * 1024)
-#define SRTP_AUTH_TAG_OVERHEAD                     10
-#define MIN_ROLLING_BUFFER_DURATION_IN_SECONDS     (DOUBLE) 0.1
-#define MIN_EXPECTED_BIT_RATE                      (DOUBLE)(102.4 * 1024) // Considering 1Kb = 1024 bits
+#define DEFAULT_EXPECTED_VIDEO_BIT_RATE            (5 * 1024 * 1024)
+// Opus has highest based on the supported codecs which is 510Kbps. So setting this to twice
+#define DEFAULT_EXPECTED_AUDIO_BIT_RATE        (1000 * 1024)
+#define DEFAULT_SEQ_NUM_BUFFER_SIZE            1000
+#define DEFAULT_VALID_INDEX_BUFFER_SIZE        1000
+#define DEFAULT_PEER_FRAME_BUFFER_SIZE         (5 * 1024)
+#define SRTP_AUTH_TAG_OVERHEAD                 10
+#define MIN_ROLLING_BUFFER_DURATION_IN_SECONDS (DOUBLE) 0.1
+#define MIN_EXPECTED_BIT_RATE                  (DOUBLE)(102.4 * 1024) // Considering 1Kb = 1024 bits
 
 // https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-huge
 // Huge frames, by definition, are frames that have an encoded size at least 2.5 times the average size of the frames.

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -10,7 +10,7 @@ extern "C" {
 // Default MTU comes from libwebrtc
 // https://groups.google.com/forum/#!topic/discuss-webrtc/gH5ysR3SoZI
 #define DEFAULT_MTU_SIZE                           1200
-#define DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS 3
+#define DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS 1
 #define HIGHEST_EXPECTED_BIT_RATE                  (10 * 1024 * 1024)
 #define DEFAULT_SEQ_NUM_BUFFER_SIZE                1000
 #define DEFAULT_VALID_INDEX_BUFFER_SIZE            1000

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -11,7 +11,7 @@ extern "C" {
 // https://groups.google.com/forum/#!topic/discuss-webrtc/gH5ysR3SoZI
 #define DEFAULT_MTU_SIZE                           1200
 #define DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS 1
-#define HIGHEST_EXPECTED_BIT_RATE                  (10 * 1024 * 1024)
+#define HIGHEST_EXPECTED_BIT_RATE                  (5 * 1024 * 1024)
 #define DEFAULT_SEQ_NUM_BUFFER_SIZE                1000
 #define DEFAULT_VALID_INDEX_BUFFER_SIZE            1000
 #define DEFAULT_PEER_FRAME_BUFFER_SIZE             (5 * 1024)
@@ -48,6 +48,9 @@ typedef struct {
     RtcRtpSender sender;
 
     PKvsPeerConnection pKvsPeerConnection;
+
+    UINT32 rollingBufferDurationInSec;
+    UINT32 rollingBufferBitrateInMBps;
 
     UINT32 jitterBufferSsrc;
     PJitterBuffer pJitterBuffer;

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -16,6 +16,8 @@ extern "C" {
 #define DEFAULT_VALID_INDEX_BUFFER_SIZE            1000
 #define DEFAULT_PEER_FRAME_BUFFER_SIZE             (5 * 1024)
 #define SRTP_AUTH_TAG_OVERHEAD                     10
+#define MIN_ROLLING_BUFFER_DURATION_IN_SECONDS     (DOUBLE) 0.1
+#define MIN_EXPECTED_BIT_RATE                      (102.4 * 1024) // Considering 1Kb = 1024 bits
 
 // https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-huge
 // Huge frames, by definition, are frames that have an encoded size at least 2.5 times the average size of the frames.

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -49,8 +49,8 @@ typedef struct {
 
     PKvsPeerConnection pKvsPeerConnection;
 
-    UINT32 rollingBufferDurationInSec;
-    UINT32 rollingBufferBitrateInMBps;
+    DOUBLE rollingBufferDurationInSec;
+    DOUBLE rollingBufferBitrateInMBps;
 
     UINT32 jitterBufferSsrc;
     PJitterBuffer pJitterBuffer;

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -9,17 +9,17 @@ extern "C" {
 
 // Default MTU comes from libwebrtc
 // https://groups.google.com/forum/#!topic/discuss-webrtc/gH5ysR3SoZI
-#define DEFAULT_MTU_SIZE                           1200
+#define DEFAULT_MTU_SIZE_BYTES                     1200
 #define DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS 3
 #define DEFAULT_EXPECTED_VIDEO_BIT_RATE            (5 * 1024 * 1024)
-// Opus has highest based on the supported codecs which is 510Kbps. So setting this to twice
+// Opus has highest based on the supported codecs which is 510Kibps. So setting this to twice
 #define DEFAULT_EXPECTED_AUDIO_BIT_RATE        (1000 * 1024)
 #define DEFAULT_SEQ_NUM_BUFFER_SIZE            1000
 #define DEFAULT_VALID_INDEX_BUFFER_SIZE        1000
 #define DEFAULT_PEER_FRAME_BUFFER_SIZE         (5 * 1024)
 #define SRTP_AUTH_TAG_OVERHEAD                 10
 #define MIN_ROLLING_BUFFER_DURATION_IN_SECONDS (DOUBLE) 0.1
-#define MIN_EXPECTED_BIT_RATE                  (DOUBLE)(102.4 * 1024) // Considering 1Kb = 1024 bits
+#define MIN_EXPECTED_BIT_RATE                  (DOUBLE)(102.4 * 1024) // Considering 1Kib = 1024 bits
 
 // https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-huge
 // Huge frames, by definition, are frames that have an encoded size at least 2.5 times the average size of the frames.

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -17,7 +17,7 @@ extern "C" {
 #define DEFAULT_PEER_FRAME_BUFFER_SIZE             (5 * 1024)
 #define SRTP_AUTH_TAG_OVERHEAD                     10
 #define MIN_ROLLING_BUFFER_DURATION_IN_SECONDS     (DOUBLE) 0.1
-#define MIN_EXPECTED_BIT_RATE                      (102.4 * 1024) // Considering 1Kb = 1024 bits
+#define MIN_EXPECTED_BIT_RATE                      (DOUBLE)(102.4 * 1024) // Considering 1Kb = 1024 bits
 
 // https://www.w3.org/TR/webrtc-stats/#dom-rtcoutboundrtpstreamstats-huge
 // Huge frames, by definition, are frames that have an encoded size at least 2.5 times the average size of the frames.

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -50,7 +50,7 @@ typedef struct {
     PKvsPeerConnection pKvsPeerConnection;
 
     DOUBLE rollingBufferDurationSec;
-    DOUBLE rollingBufferBitrateBps;
+    DOUBLE rollingBufferBitratebps;
 
     UINT32 jitterBufferSsrc;
     PJitterBuffer pJitterBuffer;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -296,6 +296,8 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PD
         }
 
         UINT64 size = (UINT64) (pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitratebps / 8 / DEFAULT_MTU_SIZE);
+
+        DLOGI("The rolling buffer is configured to store %d RTP packets", size);
         CHK_STATUS(createRtpRollingBuffer(size, &pKvsRtpTransceiver->sender.packetBuffer));
         CHK_STATUS(createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));
     }

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -295,8 +295,8 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PD
             }
         }
 
-        DLOGI("Sizes: %d, %d", pKvsRtpTransceiver->rollingBufferDurationSec, pKvsRtpTransceiver->rollingBufferBitrateInMbps);
-        UINT64 size = pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitrateInMbps / 8 / DEFAULT_MTU_SIZE;
+        DLOGI("Sizes: %lf, %lf", pKvsRtpTransceiver->rollingBufferDurationSec, pKvsRtpTransceiver->rollingBufferBitrateBps);
+        UINT64 size = (UINT64) (pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitrateBps / 8 / DEFAULT_MTU_SIZE);
         DLOGI("Cap: %d", size);
         CHK_STATUS(createRtpRollingBuffer(size, &pKvsRtpTransceiver->sender.packetBuffer));
         CHK_STATUS(createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));
@@ -1103,7 +1103,6 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
     STATUS retStatus = STATUS_SUCCESS;
     UINT32 currentMedia, currentAttribute, tokenLen = 0, codec = 0, count = 0, unknownCodecCounter = 0;
     PSdpMediaDescription pMediaDescription = NULL;
-    RtcRtpTransceiverInit rtcRtpTransceiverInit;
     PCHAR attributeValue, end, codecs = NULL;
     PCHAR rtpMapValue = NULL;
     CHAR firstCodec[MAX_PAYLOAD_TYPE_LENGTH];
@@ -1243,9 +1242,8 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
             STRCPY(track.streamId, "fakeStream");
             STRCPY(track.trackId, "fakeTrack");
             pRtcMediaStreamTrack = &track;
-            rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE;
-            CHK_STATUS(createKvsRtpTransceiver(&rtcRtpTransceiverInit, pKvsPeerConnection, (UINT32) RAND(), (UINT32) RAND(), pRtcMediaStreamTrack,
-                                               NULL, RTC_CODEC_UNKNOWN, &pKvsRtpFakeTransceiver));
+            CHK_STATUS(createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE, 0, 0, pKvsPeerConnection, (UINT32) RAND(), (UINT32) RAND(),
+                                               pRtcMediaStreamTrack, NULL, RTC_CODEC_UNKNOWN, &pKvsRtpFakeTransceiver));
 
             // add the new transceiver to a list of fake transceivers to keep a track of them
             // add the same to the pAnswerTransceivers since it will be needed later to serialize

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -295,9 +295,11 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PD
             }
         }
 
-        DLOGI("Sizes: %d, %d", pKvsRtpTransceiver->rollingBufferDurationInSec, pKvsRtpTransceiver->rollingBufferBitrateInMBps);
-        CHK_STATUS(createRtpRollingBuffer(pKvsRtpTransceiver->rollingBufferDurationInSec * pKvsRtpTransceiver->rollingBufferBitrateInMBps / 8 /
-                                              DEFAULT_MTU_SIZE,
+        DLOGI("Sizes: %lf, %lf", pKvsRtpTransceiver->rollingBufferDurationInSec, pKvsRtpTransceiver->rollingBufferBitrateInMBps);
+        UINT64 size = pKvsRtpTransceiver->rollingBufferDurationInSec * pKvsRtpTransceiver->rollingBufferBitrateInMBps / 8 /
+                      DEFAULT_MTU_SIZE;
+        DLOGI("Cap: %d", size);
+        CHK_STATUS(createRtpRollingBuffer(size,
                                           &pKvsRtpTransceiver->sender.packetBuffer));
         CHK_STATUS(createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));
     }

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -295,10 +295,11 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PD
             }
         }
 
-        UINT64 size = (UINT64) (pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitratebps / 8 / DEFAULT_MTU_SIZE);
+        UINT64 rollingBufferCapacity =
+            (UINT64) (pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitratebps / 8 / DEFAULT_MTU_SIZE);
 
-        DLOGI("The rolling buffer is configured to store %d RTP packets", size);
-        CHK_STATUS(createRtpRollingBuffer(size, &pKvsRtpTransceiver->sender.packetBuffer));
+        DLOGI("The rolling buffer is configured to store %d RTP packets", rollingBufferCapacity);
+        CHK_STATUS(createRtpRollingBuffer(rollingBufferCapacity, &pKvsRtpTransceiver->sender.packetBuffer));
         CHK_STATUS(createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));
     }
 

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -295,9 +295,7 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PD
             }
         }
 
-        DLOGI("Sizes: %lf, %lf", pKvsRtpTransceiver->rollingBufferDurationSec, pKvsRtpTransceiver->rollingBufferBitrateBps);
-        UINT64 size = (UINT64) (pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitrateBps / 8 / DEFAULT_MTU_SIZE);
-        DLOGI("Cap: %d", size);
+        UINT64 size = (UINT64) (pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitratebps / 8 / DEFAULT_MTU_SIZE);
         CHK_STATUS(createRtpRollingBuffer(size, &pKvsRtpTransceiver->sender.packetBuffer));
         CHK_STATUS(createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));
     }

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -295,7 +295,9 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PD
             }
         }
 
-        CHK_STATUS(createRtpRollingBuffer(DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS * HIGHEST_EXPECTED_BIT_RATE / 8 / DEFAULT_MTU_SIZE,
+        DLOGI("Sizes: %d, %d", pKvsRtpTransceiver->rollingBufferDurationInSec, pKvsRtpTransceiver->rollingBufferBitrateInMBps);
+        CHK_STATUS(createRtpRollingBuffer(pKvsRtpTransceiver->rollingBufferDurationInSec * pKvsRtpTransceiver->rollingBufferBitrateInMBps / 8 /
+                                              DEFAULT_MTU_SIZE,
                                           &pKvsRtpTransceiver->sender.packetBuffer));
         CHK_STATUS(createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));
     }

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -296,7 +296,7 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PD
         }
 
         UINT64 rollingBufferCapacity =
-            (UINT64) (pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitratebps / 8 / DEFAULT_MTU_SIZE);
+            (UINT64) (pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitratebps / 8 / DEFAULT_MTU_SIZE_BYTES);
 
         DLOGI("The rolling buffer is configured to store %d RTP packets", rollingBufferCapacity);
         CHK_STATUS(createRtpRollingBuffer(rollingBufferCapacity, &pKvsRtpTransceiver->sender.packetBuffer));

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -295,12 +295,10 @@ STATUS setTransceiverPayloadTypes(PHashTable codecTable, PHashTable rtxTable, PD
             }
         }
 
-        DLOGI("Sizes: %lf, %lf", pKvsRtpTransceiver->rollingBufferDurationInSec, pKvsRtpTransceiver->rollingBufferBitrateInMBps);
-        UINT64 size = pKvsRtpTransceiver->rollingBufferDurationInSec * pKvsRtpTransceiver->rollingBufferBitrateInMBps / 8 /
-                      DEFAULT_MTU_SIZE;
+        DLOGI("Sizes: %d, %d", pKvsRtpTransceiver->rollingBufferDurationSec, pKvsRtpTransceiver->rollingBufferBitrateInMbps);
+        UINT64 size = pKvsRtpTransceiver->rollingBufferDurationSec * pKvsRtpTransceiver->rollingBufferBitrateInMbps / 8 / DEFAULT_MTU_SIZE;
         DLOGI("Cap: %d", size);
-        CHK_STATUS(createRtpRollingBuffer(size,
-                                          &pKvsRtpTransceiver->sender.packetBuffer));
+        CHK_STATUS(createRtpRollingBuffer(size, &pKvsRtpTransceiver->sender.packetBuffer));
         CHK_STATUS(createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));
     }
 
@@ -1105,6 +1103,7 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
     STATUS retStatus = STATUS_SUCCESS;
     UINT32 currentMedia, currentAttribute, tokenLen = 0, codec = 0, count = 0, unknownCodecCounter = 0;
     PSdpMediaDescription pMediaDescription = NULL;
+    RtcRtpTransceiverInit rtcRtpTransceiverInit;
     PCHAR attributeValue, end, codecs = NULL;
     PCHAR rtpMapValue = NULL;
     CHAR firstCodec[MAX_PAYLOAD_TYPE_LENGTH];
@@ -1244,8 +1243,9 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
             STRCPY(track.streamId, "fakeStream");
             STRCPY(track.trackId, "fakeTrack");
             pRtcMediaStreamTrack = &track;
-            CHK_STATUS(createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE, pKvsPeerConnection, (UINT32) RAND(), (UINT32) RAND(),
-                                               pRtcMediaStreamTrack, NULL, RTC_CODEC_UNKNOWN, &pKvsRtpFakeTransceiver));
+            rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE;
+            CHK_STATUS(createKvsRtpTransceiver(&rtcRtpTransceiverInit, pKvsPeerConnection, (UINT32) RAND(), (UINT32) RAND(), pRtcMediaStreamTrack,
+                                               NULL, RTC_CODEC_UNKNOWN, &pKvsRtpFakeTransceiver));
 
             // add the new transceiver to a list of fake transceivers to keep a track of them
             // add the same to the pAnswerTransceivers since it will be needed later to serialize

--- a/tst/DtlsFunctionalityTest.cpp
+++ b/tst/DtlsFunctionalityTest.cpp
@@ -131,8 +131,8 @@ TEST_F(DtlsFunctionalityTest, putApplicationDataWithVariedSizes)
     PBYTE pData = NULL;
     INT32 dataSizes[] = {
         4,                      // very small packet
-        DEFAULT_MTU_SIZE - 200, // small packet but should be still under mtu
-        DEFAULT_MTU_SIZE + 200, // big packet and bigger than even a jumbo frame
+        DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
+        DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
     };
 
     EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
@@ -161,8 +161,8 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizes)
     PBYTE pData = NULL;
     INT32 dataSizes[] = {
         4,                      // very small packet
-        DEFAULT_MTU_SIZE - 200, // small packet but should be still under mtu
-        DEFAULT_MTU_SIZE + 200, // big packet and bigger than even a jumbo frame
+        DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
+        DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
     };
     INT32 readDataSize;
 
@@ -193,8 +193,8 @@ TEST_F(DtlsFunctionalityTest, putApplicationDataWithVariedSizesInThread)
     PBYTE pData = NULL;
     INT32 dataSizes[] = {
             4,                      // very small packet
-            DEFAULT_MTU_SIZE - 200, // small packet but should be still under mtu
-            DEFAULT_MTU_SIZE + 200, // big packet and bigger than even a jumbo frame
+            DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
+            DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
     };
 
     EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
@@ -223,8 +223,8 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizesInThread)
     PBYTE pData = NULL;
     INT32 dataSizes[] = {
             4,                      // very small packet
-            DEFAULT_MTU_SIZE - 200, // small packet but should be still under mtu
-            DEFAULT_MTU_SIZE + 200, // big packet and bigger than even a jumbo frame
+            DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
+            DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
     };
     INT32 readDataSize;
 

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -211,6 +211,7 @@ TEST_F(PeerConnectionApiTest, addConfigToServerListUnitTest)
     freePeerConnection(&pc);
 }
 
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -211,7 +211,6 @@ TEST_F(PeerConnectionApiTest, addConfigToServerListUnitTest)
     freePeerConnection(&pc);
 }
 
-
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -153,7 +153,7 @@ TEST_F(RtcpFunctionalityTest, onRtcpPacketCompoundNack)
     BYTE validRtcpPacket[] = {0x81, 0xcd, 0x00, 0x03, 0x2c, 0xd1, 0xa0, 0xde, 0x00, 0x00, 0xab, 0xe0, 0x00, 0x00, 0x00, 0x00};
     initTransceiver(44000);
     ASSERT_EQ(STATUS_SUCCESS,
-              createRtpRollingBuffer(DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS * DEFAULT_EXPECTED_VIDEO_BIT_RATE / 8 / DEFAULT_MTU_SIZE,
+              createRtpRollingBuffer(DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS * DEFAULT_EXPECTED_VIDEO_BIT_RATE / 8 / DEFAULT_MTU_SIZE_BYTES,
                                      &pKvsRtpTransceiver->sender.packetBuffer));
     ASSERT_EQ(STATUS_SUCCESS,
               createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -387,43 +387,43 @@ TEST_F(RtcpFunctionalityTest, testRollingBufferParams)
     EXPECT_EQ(STATUS_SUCCESS, ::addTransceiver(pRtcPeerConnection, &trackEmptyRtcRtpTransceiverInitTrack, nullptr, &out));
     pKvsRtpTransceiver = reinterpret_cast<PKvsRtpTransceiver>(out);
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferDurationSec, DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS);
-    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitrateBps, HIGHEST_EXPECTED_BIT_RATE);
+    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, HIGHEST_EXPECTED_BIT_RATE);
 
     trackInvalidRbTimeTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
     trackInvalidRbTimeInit.rollingBufferDurationSec = 0.01;
-    trackInvalidRbTimeInit.rollingBufferBitrateBps = 2 * 1024 * 1024;
+    trackInvalidRbTimeInit.rollingBufferBitratebps = 2 * 1024 * 1024;
 
     EXPECT_EQ(STATUS_SUCCESS, ::addTransceiver(pRtcPeerConnection, &trackInvalidRbTimeTrack, &trackInvalidRbTimeInit, &out));
     pKvsRtpTransceiver = reinterpret_cast<PKvsRtpTransceiver>(out);
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferDurationSec, DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS);
-    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitrateBps, trackInvalidRbTimeInit.rollingBufferBitrateBps);
+    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, trackInvalidRbTimeInit.rollingBufferBitratebps);
 
     trackInvalidRbBitrateTrack.codec = RTC_CODEC_OPUS;
     trackInvalidRbBitrateInit.rollingBufferDurationSec = 0.1;
-    trackInvalidRbBitrateInit.rollingBufferBitrateBps = 0.01 * 1024 * 1024;
+    trackInvalidRbBitrateInit.rollingBufferBitratebps = 0.01 * 1024 * 1024;
 
     EXPECT_EQ(STATUS_SUCCESS, ::addTransceiver(pRtcPeerConnection, &trackInvalidRbBitrateTrack, &trackInvalidRbBitrateInit, &out));
     pKvsRtpTransceiver = reinterpret_cast<PKvsRtpTransceiver>(out);
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferDurationSec, trackInvalidRbBitrateInit.rollingBufferDurationSec);
-    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitrateBps, HIGHEST_EXPECTED_BIT_RATE);
+    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, HIGHEST_EXPECTED_BIT_RATE);
 
     trackInvalidRbBitrateRbTimeTrack.codec = RTC_CODEC_OPUS;
     trackInvalidRbBitrateRbTimeInit.rollingBufferDurationSec = 0.001;
-    trackInvalidRbBitrateRbTimeInit.rollingBufferBitrateBps = 0.01 * 1024 * 1024;
+    trackInvalidRbBitrateRbTimeInit.rollingBufferBitratebps = 0.01 * 1024 * 1024;
 
     EXPECT_EQ(STATUS_SUCCESS, ::addTransceiver(pRtcPeerConnection, &trackInvalidRbBitrateRbTimeTrack, &trackInvalidRbBitrateRbTimeInit, &out));
     pKvsRtpTransceiver = reinterpret_cast<PKvsRtpTransceiver>(out);
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferDurationSec, DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS);
-    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitrateBps, HIGHEST_EXPECTED_BIT_RATE);
+    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, HIGHEST_EXPECTED_BIT_RATE);
 
     trackValidRbTrack.codec = RTC_CODEC_OPUS;
     trackValidRbInit.rollingBufferDurationSec = 10;
-    trackValidRbInit.rollingBufferBitrateBps = 10 * 1024 * 1024;
+    trackValidRbInit.rollingBufferBitratebps = 10 * 1024 * 1024;
 
     EXPECT_EQ(STATUS_SUCCESS, ::addTransceiver(pRtcPeerConnection, &trackValidRbTrack, &trackValidRbInit, &out));
     pKvsRtpTransceiver = reinterpret_cast<PKvsRtpTransceiver>(out);
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferDurationSec, trackValidRbInit.rollingBufferDurationSec);
-    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitrateBps, trackValidRbInit.rollingBufferBitrateBps);
+    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, trackValidRbInit.rollingBufferBitratebps);
 
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -153,7 +153,7 @@ TEST_F(RtcpFunctionalityTest, onRtcpPacketCompoundNack)
     BYTE validRtcpPacket[] = {0x81, 0xcd, 0x00, 0x03, 0x2c, 0xd1, 0xa0, 0xde, 0x00, 0x00, 0xab, 0xe0, 0x00, 0x00, 0x00, 0x00};
     initTransceiver(44000);
     ASSERT_EQ(STATUS_SUCCESS,
-              createRtpRollingBuffer(DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS * HIGHEST_EXPECTED_BIT_RATE / 8 / DEFAULT_MTU_SIZE,
+              createRtpRollingBuffer(DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS * DEFAULT_EXPECTED_VIDEO_BIT_RATE / 8 / DEFAULT_MTU_SIZE,
                                      &pKvsRtpTransceiver->sender.packetBuffer));
     ASSERT_EQ(STATUS_SUCCESS,
               createRetransmitter(DEFAULT_SEQ_NUM_BUFFER_SIZE, DEFAULT_VALID_INDEX_BUFFER_SIZE, &pKvsRtpTransceiver->sender.retransmitter));
@@ -384,12 +384,14 @@ TEST_F(RtcpFunctionalityTest, testRollingBufferParams)
     RtcRtpTransceiverInit trackValidRbInit{};
 
     trackEmptyRtcRtpTransceiverInitTrack.codec = RTC_CODEC_VP8;
+    trackEmptyRtcRtpTransceiverInitTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
     EXPECT_EQ(STATUS_SUCCESS, ::addTransceiver(pRtcPeerConnection, &trackEmptyRtcRtpTransceiverInitTrack, nullptr, &out));
     pKvsRtpTransceiver = reinterpret_cast<PKvsRtpTransceiver>(out);
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferDurationSec, DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS);
-    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, HIGHEST_EXPECTED_BIT_RATE);
+    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, DEFAULT_EXPECTED_VIDEO_BIT_RATE);
 
     trackInvalidRbTimeTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    trackInvalidRbTimeTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
     trackInvalidRbTimeInit.rollingBufferDurationSec = 0.01;
     trackInvalidRbTimeInit.rollingBufferBitratebps = 2 * 1024 * 1024;
 
@@ -399,24 +401,27 @@ TEST_F(RtcpFunctionalityTest, testRollingBufferParams)
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, trackInvalidRbTimeInit.rollingBufferBitratebps);
 
     trackInvalidRbBitrateTrack.codec = RTC_CODEC_OPUS;
+    trackInvalidRbBitrateTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
     trackInvalidRbBitrateInit.rollingBufferDurationSec = 0.1;
     trackInvalidRbBitrateInit.rollingBufferBitratebps = 0.01 * 1024 * 1024;
 
     EXPECT_EQ(STATUS_SUCCESS, ::addTransceiver(pRtcPeerConnection, &trackInvalidRbBitrateTrack, &trackInvalidRbBitrateInit, &out));
     pKvsRtpTransceiver = reinterpret_cast<PKvsRtpTransceiver>(out);
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferDurationSec, trackInvalidRbBitrateInit.rollingBufferDurationSec);
-    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, HIGHEST_EXPECTED_BIT_RATE);
+    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, DEFAULT_EXPECTED_AUDIO_BIT_RATE);
 
     trackInvalidRbBitrateRbTimeTrack.codec = RTC_CODEC_OPUS;
+    trackInvalidRbBitrateRbTimeTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
     trackInvalidRbBitrateRbTimeInit.rollingBufferDurationSec = 0.001;
     trackInvalidRbBitrateRbTimeInit.rollingBufferBitratebps = 0.01 * 1024 * 1024;
 
     EXPECT_EQ(STATUS_SUCCESS, ::addTransceiver(pRtcPeerConnection, &trackInvalidRbBitrateRbTimeTrack, &trackInvalidRbBitrateRbTimeInit, &out));
     pKvsRtpTransceiver = reinterpret_cast<PKvsRtpTransceiver>(out);
     EXPECT_EQ(pKvsRtpTransceiver->rollingBufferDurationSec, DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS);
-    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, HIGHEST_EXPECTED_BIT_RATE);
+    EXPECT_EQ(pKvsRtpTransceiver->rollingBufferBitratebps, DEFAULT_EXPECTED_AUDIO_BIT_RATE);
 
     trackValidRbTrack.codec = RTC_CODEC_OPUS;
+    trackValidRbTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
     trackValidRbInit.rollingBufferDurationSec = 10;
     trackValidRbInit.rollingBufferBitratebps = 10 * 1024 * 1024;
 

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -112,7 +112,7 @@ TEST_F(RtpFunctionalityTest, marshallUnmarshallH264Data)
 
         // First call for payload size and sub payload length size
         EXPECT_EQ(STATUS_SUCCESS,
-                  createPayloadForH264(DEFAULT_MTU_SIZE, (PBYTE) payload, payloadLen, NULL, &payloadArray.payloadLength, NULL,
+                  createPayloadForH264(DEFAULT_MTU_SIZE_BYTES, (PBYTE) payload, payloadLen, NULL, &payloadArray.payloadLength, NULL,
                                        &payloadArray.payloadSubLenSize));
 
         if (payloadArray.payloadLength > payloadArray.maxPayloadLength) {
@@ -132,7 +132,7 @@ TEST_F(RtpFunctionalityTest, marshallUnmarshallH264Data)
 
         // Second call with actual buffer to fill in data
         EXPECT_EQ(STATUS_SUCCESS,
-                  createPayloadForH264(DEFAULT_MTU_SIZE, (PBYTE) payload, payloadLen, payloadArray.payloadBuffer, &payloadArray.payloadLength,
+                  createPayloadForH264(DEFAULT_MTU_SIZE_BYTES, (PBYTE) payload, payloadLen, payloadArray.payloadBuffer, &payloadArray.payloadLength,
                                        payloadArray.payloadSubLength, &payloadArray.payloadSubLenSize));
 
         EXPECT_LT(0, payloadArray.payloadSubLenSize);
@@ -191,7 +191,7 @@ TEST_F(RtpFunctionalityTest, packingUnpackingVerifySameH264Frame)
 
         // First call for payload size and sub payload length size
         EXPECT_EQ(STATUS_SUCCESS,
-                  createPayloadForH264(DEFAULT_MTU_SIZE, (PBYTE) payload, payloadLen, NULL, &payloadArray.payloadLength, NULL,
+                  createPayloadForH264(DEFAULT_MTU_SIZE_BYTES, (PBYTE) payload, payloadLen, NULL, &payloadArray.payloadLength, NULL,
                                        &payloadArray.payloadSubLenSize));
 
         if (payloadArray.payloadLength > payloadArray.maxPayloadLength) {
@@ -211,7 +211,7 @@ TEST_F(RtpFunctionalityTest, packingUnpackingVerifySameH264Frame)
 
         // Second call with actual buffer to fill in data
         EXPECT_EQ(STATUS_SUCCESS,
-                  createPayloadForH264(DEFAULT_MTU_SIZE, (PBYTE) payload, payloadLen, payloadArray.payloadBuffer, &payloadArray.payloadLength,
+                  createPayloadForH264(DEFAULT_MTU_SIZE_BYTES, (PBYTE) payload, payloadLen, payloadArray.payloadBuffer, &payloadArray.payloadLength,
                                        payloadArray.payloadSubLength, &payloadArray.payloadSubLenSize));
 
         EXPECT_LT(0, payloadArray.payloadSubLenSize);
@@ -277,7 +277,7 @@ TEST_F(RtpFunctionalityTest, packingUnpackingVerifySameOpusFrame)
 
     // First call for payload size and sub payload length size
     EXPECT_EQ(STATUS_SUCCESS,
-              createPayloadForOpus(DEFAULT_MTU_SIZE, (PBYTE) &payload, payloadLen, NULL, &payloadArray.payloadLength, NULL,
+              createPayloadForOpus(DEFAULT_MTU_SIZE_BYTES, (PBYTE) &payload, payloadLen, NULL, &payloadArray.payloadLength, NULL,
                                    &payloadArray.payloadSubLenSize));
 
     if (payloadArray.payloadLength > payloadArray.maxPayloadLength) {
@@ -297,7 +297,7 @@ TEST_F(RtpFunctionalityTest, packingUnpackingVerifySameOpusFrame)
 
     // Second call with actual buffer to fill in data
     EXPECT_EQ(STATUS_SUCCESS,
-              createPayloadForOpus(DEFAULT_MTU_SIZE, (PBYTE) &payload, payloadLen, payloadArray.payloadBuffer, &payloadArray.payloadLength,
+              createPayloadForOpus(DEFAULT_MTU_SIZE_BYTES, (PBYTE) &payload, payloadLen, payloadArray.payloadBuffer, &payloadArray.payloadLength,
                                    payloadArray.payloadSubLength, &payloadArray.payloadSubLenSize));
 
     EXPECT_EQ(1, payloadArray.payloadSubLenSize);
@@ -332,7 +332,7 @@ TEST_F(RtpFunctionalityTest, packingUnpackingVerifySameShortG711Frame)
 
     // First call for payload size and sub payload length size
     EXPECT_EQ(STATUS_SUCCESS,
-              createPayloadForG711(DEFAULT_MTU_SIZE, (PBYTE) &payload, payloadLen, NULL, &payloadArray.payloadLength, NULL,
+              createPayloadForG711(DEFAULT_MTU_SIZE_BYTES, (PBYTE) &payload, payloadLen, NULL, &payloadArray.payloadLength, NULL,
                                    &payloadArray.payloadSubLenSize));
 
     if (payloadArray.payloadLength > payloadArray.maxPayloadLength) {
@@ -352,7 +352,7 @@ TEST_F(RtpFunctionalityTest, packingUnpackingVerifySameShortG711Frame)
 
     // Second call with actual buffer to fill in data
     EXPECT_EQ(STATUS_SUCCESS,
-              createPayloadForG711(DEFAULT_MTU_SIZE, (PBYTE) &payload, payloadLen, payloadArray.payloadBuffer, &payloadArray.payloadLength,
+              createPayloadForG711(DEFAULT_MTU_SIZE_BYTES, (PBYTE) &payload, payloadLen, payloadArray.payloadBuffer, &payloadArray.payloadLength,
                                    payloadArray.payloadSubLength, &payloadArray.payloadSubLenSize));
 
     EXPECT_EQ(1, payloadArray.payloadSubLenSize);

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -252,6 +252,8 @@ TEST_F(SdpApiTest, setTransceiverPayloadTypes_NoRtxType)
     transceiver.transceiver.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
     transceiver.sender.packetBuffer = NULL;
     transceiver.sender.retransmitter = NULL;
+    transceiver.rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
+    transceiver.rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pCodecTable));
     EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 1));
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pRtxTable));
@@ -278,6 +280,8 @@ TEST_F(SdpApiTest, setTransceiverPayloadTypes_HasRtxType)
     transceiver.transceiver.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
     transceiver.sender.packetBuffer = NULL;
     transceiver.sender.retransmitter = NULL;
+    transceiver.rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
+    transceiver.rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pCodecTable));
     EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 1));
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pRtxTable));

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -253,7 +253,7 @@ TEST_F(SdpApiTest, setTransceiverPayloadTypes_NoRtxType)
     transceiver.sender.packetBuffer = NULL;
     transceiver.sender.retransmitter = NULL;
     transceiver.rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
-    transceiver.rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
+    transceiver.rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pCodecTable));
     EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 1));
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pRtxTable));
@@ -281,7 +281,7 @@ TEST_F(SdpApiTest, setTransceiverPayloadTypes_HasRtxType)
     transceiver.sender.packetBuffer = NULL;
     transceiver.sender.retransmitter = NULL;
     transceiver.rollingBufferDurationSec = DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS;
-    transceiver.rollingBufferBitratebps = HIGHEST_EXPECTED_BIT_RATE;
+    transceiver.rollingBufferBitratebps = DEFAULT_EXPECTED_VIDEO_BIT_RATE;
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pCodecTable));
     EXPECT_EQ(STATUS_SUCCESS, hashTablePut(pCodecTable, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE, 1));
     EXPECT_EQ(STATUS_SUCCESS, hashTableCreate(&pRtxTable));

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -490,6 +490,7 @@ a=rtpmap:102 H264/90000
         MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
         MEMSET(&rtcMediaStreamTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
         MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+        MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
 
         EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
         EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);
@@ -981,6 +982,7 @@ a=fmtp:125 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01
         MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
         MEMSET(&rtcMediaStreamTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
         MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+        MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
 
         EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
         EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);
@@ -1456,6 +1458,7 @@ TEST_P(SdpApiTest_SdpMatch, populateSingleMediaSection_TestH264Fmtp)
     MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
     MEMSET(&track1, 0x00, SIZEOF(RtcMediaStreamTrack));
     MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
 
     EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
     EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -442,7 +442,6 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxRecvOnlyStreamNull)
 
     // Create peer connection
     EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
-
     PRtcRtpTransceiver pTransceiver;
     RtcRtpTransceiverInit rtcRtpTransceiverInit;
     rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY;


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Reduced default size of rolling buffer to about half of original to reduce default memory allocation
- Added new members to allow configuring rolling buffer size per transceiver
- Updated readme about usage details

*Why was it changed?*
- Our SDK was allocating rolling buffer worth 5 seconds of media at bitrate of 10Mbps which increases the rolling buffer size which is very large. Ideally, the bitrate depends on the media track and the codec being used. Audio tracks typically have lower bitrates than video and within audio/video, different codecs have different typical bitrates. Given this, the values should be configurable. By controlling the capacity, the SDK essentially controls the number of RTP packets the buffer holds references to.

*How was it changed?*
- Added new fields `rollingBufferDurationSec` and `rollingBufferBitratebps` in `RtcRtpTransceiverInit` struct. Applications can set these values up while setting up the tracks. An example usage pattern is provided in the README and in our samples with values set to default.
- Lowered the default rolling buffer duration to 1 seconds and bitrate to 5Mbps. 
- If the values are not provided or is less than minimum allowed, the SDK sets the defaults
- While calculating the minimum values, the consideration was to calculate a size to store 1 RTP packet. Given this, a 100 ms + 100 kbps combination leads to allowing storing reference to only 1 RTP packet.
- Post this change, using the master sample with JS viewer, the default values based peak heap memory consumption was observed to be reduced by 1.7MB.

Before the change -- peak heap memory consumption = 6.68MB
![Screenshot 2024-02-06 at 4 20 42 PM](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/assets/22107309/b5b5a676-07e7-419c-b40a-8b55aff914fd)


After the change: (with default 3 seconds, 5 Mbps for video, 3 seconds, 1000Kbps for audio) -- peak heap memory consumption = 4.98MB
<img width="679" alt="Screenshot 2024-02-09 at 12 59 49 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/assets/22107309/db9cb3b2-9c4b-49f6-ade7-c9f11dfdf01b">


With sample settings (H.264 : 3 seconds, 4 Mbps and Opus: 3 seconds, 510 Kbps) -- peak heap memory consumption = 4.82MB
<img width="679" alt="Screenshot 2024-02-09 at 11 17 13 AM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/assets/22107309/85da5102-02ee-4beb-bcd9-da0cf390d1cb">



*What testing was done for the changes?*
- Added a specific unit test to test different input combinations
- Ran the sample with different values to confirm it works fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
