### PR TITLE
[Bug] GStreamer sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,6 +584,7 @@ jobs:
       - name: Install dependencies
         shell: powershell
         run: |
+          choco install pkgconfiglite
           choco install gstreamer --version=1.16.3
           choco install gstreamer-devel --version=1.16.3
           curl.exe -o C:\tools\pthreads-w32-2-9-1-release.zip ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip

--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ To run:
 ./samples/kvsWebrtcClientViewerGstSample <channelName> <mediaType>
 ```
 
-##### Note:
-Our GStreamer samples leverage [MatroskaMux](https://gstreamer.freedesktop.org/documentation/matroska/matroskamux.html?gi-language=c) to receive media from its peer and save it to a file. However, MatroskaMux is designed for scenarios where the media's format remains constant throughout streaming. Unfortunately, this is not the case while using certain browsers as peers with ([AWS KVS JS SDK](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html)), so receiving media from the browsers andf writing it to filesink via MatroskaMux is not supported by our existing GStreamer samples. When the media's format changes mid-streaming (referred to as "caps changes"), MatroskaMux encounters limitations and is unable to handle these changes, resulting in an error message like:
+##### Known issues:
+Our GStreamer samples leverage [MatroskaMux](https://gstreamer.freedesktop.org/documentation/matroska/matroskamux.html?gi-language=c) to receive media from its peer and save it to a file. However, MatroskaMux is designed for scenarios where the media's format remains constant throughout streaming. When the media's format changes mid-streaming (referred to as "caps changes"), MatroskaMux encounters limitations, its behavior cannot be predicted and it may be unable to handle these changes, resulting in an error message like:
 
 ```shell
 matroskamux matroska-mux.c:1134:gst_matroska_mux_video_pad_setcaps:<mux> error: Caps changes are not supported by Matroska
@@ -333,12 +333,12 @@ gst-launch-1.0 videotestsrc pattern=ball num-buffers=1500 ! timeoverlay ! videoc
 
 ###### ADTS LC
 ```shell
-gst-launch-1.0 audiotestsrc num-buffers=1500 ! audioconvert ! audioresample ! faac ! capsfilter caps=audio/mpeg,mpegversion=4,stream-format=adts,base-profile=lc,channels=2,rate=48000 ! multifilesink location="sample-%03d.aac" index=1
+gst-launch-1.0 audiotestsrc num-buffers=1500 ! audioconvert ! audioresample ! faac ! capsfilter caps=audio/mpeg,mpegversion=4,stream-format=adts,base-profile=lc,channels=2,rate=16000 ! multifilesink location="sample-%03d.aac" index=1
 ```
 
 ###### RAW LC
 ```shell
-gst-launch-1.0 audiotestsrc num-buffers=1500 ! audioconvert ! audioresample ! faac ! capsfilter caps=audio/mpeg,mpegversion=4,stream-format=raw,base-profile=lc,channels=2,rate=44100 ! multifilesink location="sample-%03d.aac" index=1
+gst-launch-1.0 audiotestsrc num-buffers=1500 ! audioconvert ! audioresample ! faac ! capsfilter caps=audio/mpeg,mpegversion=4,stream-format=raw,base-profile=lc,channels=2,rate=16000 ! multifilesink location="sample-%03d.aac" index=1
 ```
 
 ### Viewing Master Samples

--- a/README.md
+++ b/README.md
@@ -309,6 +309,14 @@ To run:
 ./samples/kvsWebrtcClientViewerGstSample <channelName> <mediaType>
 ```
 
+##### Note:
+Our GStreamer samples leverage [MatroskaMux](https://gstreamer.freedesktop.org/documentation/matroska/matroskamux.html?gi-language=c) to receive media from its peer and save it to a file. However, MatroskaMux is designed for scenarios where the media's format remains constant throughout streaming. Unfortunately, this is not the case while using certain browsers as peers with ([AWS KVS JS SDK](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html)), so receiving media from the browsers andf writing it to filesink via MatroskaMux is not supported by our existing GStreamer samples. When the media's format changes mid-streaming (referred to as "caps changes"), MatroskaMux encounters limitations and is unable to handle these changes, resulting in an error message like:
+
+```shell
+matroskamux matroska-mux.c:1134:gst_matroska_mux_video_pad_setcaps:<mux> error: Caps changes are not supported by Matroska
+```
+To address this issue, users need to adapt the pipeline to utilize components capable of managing dynamic changes in media formats. This might involve integrating different muxers or customizing the pipeline to handle caps changes effectively.
+
 #### Sample: Generating sample frames
 
 ##### H264

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -880,6 +880,7 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
     pSampleConfiguration->trickleIce = trickleIce;
     pSampleConfiguration->useTurn = useTurn;
     pSampleConfiguration->enableSendingMetricsToViewerViaDc = FALSE;
+    pSampleConfiguration->receiveAudioVideoSource = NULL;
 
     pSampleConfiguration->channelInfo.version = CHANNEL_INFO_CURRENT_VERSION;
     pSampleConfiguration->channelInfo.pChannelName = channelName;

--- a/samples/GstAudioVideoReceiver.c
+++ b/samples/GstAudioVideoReceiver.c
@@ -91,7 +91,6 @@ VOID onSampleStreamingSessionShutdown(UINT64 customData, PSampleStreamingSession
     (void) (pSampleStreamingSession);
     eos = TRUE;
     GstElement* pipeline = (GstElement*) customData;
-    GstAppSrc *appsrcVideo = NULL, *appsrcAudio = NULL;
     gst_element_send_event(pipeline, gst_event_new_eos());
 }
 

--- a/samples/kvsWebRTCClientMasterGstSample.c
+++ b/samples/kvsWebRTCClientMasterGstSample.c
@@ -326,7 +326,6 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     pSampleConfiguration->videoSource = sendGstreamerAudioVideo;
     pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
-    pSampleConfiguration->receiveAudioVideoSource = NULL;
 
 #ifdef ENABLE_DATA_CHANNEL
     pSampleConfiguration->onDataChannel = onDataChannel;

--- a/samples/kvsWebRTCClientMasterGstSample.c
+++ b/samples/kvsWebRTCClientMasterGstSample.c
@@ -326,8 +326,6 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     pSampleConfiguration->videoSource = sendGstreamerAudioVideo;
     pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
-    pSampleConfiguration->receiveAudioVideoSource = receiveGstreamerAudioVideo;
-
 #ifdef ENABLE_DATA_CHANNEL
     pSampleConfiguration->onDataChannel = onDataChannel;
 #endif

--- a/samples/kvsWebRTCClientMasterGstSample.c
+++ b/samples/kvsWebRTCClientMasterGstSample.c
@@ -326,6 +326,8 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     pSampleConfiguration->videoSource = sendGstreamerAudioVideo;
     pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
+    pSampleConfiguration->receiveAudioVideoSource = NULL;
+
 #ifdef ENABLE_DATA_CHANNEL
     pSampleConfiguration->onDataChannel = onDataChannel;
 #endif


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Removed the receiver from the GstMaster sample
- PTS fix
- EOS fix

*Why was it changed?*
It was removed because it segfaults with the JS viewer because the JS viewer modifies caps mid-streaming. It is not supported by matroskamux in GStreamer. It has been broken but didn't manifest itself earlier because autovideosink in the previous pipeline did not work at all

*How was it changed?*
Removing the receiver from the GStreamer sample application as it was non-functional

*What testing was done for the changes?*
- Ran the GstSample with JS viewer and not seeing a segfault
- Ran the GstSample master with GstSample viewer and made sure the audio and video played properly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
