### PR TITLE
Contributions target branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *develop* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 


### PR DESCRIPTION
*Issue #, if available:*
No issues to link. Resolve conflicting information.

*What was changed?*
Change the contributions target branch from master to develop.

*Why was it changed?*
In the main readme, it says develop branch. Here, it says master branch. Resolve conflicting information.

*How was it changed?*
Change the branch name in Contributing.md to develop from master.

*What testing was done for the changes?*
Double-check the edited section for spelling mistakes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
