### PR TITLE
Static build prodc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,41 @@ jobs:
         run:  |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+
+  mbedtls-ubuntu-gcc-static:
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install deps
+        run: |
+          sudo apt clean && sudo apt update
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
+          sudo apt-get -q update
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_STATIC_LIBS=ON
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run:  |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
   mbedtls-ubuntu-gcc-11:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,6 @@ jobs:
           sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
           sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
           sudo apt-get -q update
-          sudo apt-get -y install gcc-4.4
           sudo apt-get -y install gdb
           sudo apt-get -y install libcurl4-openssl-dev
       - name: Build repository
@@ -353,7 +352,7 @@ jobs:
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
 
   mbedtls-ubuntu-gcc-static:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       AWS_KVS_LOG_LEVEL: 2
     permissions:
@@ -372,20 +371,18 @@ jobs:
           sudo apt clean && sudo apt update
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
           sudo apt-get -q update
+          sudo apt-get -y install gdb
           sudo apt-get -y install libcurl4-openssl-dev
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_STATIC_LIBS=ON
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_STATIC_LIBS=ON
           make
           ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+
   mbedtls-ubuntu-gcc-11:
     runs-on: ubuntu-latest
     env:
@@ -738,7 +735,7 @@ jobs:
           cmake .. -DBUILD_STATIC_LIBS=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
       - name: Verify library is ARM64 type
-        run: |
+        run: | 
           cd scripts
           chmod +x verify_lib.sh
           ./verify_lib.sh ../build/libkvsWebrtcClient.a "ARM64"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       AWS_KVS_LOG_LEVEL: 2
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     permissions:
       id-token: write
       contents: read

--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -19,6 +19,7 @@ ExternalProject_Add(libkvsCommonLws-download
       -DUSE_MBEDTLS=${USE_MBEDTLS}
       -DKVS_DEFAULT_STACK_SIZE=${KVS_DEFAULT_STACK_SIZE}
       -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+      -DBUILD_STATIC=${BUILD_STATIC}
     BUILD_ALWAYS      TRUE
     TEST_COMMAND      ""
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ endif()
 # building kvsCommonLws also builds kvspic
 set(BUILD_ARGS
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DBUILD_STATIC=${BUILD_STATIC_LIBS}
         -DUSE_OPENSSL=${USE_OPENSSL}
         -DUSE_MBEDTLS=${USE_MBEDTLS}
         -DKVS_DEFAULT_STACK_SIZE=${KVS_DEFAULT_STACK_SIZE}


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Fixed static building issue of SDK with mbedtls encountered on Ubuntu and added a CI for the same.

*Why was it changed?*
- Without this change, it seems the `libkvsCommonLws` library generated was a shared one despite setting static flag. This caused failure (complaining about compiling a shared version of libmbedtls) when trying to link mbedtls static library to shared `libkvsCommonLws` causing build failure, which surfaced this discrepancy. Same issue is not encountered with openssl, however, if static flag is set, we should make sure producer C is built static too.

*How was it changed?*
- Passing in `BUILD_STATIC_LIBS` setting to producer C.
- Added a new build only CI to build mbedtls static on ubuntu.

*What testing was done for the changes?*
- Tested on Ubuntu 22.04 EC2 instance and added CI for the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
