### PR TITLE
Fix ReadMe Typo: build -> built

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Create a build directory in the newly checked out repository, and execute CMake 
 
 `mkdir -p amazon-kinesis-video-streams-webrtc-sdk-c/build; cd amazon-kinesis-video-streams-webrtc-sdk-c/build; cmake .. `
 
-We have provided an example of using GStreamer to capture/encode video, and then send via this library. This is only build if `pkg-config` finds
+We have provided an example of using GStreamer to capture/encode video, and then send via this library. This is only built if `pkg-config` finds
 GStreamer is installed on your system.
 
 On Ubuntu and Raspberry Pi OS you can get the libraries by running


### PR DESCRIPTION
*Issue #, if available:*
None.

*What was changed?*
A word in the ReadMe from the sentence: This is only build if pkg-config finds GStreamer is installed on your system.

*Why was it changed?*
To correct the spelling/grammar of the sentence: This is only build if pkg-config finds GStreamer is installed on your system.

*How was it changed?*
By replacing "build" with "built"

*What testing was done for the changes?*
Reading it a few times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
