### PR TITLE
Remove sample from codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
+          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE -DBUILD_SAMPLE=OFF
           make
           ulimit -c unlimited -S
       - name: Run tests


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Excluding samples from codecov to show the actual coverage

*Why was it changed?*
- To ensure codecov tool reports the right coverage %. By excluding samples from the calculation, the coverage value increases from 80% to 89%. Having unit tests for samples is not typical and this change can be reversed if we include any in the future.

*How was it changed?*
- Changed the CI script to build with `-DBUILD_SAMPLE=OFF`.

*What testing was done for the changes?*
- Confirmed by opening the codecov link to verify samples are not included in the calculation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
