### PR TITLE
Add copy code buttons to github clone commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Please refer to the release notes in [Releases](https://github.com/awslabs/amazo
 ### Download
 To download run the following command:
 
-`git clone --recursive https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c.git`
+```
+git clone --recursive https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c.git
+```
 
 You will also need to install `pkg-config` and `CMake` and a build environment
 
@@ -63,7 +65,9 @@ You will also need to install `pkg-config` and `CMake` and a build environment
 
 Create a build directory in the newly checked out repository, and execute CMake from it.
 
-`mkdir -p amazon-kinesis-video-streams-webrtc-sdk-c/build; cd amazon-kinesis-video-streams-webrtc-sdk-c/build; cmake .. `
+```
+mkdir -p amazon-kinesis-video-streams-webrtc-sdk-c/build; cd amazon-kinesis-video-streams-webrtc-sdk-c/build; cmake ..
+```
 
 We have provided an example of using GStreamer to capture/encode video, and then send via this library. This is only built if `pkg-config` finds
 GStreamer is installed on your system.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Please refer to the release notes in [Releases](https://github.com/awslabs/amazo
 ### Download
 To download run the following command:
 
-```
+```shell
 git clone --recursive https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c.git
 ```
 
@@ -65,7 +65,7 @@ You will also need to install `pkg-config` and `CMake` and a build environment
 
 Create a build directory in the newly checked out repository, and execute CMake from it.
 
-```
+```shell
 mkdir -p amazon-kinesis-video-streams-webrtc-sdk-c/build; cd amazon-kinesis-video-streams-webrtc-sdk-c/build; cmake ..
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
None

*What was changed?*
Changes some of the ReadMe's in-line code formatting to code-block formatting to provide a quick-copy button. Specified the language for the code block.

*Why was it changed?*
This makes following the ReadMe's instructions slightly easier as now all the commands can be copied with the click of a button. Specifying the language provides syntax highlighting to the code block.

*How was it changed?*
Added two more "`" characters to the ones around the relevant commands and moved the command to a new line separate from the "```". The code language was added just after the beginning "```" in each case.

*What testing was done for the changes?*
Viewing the formatted ReadMe and confirming that the quick-copy button is there and that commands are properly copied.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
