### PR TITLE
Add videoscale and videorate

### DIFF
--- a/samples/kvsWebRTCClientMasterGstSample.c
+++ b/samples/kvsWebRTCClientMasterGstSample.c
@@ -157,7 +157,8 @@ PVOID sendGstreamerAudioVideo(PVOID args)
             switch (pSampleConfiguration->srcType) {
                 case TEST_SOURCE: {
                     pipeline =
-                        gst_parse_launch("videotestsrc is-live=TRUE ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
+                        gst_parse_launch("videotestsrc is-live=TRUE ! queue ! videoconvert ! videoscale ! video/x-raw,width=1280,height=720 ! "
+                                         "videorate ! video/x-raw,framerate=25/1 ! "
                                          "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
                                          "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE emit-signals=TRUE "
                                          "name=appsink-video",
@@ -165,7 +166,8 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                     break;
                 }
                 case DEVICE_SOURCE: {
-                    pipeline = gst_parse_launch("autovideosrc ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
+                    pipeline = gst_parse_launch("autovideosrc ! queue ! videoconvert ! videoscale ! video/x-raw,width=1280,height=720 ! "
+                                                "videorate ! video/x-raw,framerate=25/1 ! "
                                                 "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
                                                 "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE "
                                                 "emit-signals=TRUE name=appsink-video",
@@ -207,7 +209,8 @@ PVOID sendGstreamerAudioVideo(PVOID args)
                 }
                 case DEVICE_SOURCE: {
                     pipeline =
-                        gst_parse_launch("autovideosrc ! queue ! videoconvert ! video/x-raw,width=1280,height=720,framerate=25/1 ! "
+                        gst_parse_launch("autovideosrc ! queue ! videoconvert ! videoscale ! video/x-raw,width=1280,height=720 ! "
+                                         "videorate ! video/x-raw,framerate=25/1 ! "
                                          "x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency ! "
                                          "video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! appsink sync=TRUE emit-signals=TRUE "
                                          "name=appsink-video autoaudiosrc ! "
@@ -286,7 +289,7 @@ CleanUp:
         g_clear_error(&error);
     }
 
-    return (PVOID) (ULONG_PTR) retStatus;
+    return (PVOID)(ULONG_PTR) retStatus;
 }
 
 VOID onGstAudioFrameReady(UINT64 customData, PFrame pFrame)
@@ -382,7 +385,7 @@ CleanUp:
         g_clear_error(&error);
     }
 
-    return (PVOID) (ULONG_PTR) retStatus;
+    return (PVOID)(ULONG_PTR) retStatus;
 }
 
 INT32 main(INT32 argc, CHAR* argv[])

--- a/samples/kvsWebRTCClientMasterGstSample.c
+++ b/samples/kvsWebRTCClientMasterGstSample.c
@@ -289,7 +289,7 @@ CleanUp:
         g_clear_error(&error);
     }
 
-    return (PVOID)(ULONG_PTR) retStatus;
+    return (PVOID) (ULONG_PTR) retStatus;
 }
 
 VOID onGstAudioFrameReady(UINT64 customData, PFrame pFrame)
@@ -385,7 +385,7 @@ CleanUp:
         g_clear_error(&error);
     }
 
-    return (PVOID)(ULONG_PTR) retStatus;
+    return (PVOID) (ULONG_PTR) retStatus;
 }
 
 INT32 main(INT32 argc, CHAR* argv[])


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
Added videoscale and videorate to gstreamer pipelines in samples.

*Why was it changed?*
we're using autovideosrc for device streams, and the detected video source is not guaranteed to be able to support 1280/720 or 25/1 fps.

*How was it changed?*
Added videoscale and videorate to the gstreamer pieplines in samples

*What testing was done for the changes?*
Manual testing as samples still lack automated tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
