### PR TITLE
Mbedtls cross compile in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,6 +649,7 @@ jobs:
       - name: Verify library is ARM64 type
         run: |
           cd scripts
+          chmod +x verify_lib.sh
           ./verify_lib.sh ../build/libkvsWebrtcClient.so "ARM64"
 
   arm64-cross-compilation-mbedtls-static:
@@ -672,6 +673,7 @@ jobs:
       - name: Verify library is ARM64 type
         run: | 
           cd scripts
+          chmod +x verify_lib.sh
           ./verify_lib.sh ../build/libkvsWebrtcClient.a "ARM64"
 
   linux-aarch64-cross-compilation:
@@ -695,6 +697,7 @@ jobs:
       - name: Verify library is ARM64 type
         run: |
           cd scripts
+          chmod +x verify_lib.sh
           ./verify_lib.sh ../build/libkvsWebrtcClient.so "ARM64"
 
   arm32-cross-compilation:
@@ -718,6 +721,7 @@ jobs:
       - name: Verify library is ARM32 type
         run: |
           cd scripts
+          chmod +x verify_lib.sh
           ./verify_lib.sh ../build/libkvsWebrtcClient.a "ARM32"
 
   arm32-cross-compilation-mbedtls:
@@ -741,6 +745,7 @@ jobs:
       - name: Verify library is ARM32 type
         run: |
           cd scripts
+          chmod +x verify_lib.sh
           ./verify_lib.sh ../build/libkvsWebrtcClient.so "ARM32"
 
   arm32-cross-compilation-mbedtls-static:
@@ -764,4 +769,5 @@ jobs:
       - name: Verify library is ARM32 type
         run: |
           cd scripts
+          chmod +x verify_lib.sh
           ./verify_lib.sh ../build/libkvsWebrtcClient.a "ARM32"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,7 +670,7 @@ jobs:
           make
       - name: Verify library is ARM64 type
         run: | 
-          ar -xv libkvsWebrtcClient.a
+          ls
 
   linux-aarch64-cross-compilation:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,629 +5,628 @@ on:
     branches:
       - develop
       - master
-      - mbedtls-cross-compile
   pull_request:
     branches:
       - develop
       - master
 jobs:
-#  clang-format-check:
-#    runs-on: macos-latest
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Install clang-format
-#        run: |
-#          brew install clang-format
-#          clang-format --version
-#      - name: Run clang format check
-#        run: |
-#          bash scripts/check-clang.sh
-#  mac-os-build-clang:
-#    runs-on: macos-11
-#    env:
-#      CC: /usr/bin/clang
-#      CXX: /usr/bin/clang++
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Build repository
-#        run: |
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-#          make
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          ./tst/webrtc_client_test
-#  mac-os-build-gcc:
-#    runs-on: macos-11
-#    env:
-#      CC: gcc
-#      CXX: g++
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Build repository
-#        run: |
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-#          make
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          ./tst/webrtc_client_test
-#  mac-os-m1-build-clang:
-#    runs-on: macos-13-xlarge
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Build repository
-#        run: |
-#          brew unlink openssl
-#          mkdir build && cd build
-#          sh -c 'cmake .. -DBUILD_TEST=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
-#          make
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          ./tst/webrtc_client_test
-#  static-build-mac:
-#    runs-on: macos-11
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Build repository
-#        run: |
-#          mkdir build && cd build
-#          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
-#          make
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          ./tst/webrtc_client_test
-#  address-sanitizer:
-#    runs-on: ubuntu-20.04
-#    env:
-#      ASAN_OPTIONS: detect_odr_violation=0:detect_leaks=1
-#      LSAN_OPTIONS: suppressions=../tst/suppressions/LSAN.supp
-#      CC: clang
-#      CXX: clang++
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install dependencies
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo apt-get -y install clang
-#          sudo apt-get -y install libcurl4-openssl-dev
-#      - name: Build repository
-#        run: |
-#          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
-#          make
-#          ulimit -c unlimited -S
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-#  undefined-behavior-sanitizer:
-#    runs-on: ubuntu-20.04
-#    env:
-#      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-#      CC: clang
-#      CXX: clang++
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install dependencies
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo apt-get -y install clang
-#          sudo apt-get -y install libcurl4-openssl-dev
-#      - name: Build repository
-#        run: |
-#          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
-#          make
-#          ulimit -c unlimited -S
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-#  # memory-sanitizer:
-#  #   runs-on: ubuntu-18.04
-#  #   env:
-#  #     CC: clang-7
-#  #     CXX: clang++-7
-#  #     AWS_KVS_LOG_LEVEL: 2
-#  #   steps:
-#  #     - name: Clone repository
-#  #       uses: actions/checkout@v4
-#  #     - name: Install dependencies
-#  #       run: |
-#  #         sudo apt clean && sudo apt update
-#  #         sudo apt-get -y install clang-7
-#  #     - name: Build repository
-#  #       run: |
-#  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#  #         mkdir build && cd build
-#  #         cmake .. -DMEMORY_SANITIZER=TRUE -DBUILD_TEST=TRUE
-#  #         make
-#  #         ulimit -c unlimited -S
-#  #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
-#  thread-sanitizer:
-#    runs-on: ubuntu-20.04
-#    env:
-#      TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
-#      CC: clang
-#      CXX: clang++
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install dependencies
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo apt-get -y install clang
-#          sudo apt-get -y install libcurl4-openssl-dev
-#      - name: Build repository
-#        run: |
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
-#          make
-#          ulimit -c unlimited -S
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-#  linux-gcc-4_4:
-#    runs-on: ubuntu-20.04
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#      CC: gcc-4.4
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install deps
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-#          sudo apt-get -q update
-#          sudo apt-get -y install gcc-4.4
-#          sudo apt-get -y install gdb
-#          sudo apt-get -y install libcurl4-openssl-dev
-#      - name: Build repository
-#        run: |
-#          mkdir build && cd build
-#          # As per REAMDE here: https://github.com/aws/aws-sdk-cpp minimum supported GCC is 4.9 so we do not run those tests here
-#          cmake .. -DBUILD_TEST=TRUE -DENABLE_AWS_SDK_IN_TESTS=OFF
-#          make
-#          ulimit -c unlimited -S
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-#  static-build-linux:
-#    runs-on: ubuntu-20.04
-#    container:
-#      image: alpine:3.15.4
-#    env:
-#      CC: gcc
-#      CXX: g++
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Install dependencies
-#        run: |
-#          apk update
-#          apk upgrade
-#          apk add alpine-sdk cmake clang linux-headers perl bash openssl-dev zlib-dev curl-dev
-#      - name: Build Repository
-#        run: |
-#          mkdir build && cd build
-#          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
-#          make
-#  mbedtls-ubuntu-gcc:
-#    runs-on: ubuntu-20.04
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install deps
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-#          sudo apt-get -q update
-#          sudo apt-get -y install gcc-4.4
-#          sudo apt-get -y install gdb
-#          sudo apt-get -y install libcurl4-openssl-dev
-#      - name: Build repository
-#        run: |
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-#          make
-#          ulimit -c unlimited -S
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-#  mbedtls-ubuntu-gcc-11:
-#    runs-on: ubuntu-latest
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install deps
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
-#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
-#          sudo apt-get -q update
-#          sudo apt-get -y install libcurl4-openssl-dev
-#      - name: Build repository
-#        run: |
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-#          make
-#          ulimit -c unlimited -S
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-#
-#  mbedtls-ubuntu-gcc-4_4-build:
-#    runs-on: ubuntu-20.04
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#      CC: gcc-4.4
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install deps
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-#          sudo apt-get -q update
-#          sudo apt-get -y install gcc-4.4
-#          sudo apt-get -y install gdb
-#      - name: Build repository
-#        run: |
-#          mkdir build && cd build
-#          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-#          make
-#
-#  mbedtls-ubuntu-clang:
-#    runs-on: ubuntu-20.04
-#    env:
-#      CC: clang
-#      CXX: clang++
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install dependencies
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo apt-get -y install clang
-#          sudo apt-get -y install libcurl4-openssl-dev
-#      - name: Build repository
-#        run: |
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-#          make
-#          ulimit -c unlimited -S
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-#  sample-check:
-#    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
-#    runs-on: ubuntu-latest
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#          role-duration-seconds: 10800
-#      - name: Build repository
-#        run: |
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          mkdir build && cd build
-#          cmake ..
-#          make
-#      - name: Sample check
-#        run: |
-#          ./scripts/check-sample.sh
-#  sample-check-no-data-channel:
-#    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
-#    runs-on: ubuntu-latest
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#          role-duration-seconds: 10800
-#      - name: Build repository
-#        run: |
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          mkdir build && cd build
-#          cmake .. -DENABLE_DATA_CHANNEL=OFF
-#          make
-#      - name: Sample check without data channel
-#        run: |
-#          ./scripts/check-sample.sh
-#  ubuntu-os-build:
-#    runs-on: ubuntu-20.04
-#    env:
-#      AWS_KVS_LOG_LEVEL: 2
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Install dependencies
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo apt-get -y install libcurl4-openssl-dev
-#      - name: Build repository
-#        run: |
-#          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          mkdir build && cd build
-#          cmake .. -DBUILD_TEST=TRUE
-#          make
-#      - name: Run tests
-#        run:  |
-#          cd build
-#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-#  windows-msvc-openssl:
-#    runs-on: windows-2022
-#    env:
-#      AWS_KVS_LOG_LEVEL: 1
-#    permissions:
-#      id-token: write
-#      contents: read
-#    steps:
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#      - name: Move cloned repo
-#        shell: powershell
-#        run: |
-#          mkdir C:\webrtc
-#          Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "C:\webrtc"
-#      - name: Install dependencies
-#        shell: powershell
-#        run: |
-#          choco install gstreamer --version=1.16.2
-#          choco install gstreamer-devel --version=1.16.2
-#          curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
-#          mkdir C:\tools\pthreads-w32-2-9-1-release\
-#          Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
-#      # - name: Build libwebsockets from source
-#      #   shell: powershell
-#      #   run: |
-#      #     $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\lib\x64;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\include'
-#      #     git config --system core.longpaths true
-#      #     cd C:\tools\
-#      #     git clone https://github.com/warmcat/libwebsockets.git
-#      #     git checkout v4.2.2
-#      #     cd libwebsockets
-#      #     mkdir build
-#      #     cd build
-#      #     cmake .. -DLWS_HAVE_PTHREAD_H=1 -DLWS_EXT_PTHREAD_INCLUDE_DIR="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\include" -DLWS_EXT_PTHREAD_LIBRARIES="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\lib\\x64\\libpthreadGC2.a" -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_OPENSSL_INCLUDE_DIRS="C:\\Program Files\\OpenSSL\\include" -DLWS_OPENSSL_LIBRARIES="C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib"
-#      #     cmake --build . --config DEBUG
-#      - name: Build repository
-#        shell: powershell
-#        run: |
-#          cd C:\webrtc
-#          git config --system core.longpaths true
-#          .github\build_windows_openssl.bat
-#      - name: Run tests
-#        shell: powershell
-#        run: |
-#          $env:Path += ';C:\webrtc\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\dll\x64;C:\webrtc\build'
-#          & "C:\webrtc\build\tst\webrtc_client_test.exe" --gtest_filter="-DataChannelFunctionalityTest.*:DtlsApiTest.*:IceApiTest.*:IceFunctionalityTest.*:PeerConnectionFunctionalityTest.*:SignalingApiFunctionalityTest.*:TurnConnectionFunctionalityTest.*:RtpFunctionalityTest.marshallUnmarshallH264Data:RtpFunctionalityTest.packingUnpackingVerifySameH264Frame:RtcpFunctionalityTest.onRtcpPacketCompound:RtcpFunctionalityTest.twcc3"
-#  # windows-msvc-mbedtls:
-#  #   runs-on: windows-2022
-#  #   env:
-#  #     AWS_KVS_LOG_LEVEL: 7
-#  #   steps:
-#  #     - name: Clone repository
-#  #       uses: actions/checkout@v4
-#  #     - name: Move cloned repo
-#  #       shell: powershell
-#  #       run: |
-#  #         mkdir D:\a\webrtc
-#  #         Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "D:\a\webrtc"
-#  #         cd D:\a\webrtc
-#  #         dir
-#  #     - name: Install dependencies
-#  #       shell: powershell
-#  #       run: |
-#  #         choco install gstreamer --version=1.16.2
-#  #         choco install gstreamer-devel --version=1.16.2
-#  #         curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
-#  #         mkdir C:\tools\pthreads-w32-2-9-1-release\
-#  #         Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
-#  #     - name: Build repository
-#  #       shell: powershell
-#  #       run: |
-#  #         cd D:\a\webrtc
-#  #         git config --system core.longpaths true
-#  #         .github\build_windows_mbedtls.bat
-#  arm64-cross-compilation:
-#    runs-on: ubuntu-20.04
-#    env:
-#      CC: aarch64-linux-gnu-gcc
-#      CXX: aarch64-linux-gnu-g++
-#    steps:
-#      - name: Install dependencies
-#        run: |
-#          sudo apt clean && sudo apt update
-#          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-#      - name: Clone repository
-#        uses: actions/checkout@v4
-#      - name: Build Repository
-#        run: |
-#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-#          mkdir build && cd build
-#          cmake .. -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
-#          make
+  clang-format-check:
+    runs-on: macos-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install clang-format
+        run: |
+          brew install clang-format
+          clang-format --version
+      - name: Run clang format check
+        run: |
+          bash scripts/check-clang.sh
+  mac-os-build-clang:
+    runs-on: macos-11
+    env:
+      CC: /usr/bin/clang
+      CXX: /usr/bin/clang++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
+          make
+      - name: Run tests
+        run:  |
+          cd build
+          ./tst/webrtc_client_test
+  mac-os-build-gcc:
+    runs-on: macos-11
+    env:
+      CC: gcc
+      CXX: g++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
+          make
+      - name: Run tests
+        run:  |
+          cd build
+          ./tst/webrtc_client_test
+  mac-os-m1-build-clang:
+    runs-on: macos-13-xlarge
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          brew unlink openssl
+          mkdir build && cd build
+          sh -c 'cmake .. -DBUILD_TEST=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
+          make
+      - name: Run tests
+        run:  |
+          cd build
+          ./tst/webrtc_client_test
+  static-build-mac:
+    runs-on: macos-11
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
+          make
+      - name: Run tests
+        run:  |
+          cd build
+          ./tst/webrtc_client_test
+  address-sanitizer:
+    runs-on: ubuntu-20.04
+    env:
+      ASAN_OPTIONS: detect_odr_violation=0:detect_leaks=1
+      LSAN_OPTIONS: suppressions=../tst/suppressions/LSAN.supp
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install clang
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  undefined-behavior-sanitizer:
+    runs-on: ubuntu-20.04
+    env:
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install clang
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  # memory-sanitizer:
+  #   runs-on: ubuntu-18.04
+  #   env:
+  #     CC: clang-7
+  #     CXX: clang++-7
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v4
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install clang-7
+  #     - name: Build repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DMEMORY_SANITIZER=TRUE -DBUILD_TEST=TRUE
+  #         make
+  #         ulimit -c unlimited -S
+  #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
+  thread-sanitizer:
+    runs-on: ubuntu-20.04
+    env:
+      TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install clang
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  linux-gcc-4_4:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      CC: gcc-4.4
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install deps
+        run: |
+          sudo apt clean && sudo apt update
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+          sudo apt-get -q update
+          sudo apt-get -y install gcc-4.4
+          sudo apt-get -y install gdb
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          # As per REAMDE here: https://github.com/aws/aws-sdk-cpp minimum supported GCC is 4.9 so we do not run those tests here
+          cmake .. -DBUILD_TEST=TRUE -DENABLE_AWS_SDK_IN_TESTS=OFF
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  static-build-linux:
+    runs-on: ubuntu-20.04
+    container:
+      image: alpine:3.15.4
+    env:
+      CC: gcc
+      CXX: g++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apk update
+          apk upgrade
+          apk add alpine-sdk cmake clang linux-headers perl bash openssl-dev zlib-dev curl-dev
+      - name: Build Repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
+          make
+  mbedtls-ubuntu-gcc:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install deps
+        run: |
+          sudo apt clean && sudo apt update
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+          sudo apt-get -q update
+          sudo apt-get -y install gcc-4.4
+          sudo apt-get -y install gdb
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  mbedtls-ubuntu-gcc-11:
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install deps
+        run: |
+          sudo apt clean && sudo apt update
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
+          sudo apt-get -q update
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+
+  mbedtls-ubuntu-gcc-4_4-build:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      CC: gcc-4.4
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install deps
+        run: |
+          sudo apt clean && sudo apt update
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+          sudo apt-get -q update
+          sudo apt-get -y install gcc-4.4
+          sudo apt-get -y install gdb
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          make
+
+  mbedtls-ubuntu-clang:
+    runs-on: ubuntu-20.04
+    env:
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install clang
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  sample-check:
+    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Build repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake ..
+          make
+      - name: Sample check
+        run: |
+          ./scripts/check-sample.sh
+  sample-check-no-data-channel:
+    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-duration-seconds: 10800
+      - name: Build repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DENABLE_DATA_CHANNEL=OFF
+          make
+      - name: Sample check without data channel
+        run: |
+          ./scripts/check-sample.sh
+  ubuntu-os-build:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE
+          make
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  windows-msvc-openssl:
+    runs-on: windows-2022
+    env:
+      AWS_KVS_LOG_LEVEL: 1
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Move cloned repo
+        shell: powershell
+        run: |
+          mkdir C:\webrtc
+          Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "C:\webrtc"
+      - name: Install dependencies
+        shell: powershell
+        run: |
+          choco install gstreamer --version=1.16.2
+          choco install gstreamer-devel --version=1.16.2
+          curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
+          mkdir C:\tools\pthreads-w32-2-9-1-release\
+          Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
+      # - name: Build libwebsockets from source
+      #   shell: powershell
+      #   run: |
+      #     $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\lib\x64;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\include'
+      #     git config --system core.longpaths true
+      #     cd C:\tools\
+      #     git clone https://github.com/warmcat/libwebsockets.git
+      #     git checkout v4.2.2
+      #     cd libwebsockets
+      #     mkdir build
+      #     cd build
+      #     cmake .. -DLWS_HAVE_PTHREAD_H=1 -DLWS_EXT_PTHREAD_INCLUDE_DIR="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\include" -DLWS_EXT_PTHREAD_LIBRARIES="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\lib\\x64\\libpthreadGC2.a" -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_OPENSSL_INCLUDE_DIRS="C:\\Program Files\\OpenSSL\\include" -DLWS_OPENSSL_LIBRARIES="C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib"
+      #     cmake --build . --config DEBUG
+      - name: Build repository
+        shell: powershell
+        run: |
+          cd C:\webrtc
+          git config --system core.longpaths true
+          .github\build_windows_openssl.bat
+      - name: Run tests
+        shell: powershell
+        run: |
+          $env:Path += ';C:\webrtc\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\dll\x64;C:\webrtc\build'
+          & "C:\webrtc\build\tst\webrtc_client_test.exe" --gtest_filter="-DataChannelFunctionalityTest.*:DtlsApiTest.*:IceApiTest.*:IceFunctionalityTest.*:PeerConnectionFunctionalityTest.*:SignalingApiFunctionalityTest.*:TurnConnectionFunctionalityTest.*:RtpFunctionalityTest.marshallUnmarshallH264Data:RtpFunctionalityTest.packingUnpackingVerifySameH264Frame:RtcpFunctionalityTest.onRtcpPacketCompound:RtcpFunctionalityTest.twcc3"
+  # windows-msvc-mbedtls:
+  #   runs-on: windows-2022
+  #   env:
+  #     AWS_KVS_LOG_LEVEL: 7
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v4
+  #     - name: Move cloned repo
+  #       shell: powershell
+  #       run: |
+  #         mkdir D:\a\webrtc
+  #         Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "D:\a\webrtc"
+  #         cd D:\a\webrtc
+  #         dir
+  #     - name: Install dependencies
+  #       shell: powershell
+  #       run: |
+  #         choco install gstreamer --version=1.16.2
+  #         choco install gstreamer-devel --version=1.16.2
+  #         curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
+  #         mkdir C:\tools\pthreads-w32-2-9-1-release\
+  #         Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
+  #     - name: Build repository
+  #       shell: powershell
+  #       run: |
+  #         cd D:\a\webrtc
+  #         git config --system core.longpaths true
+  #         .github\build_windows_mbedtls.bat
+  arm64-cross-compilation:
+    runs-on: ubuntu-20.04
+    env:
+      CC: aarch64-linux-gnu-gcc
+      CXX: aarch64-linux-gnu-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+          make
   arm64-cross-compilation-mbedtls:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,8 +648,8 @@ jobs:
           make
       - name: Verify library is ARM64 type
         run: |
-          cd build
-          ./verify_lib.sh libkvsWebrtcClient.so "ARM aarch64"
+          cd scripts
+          ./verify_lib.sh ../build/libkvsWebrtcClient.so "ARM64"
 
   arm64-cross-compilation-mbedtls-static:
     runs-on: ubuntu-20.04
@@ -671,8 +671,8 @@ jobs:
           make
       - name: Verify library is ARM64 type
         run: | 
-          cd build
-          ./verify_lib.sh libkvsWebrtcClient.a "ARM aarch64"
+          cd scripts
+          ./verify_lib.sh ../build/libkvsWebrtcClient.a "ARM64"
 
   linux-aarch64-cross-compilation:
     runs-on: ubuntu-20.04
@@ -692,6 +692,10 @@ jobs:
           mkdir build && cd build
           cmake .. -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
+      - name: Verify library is ARM64 type
+        run: |
+          cd scripts
+          ./verify_lib.sh ../build/libkvsWebrtcClient.so "ARM64"
 
   arm32-cross-compilation:
     runs-on: ubuntu-20.04
@@ -711,6 +715,10 @@ jobs:
           mkdir build && cd build
           cmake .. -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
+      - name: Verify library is ARM32 type
+        run: |
+          cd scripts
+          ./verify_lib.sh ../build/libkvsWebrtcClient.a "ARM32"
 
   arm32-cross-compilation-mbedtls:
     runs-on: ubuntu-20.04
@@ -732,8 +740,8 @@ jobs:
           make
       - name: Verify library is ARM32 type
         run: |
-          cd build
-          ./verify_lib.sh libkvsWebrtcClient.so "ARM"
+          cd scripts
+          ./verify_lib.sh ../build/libkvsWebrtcClient.so "ARM32"
 
   arm32-cross-compilation-mbedtls-static:
     runs-on: ubuntu-20.04
@@ -755,5 +763,5 @@ jobs:
           make
       - name: Verify library is ARM32 type
         run: |
-          cd build
-          ./verify_lib.sh libkvsWebrtcClient.a "ARM aarch64"
+          cd scripts
+          ./verify_lib.sh ../build/libkvsWebrtcClient.a "ARM32"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,7 +722,7 @@ jobs:
         run: |
           cd scripts
           chmod +x verify_lib.sh
-          ./verify_lib.sh ../build/libkvsWebrtcClient.a "ARM32"
+          ./verify_lib.sh ../build/libkvsWebrtcClient.so "ARM32"
 
   arm32-cross-compilation-mbedtls:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,6 +648,7 @@ jobs:
           make
       - name: Verify library is ARM64 type
         run: |
+          cd build
           file libkvsWebrtcClient.so
 
   arm64-cross-compilation-mbedtls-static:
@@ -670,6 +671,10 @@ jobs:
           make
       - name: Verify library is ARM64 type
         run: | 
+          cd build
+          ls
+          file libkvsWebrtcClient.a
+          ar -xv libkvsWebrtcClient.a
           ls
 
   linux-aarch64-cross-compilation:
@@ -730,4 +735,5 @@ jobs:
           make
       - name: Verify library is ARM32 type
         run: |
+          cd build
           file libkvsWebrtcClient.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,7 +667,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+          cmake .. -DBUILD_STATIC_LIBS=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
       - name: Verify library is ARM64 type
         run: | 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,611 +5,652 @@ on:
     branches:
       - develop
       - master
+      - mbedtls-cross-compile
   pull_request:
     branches:
       - develop
       - master
 jobs:
-  clang-format-check:
-    runs-on: macos-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Install clang-format
-        run: |
-          brew install clang-format
-          clang-format --version
-      - name: Run clang format check
-        run: |
-          bash scripts/check-clang.sh
-  mac-os-build-clang:
-    runs-on: macos-11
+#  clang-format-check:
+#    runs-on: macos-latest
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Install clang-format
+#        run: |
+#          brew install clang-format
+#          clang-format --version
+#      - name: Run clang format check
+#        run: |
+#          bash scripts/check-clang.sh
+#  mac-os-build-clang:
+#    runs-on: macos-11
+#    env:
+#      CC: /usr/bin/clang
+#      CXX: /usr/bin/clang++
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Build repository
+#        run: |
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
+#          make
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          ./tst/webrtc_client_test
+#  mac-os-build-gcc:
+#    runs-on: macos-11
+#    env:
+#      CC: gcc
+#      CXX: g++
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Build repository
+#        run: |
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
+#          make
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          ./tst/webrtc_client_test
+#  mac-os-m1-build-clang:
+#    runs-on: macos-13-xlarge
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Build repository
+#        run: |
+#          brew unlink openssl
+#          mkdir build && cd build
+#          sh -c 'cmake .. -DBUILD_TEST=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
+#          make
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          ./tst/webrtc_client_test
+#  static-build-mac:
+#    runs-on: macos-11
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Build repository
+#        run: |
+#          mkdir build && cd build
+#          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
+#          make
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          ./tst/webrtc_client_test
+#  address-sanitizer:
+#    runs-on: ubuntu-20.04
+#    env:
+#      ASAN_OPTIONS: detect_odr_violation=0:detect_leaks=1
+#      LSAN_OPTIONS: suppressions=../tst/suppressions/LSAN.supp
+#      CC: clang
+#      CXX: clang++
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install dependencies
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo apt-get -y install clang
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Build repository
+#        run: |
+#          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
+#          make
+#          ulimit -c unlimited -S
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+#  undefined-behavior-sanitizer:
+#    runs-on: ubuntu-20.04
+#    env:
+#      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+#      CC: clang
+#      CXX: clang++
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install dependencies
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo apt-get -y install clang
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Build repository
+#        run: |
+#          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
+#          make
+#          ulimit -c unlimited -S
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+#  # memory-sanitizer:
+#  #   runs-on: ubuntu-18.04
+#  #   env:
+#  #     CC: clang-7
+#  #     CXX: clang++-7
+#  #     AWS_KVS_LOG_LEVEL: 2
+#  #   steps:
+#  #     - name: Clone repository
+#  #       uses: actions/checkout@v4
+#  #     - name: Install dependencies
+#  #       run: |
+#  #         sudo apt clean && sudo apt update
+#  #         sudo apt-get -y install clang-7
+#  #     - name: Build repository
+#  #       run: |
+#  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#  #         mkdir build && cd build
+#  #         cmake .. -DMEMORY_SANITIZER=TRUE -DBUILD_TEST=TRUE
+#  #         make
+#  #         ulimit -c unlimited -S
+#  #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
+#  thread-sanitizer:
+#    runs-on: ubuntu-20.04
+#    env:
+#      TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
+#      CC: clang
+#      CXX: clang++
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install dependencies
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo apt-get -y install clang
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Build repository
+#        run: |
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
+#          make
+#          ulimit -c unlimited -S
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+#  linux-gcc-4_4:
+#    runs-on: ubuntu-20.04
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#      CC: gcc-4.4
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install deps
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+#          sudo apt-get -q update
+#          sudo apt-get -y install gcc-4.4
+#          sudo apt-get -y install gdb
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Build repository
+#        run: |
+#          mkdir build && cd build
+#          # As per REAMDE here: https://github.com/aws/aws-sdk-cpp minimum supported GCC is 4.9 so we do not run those tests here
+#          cmake .. -DBUILD_TEST=TRUE -DENABLE_AWS_SDK_IN_TESTS=OFF
+#          make
+#          ulimit -c unlimited -S
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+#  static-build-linux:
+#    runs-on: ubuntu-20.04
+#    container:
+#      image: alpine:3.15.4
+#    env:
+#      CC: gcc
+#      CXX: g++
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Install dependencies
+#        run: |
+#          apk update
+#          apk upgrade
+#          apk add alpine-sdk cmake clang linux-headers perl bash openssl-dev zlib-dev curl-dev
+#      - name: Build Repository
+#        run: |
+#          mkdir build && cd build
+#          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
+#          make
+#  mbedtls-ubuntu-gcc:
+#    runs-on: ubuntu-20.04
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install deps
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+#          sudo apt-get -q update
+#          sudo apt-get -y install gcc-4.4
+#          sudo apt-get -y install gdb
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Build repository
+#        run: |
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+#          make
+#          ulimit -c unlimited -S
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+#  mbedtls-ubuntu-gcc-11:
+#    runs-on: ubuntu-latest
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install deps
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
+#          sudo apt-get -q update
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Build repository
+#        run: |
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+#          make
+#          ulimit -c unlimited -S
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+#
+#  mbedtls-ubuntu-gcc-4_4-build:
+#    runs-on: ubuntu-20.04
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#      CC: gcc-4.4
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install deps
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+#          sudo apt-get -q update
+#          sudo apt-get -y install gcc-4.4
+#          sudo apt-get -y install gdb
+#      - name: Build repository
+#        run: |
+#          mkdir build && cd build
+#          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+#          make
+#
+#  mbedtls-ubuntu-clang:
+#    runs-on: ubuntu-20.04
+#    env:
+#      CC: clang
+#      CXX: clang++
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install dependencies
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo apt-get -y install clang
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Build repository
+#        run: |
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+#          make
+#          ulimit -c unlimited -S
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+#  sample-check:
+#    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
+#    runs-on: ubuntu-latest
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#          role-duration-seconds: 10800
+#      - name: Build repository
+#        run: |
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          mkdir build && cd build
+#          cmake ..
+#          make
+#      - name: Sample check
+#        run: |
+#          ./scripts/check-sample.sh
+#  sample-check-no-data-channel:
+#    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
+#    runs-on: ubuntu-latest
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#          role-duration-seconds: 10800
+#      - name: Build repository
+#        run: |
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          mkdir build && cd build
+#          cmake .. -DENABLE_DATA_CHANNEL=OFF
+#          make
+#      - name: Sample check without data channel
+#        run: |
+#          ./scripts/check-sample.sh
+#  ubuntu-os-build:
+#    runs-on: ubuntu-20.04
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install dependencies
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Build repository
+#        run: |
+#          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          mkdir build && cd build
+#          cmake .. -DBUILD_TEST=TRUE
+#          make
+#      - name: Run tests
+#        run:  |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+#  windows-msvc-openssl:
+#    runs-on: windows-2022
+#    env:
+#      AWS_KVS_LOG_LEVEL: 1
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Move cloned repo
+#        shell: powershell
+#        run: |
+#          mkdir C:\webrtc
+#          Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "C:\webrtc"
+#      - name: Install dependencies
+#        shell: powershell
+#        run: |
+#          choco install gstreamer --version=1.16.2
+#          choco install gstreamer-devel --version=1.16.2
+#          curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
+#          mkdir C:\tools\pthreads-w32-2-9-1-release\
+#          Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
+#      # - name: Build libwebsockets from source
+#      #   shell: powershell
+#      #   run: |
+#      #     $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\lib\x64;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\include'
+#      #     git config --system core.longpaths true
+#      #     cd C:\tools\
+#      #     git clone https://github.com/warmcat/libwebsockets.git
+#      #     git checkout v4.2.2
+#      #     cd libwebsockets
+#      #     mkdir build
+#      #     cd build
+#      #     cmake .. -DLWS_HAVE_PTHREAD_H=1 -DLWS_EXT_PTHREAD_INCLUDE_DIR="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\include" -DLWS_EXT_PTHREAD_LIBRARIES="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\lib\\x64\\libpthreadGC2.a" -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_OPENSSL_INCLUDE_DIRS="C:\\Program Files\\OpenSSL\\include" -DLWS_OPENSSL_LIBRARIES="C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib"
+#      #     cmake --build . --config DEBUG
+#      - name: Build repository
+#        shell: powershell
+#        run: |
+#          cd C:\webrtc
+#          git config --system core.longpaths true
+#          .github\build_windows_openssl.bat
+#      - name: Run tests
+#        shell: powershell
+#        run: |
+#          $env:Path += ';C:\webrtc\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\dll\x64;C:\webrtc\build'
+#          & "C:\webrtc\build\tst\webrtc_client_test.exe" --gtest_filter="-DataChannelFunctionalityTest.*:DtlsApiTest.*:IceApiTest.*:IceFunctionalityTest.*:PeerConnectionFunctionalityTest.*:SignalingApiFunctionalityTest.*:TurnConnectionFunctionalityTest.*:RtpFunctionalityTest.marshallUnmarshallH264Data:RtpFunctionalityTest.packingUnpackingVerifySameH264Frame:RtcpFunctionalityTest.onRtcpPacketCompound:RtcpFunctionalityTest.twcc3"
+#  # windows-msvc-mbedtls:
+#  #   runs-on: windows-2022
+#  #   env:
+#  #     AWS_KVS_LOG_LEVEL: 7
+#  #   steps:
+#  #     - name: Clone repository
+#  #       uses: actions/checkout@v4
+#  #     - name: Move cloned repo
+#  #       shell: powershell
+#  #       run: |
+#  #         mkdir D:\a\webrtc
+#  #         Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "D:\a\webrtc"
+#  #         cd D:\a\webrtc
+#  #         dir
+#  #     - name: Install dependencies
+#  #       shell: powershell
+#  #       run: |
+#  #         choco install gstreamer --version=1.16.2
+#  #         choco install gstreamer-devel --version=1.16.2
+#  #         curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
+#  #         mkdir C:\tools\pthreads-w32-2-9-1-release\
+#  #         Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
+#  #     - name: Build repository
+#  #       shell: powershell
+#  #       run: |
+#  #         cd D:\a\webrtc
+#  #         git config --system core.longpaths true
+#  #         .github\build_windows_mbedtls.bat
+#  arm64-cross-compilation:
+#    runs-on: ubuntu-20.04
+#    env:
+#      CC: aarch64-linux-gnu-gcc
+#      CXX: aarch64-linux-gnu-g++
+#    steps:
+#      - name: Install dependencies
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Build Repository
+#        run: |
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          mkdir build && cd build
+#          cmake .. -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+#          make
+  arm64-cross-compilation-mbedtls:
+    runs-on: ubuntu-latest
     env:
-      CC: /usr/bin/clang
-      CXX: /usr/bin/clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
+      CC: aarch64-linux-gnu-gcc
+      CXX: aarch64-linux-gnu-g++
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-          make
-      - name: Run tests
-        run:  |
-          cd build
-          ./tst/webrtc_client_test
-  mac-os-build-gcc:
-    runs-on: macos-11
-    env:
-      CC: gcc
-      CXX: g++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
-          make
-      - name: Run tests
-        run:  |
-          cd build
-          ./tst/webrtc_client_test
-  mac-os-m1-build-clang:
-    runs-on: macos-13-xlarge
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Build repository
-        run: |
-          brew unlink openssl
-          mkdir build && cd build
-          sh -c 'cmake .. -DBUILD_TEST=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
-          make
-      - name: Run tests
-        run:  |
-          cd build
-          ./tst/webrtc_client_test
-  static-build-mac:
-    runs-on: macos-11
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
-          make
-      - name: Run tests
-        run:  |
-          cd build
-          ./tst/webrtc_client_test
-  address-sanitizer:
-    runs-on: ubuntu-20.04
-    env:
-      ASAN_OPTIONS: detect_odr_violation=0:detect_leaks=1
-      LSAN_OPTIONS: suppressions=../tst/suppressions/LSAN.supp
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
       - name: Install dependencies
         run: |
           sudo apt clean && sudo apt update
-          sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  undefined-behavior-sanitizer:
-    runs-on: ubuntu-20.04
-    env:
-      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
+          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
       - name: Clone repository
         uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  # memory-sanitizer:
-  #   runs-on: ubuntu-18.04
-  #   env:
-  #     CC: clang-7
-  #     CXX: clang++-7
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v4
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt-get -y install clang-7
-  #     - name: Build repository
-  #       run: |
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #         mkdir build && cd build
-  #         cmake .. -DMEMORY_SANITIZER=TRUE -DBUILD_TEST=TRUE
-  #         make
-  #         ulimit -c unlimited -S
-  #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
-  thread-sanitizer:
-    runs-on: ubuntu-20.04
-    env:
-      TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  linux-gcc-4_4:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-      CC: gcc-4.4
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install deps
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-          sudo apt-get -q update
-          sudo apt-get -y install gcc-4.4
-          sudo apt-get -y install gdb
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          # As per REAMDE here: https://github.com/aws/aws-sdk-cpp minimum supported GCC is 4.9 so we do not run those tests here
-          cmake .. -DBUILD_TEST=TRUE -DENABLE_AWS_SDK_IN_TESTS=OFF
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  static-build-linux:
-    runs-on: ubuntu-20.04
-    container:
-      image: alpine:3.15.4
-    env:
-      CC: gcc
-      CXX: g++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          apk update
-          apk upgrade
-          apk add alpine-sdk cmake clang linux-headers perl bash openssl-dev zlib-dev curl-dev
       - name: Build Repository
         run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
-          make
-  mbedtls-ubuntu-gcc:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install deps
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-          sudo apt-get -q update
-          sudo apt-get -y install gcc-4.4
-          sudo apt-get -y install gdb
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  mbedtls-ubuntu-gcc-11:
-    runs-on: ubuntu-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install deps
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
-          sudo apt-get -q update
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  
-  mbedtls-ubuntu-gcc-4_4-build:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-      CC: gcc-4.4
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install deps
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-          sudo apt-get -q update
-          sudo apt-get -y install gcc-4.4
-          sudo apt-get -y install gdb
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
-          
-  mbedtls-ubuntu-clang:
-    runs-on: ubuntu-20.04
-    env:
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  sample-check:
-    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
-    runs-on: ubuntu-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Build repository
+      - name: Verify library is ARM64 type
         run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake ..
-          make
-      - name: Sample check
-        run: |
-          ./scripts/check-sample.sh
-  sample-check-no-data-channel:
-    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
-    runs-on: ubuntu-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Build repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DENABLE_DATA_CHANNEL=OFF
-          make
-      - name: Sample check without data channel
-        run: |
-          ./scripts/check-sample.sh
-  ubuntu-os-build:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE
-          make
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  windows-msvc-openssl:
-    runs-on: windows-2022
-    env:
-      AWS_KVS_LOG_LEVEL: 1
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Move cloned repo
-        shell: powershell
-        run: |
-          mkdir C:\webrtc
-          Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "C:\webrtc"
-      - name: Install dependencies
-        shell: powershell
-        run: |
-          choco install gstreamer --version=1.16.2
-          choco install gstreamer-devel --version=1.16.2
-          curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
-          mkdir C:\tools\pthreads-w32-2-9-1-release\
-          Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
-      # - name: Build libwebsockets from source
-      #   shell: powershell
-      #   run: |
-      #     $env:Path += ';C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Strawberry\c\bin;C:\Program Files\NASM;D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\lib\x64;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\include'
-      #     git config --system core.longpaths true
-      #     cd C:\tools\
-      #     git clone https://github.com/warmcat/libwebsockets.git
-      #     git checkout v4.2.2
-      #     cd libwebsockets
-      #     mkdir build
-      #     cd build
-      #     cmake .. -DLWS_HAVE_PTHREAD_H=1 -DLWS_EXT_PTHREAD_INCLUDE_DIR="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\include" -DLWS_EXT_PTHREAD_LIBRARIES="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\lib\\x64\\libpthreadGC2.a" -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_OPENSSL_INCLUDE_DIRS="C:\\Program Files\\OpenSSL\\include" -DLWS_OPENSSL_LIBRARIES="C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib"
-      #     cmake --build . --config DEBUG
-      - name: Build repository
-        shell: powershell
-        run: |
-          cd C:\webrtc
-          git config --system core.longpaths true
-          .github\build_windows_openssl.bat
-      - name: Run tests
-        shell: powershell
-        run: |
-          $env:Path += ';C:\webrtc\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre-built.2\dll\x64;C:\webrtc\build'
-          & "C:\webrtc\build\tst\webrtc_client_test.exe" --gtest_filter="-DataChannelFunctionalityTest.*:DtlsApiTest.*:IceApiTest.*:IceFunctionalityTest.*:PeerConnectionFunctionalityTest.*:SignalingApiFunctionalityTest.*:TurnConnectionFunctionalityTest.*:RtpFunctionalityTest.marshallUnmarshallH264Data:RtpFunctionalityTest.packingUnpackingVerifySameH264Frame:RtcpFunctionalityTest.onRtcpPacketCompound:RtcpFunctionalityTest.twcc3"
-  # windows-msvc-mbedtls:
-  #   runs-on: windows-2022
-  #   env:
-  #     AWS_KVS_LOG_LEVEL: 7
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v4
-  #     - name: Move cloned repo
-  #       shell: powershell
-  #       run: |
-  #         mkdir D:\a\webrtc
-  #         Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "D:\a\webrtc"
-  #         cd D:\a\webrtc
-  #         dir
-  #     - name: Install dependencies
-  #       shell: powershell
-  #       run: |
-  #         choco install gstreamer --version=1.16.2
-  #         choco install gstreamer-devel --version=1.16.2
-  #         curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
-  #         mkdir C:\tools\pthreads-w32-2-9-1-release\
-  #         Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release
-  #     - name: Build repository
-  #       shell: powershell
-  #       run: |
-  #         cd D:\a\webrtc
-  #         git config --system core.longpaths true
-  #         .github\build_windows_mbedtls.bat
-  arm64-cross-compilation:
+          file libkvsWebrtcClient.so
+
+  arm64-cross-compilation-mbedtls-static:
     runs-on: ubuntu-20.04
     env:
       CC: aarch64-linux-gnu-gcc
@@ -625,8 +666,12 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
+      - name: Verify library is ARM64 type
+        run: | 
+          ar -xv libkvsWebrtcClient.a
+
   linux-aarch64-cross-compilation:
     runs-on: ubuntu-20.04
     env:
@@ -643,8 +688,9 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+          cmake .. -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
+
   arm32-cross-compilation:
     runs-on: ubuntu-20.04
     env:
@@ -661,5 +707,27 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+          cmake .. -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
+
+  arm32-cross-compilation-mbedtls:
+    runs-on: ubuntu-20.04
+    env:
+      CC: arm-linux-gnueabi-gcc
+      CXX: arm-linux-gnueabi-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+          make
+      - name: Verify library is ARM32 type
+        run: |
+          file libkvsWebrtcClient.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,7 +649,7 @@ jobs:
       - name: Verify library is ARM64 type
         run: |
           cd build
-          file libkvsWebrtcClient.so
+          ./verify_lib.sh libkvsWebrtcClient.so "ARM aarch64"
 
   arm64-cross-compilation-mbedtls-static:
     runs-on: ubuntu-20.04
@@ -672,10 +672,7 @@ jobs:
       - name: Verify library is ARM64 type
         run: | 
           cd build
-          ls
-          file libkvsWebrtcClient.a
-          ar -xv libkvsWebrtcClient.a
-          ls
+          ./verify_lib.sh libkvsWebrtcClient.a "ARM aarch64"
 
   linux-aarch64-cross-compilation:
     runs-on: ubuntu-20.04
@@ -736,4 +733,27 @@ jobs:
       - name: Verify library is ARM32 type
         run: |
           cd build
-          file libkvsWebrtcClient.so
+          ./verify_lib.sh libkvsWebrtcClient.so "ARM"
+
+  arm32-cross-compilation-mbedtls-static:
+    runs-on: ubuntu-20.04
+    env:
+      CC: arm-linux-gnueabi-gcc
+      CXX: arm-linux-gnueabi-g++
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Build Repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_STATIC_LIBS=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+          make
+      - name: Verify library is ARM32 type
+        run: |
+          cd build
+          ./verify_lib.sh libkvsWebrtcClient.a "ARM aarch64"

--- a/scripts/verify_lib.sh
+++ b/scripts/verify_lib.sh
@@ -41,9 +41,6 @@ if [[ -z "${ARCH_PATTERNS[$ARCH_EXPECTED]}" ]]; then
     exit 1
 fi
 
-# Check for expected architecture in the output
-ARCH_MATCH=$(echo "$FILE_OUTPUT" | grep -q "${ARCH_PATTERNS[$ARCH_EXPECTED]}"; echo $?)
-
 # Initialize LINK_MATCH based on determined linkage type
 LINK_MATCH=1 # Default to fail
 
@@ -56,6 +53,8 @@ if [ "$LINKAGE_TYPE" == "static" ]; then
         ar -x $LIB_FILE $FIRST_OBJ
         OBJ_FILE_OUTPUT=$(file $FIRST_OBJ)
         echo $OBJ_FILE_OUTPUT
+        # Check for expected architecture in the output
+        ARCH_MATCH=$(echo "$OBJ_FILE_OUTPUT" | grep -q "${ARCH_PATTERNS[$ARCH_EXPECTED]}"; echo $?)
         LINK_MATCH=$(echo "$OBJ_FILE_OUTPUT" | grep -Eq "relocatable"; echo $?)
         # Clean up extracted file
         rm -f $FIRST_OBJ
@@ -63,6 +62,8 @@ if [ "$LINKAGE_TYPE" == "static" ]; then
 elif [ "$LINKAGE_TYPE" == "dynamic" ]; then
   # Use the file command to check the file type
   FILE_OUTPUT=$(file $LIB_FILE)
+  # Check for expected architecture in the output
+  ARCH_MATCH=$(echo "$FILE_OUTPUT" | grep -q "${ARCH_PATTERNS[$ARCH_EXPECTED]}"; echo $?)
   echo $FILE_OUTPUT
   # Check for "dynamically linked" in the output for dynamic libraries
   LINK_MATCH=$(echo "$FILE_OUTPUT" | grep -q "dynamically linked"; echo $?)

--- a/scripts/verify_lib.sh
+++ b/scripts/verify_lib.sh
@@ -9,7 +9,7 @@ ARCH_EXPECTED="$2"
 declare -A ARCH_PATTERNS
 ARCH_PATTERNS=(
     ["ARM64"]="ARM aarch64"
-    ["ARM32"]="ARM,"
+    ["ARM32"]="32-bit" # Using 32-bit instead of ARM for distinct string
     ["x86_64"]="x86-64"
     # Add more architectures here as needed
 )
@@ -44,7 +44,6 @@ fi
 # Initialize LINK_MATCH based on determined linkage type
 LINK_MATCH=1 # Default to fail
 
-echo $LINKAGE_TYPE
 if [ "$LINKAGE_TYPE" == "static" ]; then
     # Extract and check the first object file if static
     FIRST_OBJ=$(ar -t $LIB_FILE | head -n 1)
@@ -52,7 +51,6 @@ if [ "$LINKAGE_TYPE" == "static" ]; then
     if [ -n "$FIRST_OBJ" ]; then
         ar -x $LIB_FILE $FIRST_OBJ
         OBJ_FILE_OUTPUT=$(file $FIRST_OBJ)
-        echo $OBJ_FILE_OUTPUT
         # Check for expected architecture in the output
         ARCH_MATCH=$(echo "$OBJ_FILE_OUTPUT" | grep -q "${ARCH_PATTERNS[$ARCH_EXPECTED]}"; echo $?)
         LINK_MATCH=$(echo "$OBJ_FILE_OUTPUT" | grep -Eq "relocatable"; echo $?)
@@ -64,7 +62,6 @@ elif [ "$LINKAGE_TYPE" == "dynamic" ]; then
   FILE_OUTPUT=$(file $LIB_FILE)
   # Check for expected architecture in the output
   ARCH_MATCH=$(echo "$FILE_OUTPUT" | grep -q "${ARCH_PATTERNS[$ARCH_EXPECTED]}"; echo $?)
-  echo $FILE_OUTPUT
   # Check for "dynamically linked" in the output for dynamic libraries
   LINK_MATCH=$(echo "$FILE_OUTPUT" | grep -q "dynamically linked"; echo $?)
 fi

--- a/scripts/verify_lib.sh
+++ b/scripts/verify_lib.sh
@@ -2,8 +2,17 @@
 
 # Path to the library file
 LIB_FILE="$1"
-# Expected architecture: "ARM aarch64", "ARM" (for 32-bit), etc.
+# Expected architecture identifier (e.g., "ARM64", "ARM32", "x86_64", etc.)
 ARCH_EXPECTED="$2"
+
+# Associative array mapping human-readable architecture names to file command patterns
+declare -A ARCH_PATTERNS
+ARCH_PATTERNS=(
+    ["ARM64"]="ARM aarch64"
+    ["ARM32"]="ARM,"
+    ["x86_64"]="x86-64"
+    # Add more architectures here as needed
+)
 
 # Determine the linkage type based on file extension
 if [[ $LIB_FILE == *.so ]]; then
@@ -15,18 +24,27 @@ else
     exit 1
 fi
 
+# Use the file command to check the file type
+FILE_OUTPUT=$(file $LIB_FILE)
+
 # Function to print verification result and exit appropriately
 function verify_result() {
     if $1; then
-        echo "Verification passed: $LIB_FILE matches criteria for $ARCH_EXPECTED and $LINKAGE_TYPE linkage."
+        echo "Verification passed: $LIB_FILE matches criteria for ${ARCH_PATTERNS[$ARCH_EXPECTED]} and $LINKAGE_TYPE linkage."
     else
-        echo "Verification failed: $LIB_FILE does not match criteria for $ARCH_EXPECTED and $LINKAGE_TYPE linkage."
+        echo "Verification failed: $LIB_FILE does not match criteria for ${ARCH_PATTERNS[$ARCH_EXPECTED]} and $LINKAGE_TYPE linkage."
         exit 1 # Exit with an error status
     fi
 }
 
+# Validate expected architecture argument
+if [[ -z "${ARCH_PATTERNS[$ARCH_EXPECTED]}" ]]; then
+    echo "Unsupported or undefined architecture: $ARCH_EXPECTED"
+    exit 1
+fi
+
 # Check for expected architecture in the output
-ARCH_MATCH=$(echo "$FILE_OUTPUT" | grep -q "$ARCH_EXPECTED"; echo $?)
+ARCH_MATCH=$(echo "$FILE_OUTPUT" | grep -q "${ARCH_PATTERNS[$ARCH_EXPECTED]}"; echo $?)
 
 # Initialize LINK_MATCH based on determined linkage type
 LINK_MATCH=1 # Default to fail
@@ -42,8 +60,6 @@ if [ "$LINKAGE_TYPE" == "static" ]; then
         rm -f $FIRST_OBJ
     fi
 elif [ "$LINKAGE_TYPE" == "dynamic" ]; then
-    # Use the file command to check the file type
-    FILE_OUTPUT=$(file $LIB_FILE)
     # Check for "dynamically linked" in the output for dynamic libraries
     LINK_MATCH=$(echo "$FILE_OUTPUT" | grep -q "dynamically linked"; echo $?)
 fi

--- a/scripts/verify_lib.sh
+++ b/scripts/verify_lib.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Path to the library file
+LIB_FILE="$1"
+# Expected architecture: "ARM aarch64", "ARM" (for 32-bit), etc.
+ARCH_EXPECTED="$2"
+
+# Determine the linkage type based on file extension
+if [[ $LIB_FILE == *.so ]]; then
+    LINKAGE_TYPE="dynamic"
+elif [[ $LIB_FILE == *.a ]]; then
+    LINKAGE_TYPE="static"
+else
+    echo "Unsupported file extension for $LIB_FILE."
+    exit 1
+fi
+
+# Function to print verification result and exit appropriately
+function verify_result() {
+    if $1; then
+        echo "Verification passed: $LIB_FILE matches criteria for $ARCH_EXPECTED and $LINKAGE_TYPE linkage."
+    else
+        echo "Verification failed: $LIB_FILE does not match criteria for $ARCH_EXPECTED and $LINKAGE_TYPE linkage."
+        exit 1 # Exit with an error status
+    fi
+}
+
+# Check for expected architecture in the output
+ARCH_MATCH=$(echo "$FILE_OUTPUT" | grep -q "$ARCH_EXPECTED"; echo $?)
+
+# Initialize LINK_MATCH based on determined linkage type
+LINK_MATCH=1 # Default to fail
+
+if [ "$LINKAGE_TYPE" == "static" ]; then
+    # Extract and check the first object file if static
+    FIRST_OBJ=$(ar -t $LIB_FILE | head -n 1)
+    if [ -n "$FIRST_OBJ" ]; then
+        ar -x $LIB_FILE $FIRST_OBJ
+        OBJ_FILE_OUTPUT=$(file $FIRST_OBJ)
+        LINK_MATCH=$(echo "$OBJ_FILE_OUTPUT" | grep -Eq "relocatable"; echo $?)
+        # Clean up extracted file
+        rm -f $FIRST_OBJ
+    fi
+elif [ "$LINKAGE_TYPE" == "dynamic" ]; then
+    # Use the file command to check the file type
+    FILE_OUTPUT=$(file $LIB_FILE)
+    # Check for "dynamically linked" in the output for dynamic libraries
+    LINK_MATCH=$(echo "$FILE_OUTPUT" | grep -q "dynamically linked"; echo $?)
+fi
+
+# Verify both expected architecture and determined linkage type
+if [ $ARCH_MATCH -eq 0 ] && [ $LINK_MATCH -eq 0 ]; then
+    verify_result true
+else
+    verify_result false
+fi

--- a/scripts/verify_lib.sh
+++ b/scripts/verify_lib.sh
@@ -24,8 +24,6 @@ else
     exit 1
 fi
 
-# Use the file command to check the file type
-FILE_OUTPUT=$(file $LIB_FILE)
 
 # Function to print verification result and exit appropriately
 function verify_result() {
@@ -49,19 +47,25 @@ ARCH_MATCH=$(echo "$FILE_OUTPUT" | grep -q "${ARCH_PATTERNS[$ARCH_EXPECTED]}"; e
 # Initialize LINK_MATCH based on determined linkage type
 LINK_MATCH=1 # Default to fail
 
+echo $LINKAGE_TYPE
 if [ "$LINKAGE_TYPE" == "static" ]; then
     # Extract and check the first object file if static
     FIRST_OBJ=$(ar -t $LIB_FILE | head -n 1)
+    echo $FIRST_OBJ
     if [ -n "$FIRST_OBJ" ]; then
         ar -x $LIB_FILE $FIRST_OBJ
         OBJ_FILE_OUTPUT=$(file $FIRST_OBJ)
+        echo $OBJ_FILE_OUTPUT
         LINK_MATCH=$(echo "$OBJ_FILE_OUTPUT" | grep -Eq "relocatable"; echo $?)
         # Clean up extracted file
         rm -f $FIRST_OBJ
     fi
 elif [ "$LINKAGE_TYPE" == "dynamic" ]; then
-    # Check for "dynamically linked" in the output for dynamic libraries
-    LINK_MATCH=$(echo "$FILE_OUTPUT" | grep -q "dynamically linked"; echo $?)
+  # Use the file command to check the file type
+  FILE_OUTPUT=$(file $LIB_FILE)
+  echo $FILE_OUTPUT
+  # Check for "dynamically linked" in the output for dynamic libraries
+  LINK_MATCH=$(echo "$FILE_OUTPUT" | grep -q "dynamically linked"; echo $?)
 fi
 
 # Verify both expected architecture and determined linkage type


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Include cross compile builds for mbedtls. The toolchains being tested with are:
  - `aarch64-linux-gnu-gcc`
  - `arm-linux-gnueabi-gcc`
- Also added a script that would verify the library built matches the expected platform type and linkage

*Why was it changed?*
- MBedTLS cross compile build was missing.

*How was it changed?*
-  Added 4 new builds - ARM64 dynamic mbedtls, ARM64 static mbedtls, ARM32 dynamic MBedTLS, ARM32 static mbedtls
- Created a new shell script that would run as part of these CI jobs to verify library file type

Sample CI output for ARM32 shared library build:

<img width="768" alt="Screenshot 2024-02-13 at 2 28 22 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/assets/22107309/d93b3b86-f1f1-4c43-9365-f6ba4ef179bd">


*What testing was done for the changes?*
- Ran the build locally on an Ubuntu x86 EC2 instance using the `aarch64-linux-gnu-gcc` toolchain. SCPed the generated libraries to an ARM64 Ubuntu EC2 instance to verify the samples run. Did the same test for static and dynamic build
- CI jobs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
