### PR TITLE
Viewer fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,8 +552,8 @@ jobs:
       - name: Install dependencies
         shell: powershell
         run: |
-          choco install gstreamer --version=1.16.2
-          choco install gstreamer-devel --version=1.16.2
+          choco install gstreamer --version=1.16.3
+          choco install gstreamer-devel --version=1.16.3
           curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
           mkdir C:\tools\pthreads-w32-2-9-1-release\
           Expand-Archive -Path C:\tools\pthreads-w32-2-9-1-release.zip -DestinationPath C:\tools\pthreads-w32-2-9-1-release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,7 @@ include(CheckIncludeFiles)
 include(CheckFunctionExists)
 
 # The version MUST be updated before every release
-project(KinesisVideoWebRTCClient VERSION 1.10.0 LANGUAGES C)
-
-
-
+project(KinesisVideoWebRTCClient VERSION 1.10.1 LANGUAGES C)
 
 # User Flags
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -328,11 +328,7 @@ STATUS iceAgentAddConfig(PIceAgent pIceAgent, PIceConfigInfo pIceConfigInfo)
             DLOGE("Failed to parse ICE servers");
         }
     }
-    //    if(!locked) {
-    //        MUTEX_LOCK(pIceAgent->lock);
-    //        locked = TRUE;
     ATOMIC_STORE_BOOL(&pIceAgent->addedRelayCandidate, TRUE);
-//    }
 CleanUp:
     CHK_LOG_ERR(retStatus);
 

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -43,6 +43,7 @@ STATUS createIceAgent(PCHAR username, PCHAR password, PIceAgentCallbacks pIceAge
 
     ATOMIC_STORE_BOOL(&pIceAgent->remoteCredentialReceived, FALSE);
     ATOMIC_STORE_BOOL(&pIceAgent->agentStartGathering, FALSE);
+    ATOMIC_STORE_BOOL(&pIceAgent->stopGathering, FALSE);
     ATOMIC_STORE_BOOL(&pIceAgent->candidateGatheringFinished, FALSE);
     ATOMIC_STORE_BOOL(&pIceAgent->shutdown, FALSE);
     ATOMIC_STORE_BOOL(&pIceAgent->restart, FALSE);

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -204,6 +204,7 @@ struct __IceAgent {
     volatile ATOMIC_BOOL shutdown;
     volatile ATOMIC_BOOL restart;
     volatile ATOMIC_BOOL processStun;
+    volatile ATOMIC_BOOL addedRelayCandidate;
 
     CHAR localUsername[MAX_ICE_CONFIG_USER_NAME_LEN + 1];
     CHAR localPassword[MAX_ICE_CONFIG_CREDENTIAL_LEN + 1];

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -205,6 +205,7 @@ struct __IceAgent {
     volatile ATOMIC_BOOL restart;
     volatile ATOMIC_BOOL processStun;
     volatile ATOMIC_BOOL addedRelayCandidate;
+    volatile ATOMIC_BOOL stopGathering;
 
     CHAR localUsername[MAX_ICE_CONFIG_USER_NAME_LEN + 1];
     CHAR localPassword[MAX_ICE_CONFIG_CREDENTIAL_LEN + 1];


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Added new flags to monitor relay candidate gathering. 

*Why was it changed?*
- In case of viewer connection, the getIceServerConfig resolves after candidate gathering callback exits due to which relay candidates do not get added to the list, causing the gathering callback to assume that all candidates in the local candidate list are addressed and reported. This causes connections requiring TURN to fail. Adding new checks to ensure we stop gathering callback only if candidate pair is nominated or the relay candidates are added to the list fixes this problem. Forcing TURN does not catch this issue because the timer callback waits for the local candidate list to have some entry.

*How was it changed?*
- Added a flag for 2 cases: 
   1. `addedRelayCandidate`: This is set once relay candidate entries are created in `addIceServerConfig`. 
   2. `stopGathering`: This is set once a pair is nominated. It is useful in cases where the connection with STUN/host candidates is already established and the SDK need not wait on relay candidates to be generated.

*What testing was done for the changes?*
- Confirmed existing unit tests passed
- Ran the JS SDK on phone and laptop with Viewer C SDK to confirm relay connection gets established and non-relay too
- Ran the JS SDK on phone and laptop with Master C SDK to confirm existing functionality is not broken.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
