### PR TITLE
Fix log disorder in createSignalingClientSync and signalingClientFetchSync

### DIFF
--- a/src/source/Signaling/Client.c
+++ b/src/source/Signaling/Client.c
@@ -101,7 +101,7 @@ STATUS createSignalingClientSync(PSignalingClientInfo pClientInfo, PChannelInfo 
 
         DLOGV("Attempting to back off for [%lf] milliseconds before creating signaling client again. "
               "Signaling client creation retry count [%u]",
-              retStatus, signalingClientCreationWaitTime / 1000.0f, signalingClientCreationMaxRetryCount);
+              signalingClientCreationWaitTime / 1000.0f, signalingClientCreationMaxRetryCount);
         THREAD_SLEEP(signalingClientCreationWaitTime);
         signalingClientCreationMaxRetryCount--;
     }
@@ -228,7 +228,7 @@ STATUS signalingClientFetchSync(SIGNALING_CLIENT_HANDLE signalingClientHandle)
 
         DLOGV("Attempting to back off for [%lf] milliseconds before creating signaling client again. "
               "Signaling client creation retry count [%u]",
-              retStatus, signalingClientCreationWaitTime / 1000.0f, signalingClientCreationMaxRetryCount);
+              signalingClientCreationWaitTime / 1000.0f, signalingClientCreationMaxRetryCount);
         THREAD_SLEEP(signalingClientCreationWaitTime);
         signalingClientCreationMaxRetryCount--;
     }


### PR DESCRIPTION
Issue #, if available:

What was changed?
remove redundant `retStatus` in some logs.

Why was it changed?
`retStatus` takes the position of `signalingClientCreationWaitTime`, which leads to errors when print other variables.

How was it changed?
remove `retStatus`

What testing was done for the changes?
```
before:
05-15 11:05:59.759 678 754 I 00000/SignalingClient: signalingClientFetchSync(): Attempting to back off for [0.000000] milliseconds before creating signaling client again. Signaling client creation retry count [2147483648]

after
05-15 14:09:08.539 1707 1749 I 00000/SignalingClient: signalingClientFetchSync(): Attempting to back off for [15804.994141] milliseconds before creating signaling client again. Signaling client creation retry count [7]
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.