### PR TITLE
Fix retransmitter bug

### DIFF
--- a/src/source/PeerConnection/Retransmitter.c
+++ b/src/source/PeerConnection/Retransmitter.c
@@ -1,6 +1,21 @@
 #define LOG_CLASS "Retransmitter"
 
 #include "../Include_i.h"
+/**
+    Layout of Retransmitter
+     0                                                            [ PSequenceNumberList ]
+     8                                                            [ seqNumberListLen ]
+    12                                                            [ validIndexList ]
+    16                                                            [ PValidIndexList ]
+    24 (PSequenceNumberList)                                      [ seq_num_0 ]
+    26 (PSequenceNumberList + 1)                                  [ seq_num_1 ]
+    ...
+    (PSequenceNumberList + seqNumListLen - 1)                     [ seq_num_{seqNumListLen - 1} ]
+    PValidIndexList = (PSequenceNumberList + seqNumListLen)       [ valid_index_0 ]
+    (PValidIndexList + 1)                                         [ valid_index_1 ]
+    ...
+    (PValidIndexList + validIndexLen - 1)                         [ valid_index_{seqNumListLen - 1} ]
+**/
 
 STATUS createRetransmitter(UINT32 seqNumListLen, UINT32 validIndexListLen, PRetransmitter* ppRetransmitter)
 {
@@ -105,7 +120,7 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
             }
             // putBackPacketToRollingBuffer
             retStatus =
-                rollingBufferInsertData(pSenderTranceiver->sender.packetBuffer->pRollingBuffer, pRetransmitter->sequenceNumberList[index], item);
+                rollingBufferInsertData(pSenderTranceiver->sender.packetBuffer->pRollingBuffer, pRetransmitter->validIndexList[index], item);
             CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_ROLLING_BUFFER_NOT_IN_RANGE, retStatus);
 
             // free the packet if it is not in the valid range any more

--- a/src/source/Rtcp/RtcpPacket.c
+++ b/src/source/Rtcp/RtcpPacket.c
@@ -32,7 +32,7 @@ CleanUp:
     return retStatus;
 }
 
-// Given a RTCP Packet list extract the list of SSRCes, since the list of SSRCes may not be know ahead of time (because of BLP)
+// Given a RTCP Packet list extract the list of SSRCes, since the list of SSRCes may not be known ahead of time (because of BLP)
 // we need to allocate the list dynamically
 STATUS rtcpNackListGet(PBYTE pPayload, UINT32 payloadLen, PUINT32 pSenderSsrc, PUINT32 pReceiverSsrc, PUINT16 pSequenceNumberList,
                        PUINT32 pSequenceNumberListLen)
@@ -55,14 +55,14 @@ STATUS rtcpNackListGet(PBYTE pPayload, UINT32 payloadLen, PUINT32 pSenderSsrc, P
         BLP = getInt16(*(PUINT16) (pPayload + i + 2));
 
         // If pSsrcList is not NULL and we have space push and increment
-        if (pSequenceNumberList != NULL && sequenceNumberCount <= *pSequenceNumberListLen) {
+        if (pSequenceNumberList != NULL && sequenceNumberCount < *pSequenceNumberListLen) {
             pSequenceNumberList[sequenceNumberCount] = currentSequenceNumber;
         }
         sequenceNumberCount++;
 
         for (j = 0; j < 16; j++) {
             if ((BLP & (1 << j)) >> j) {
-                if (pSequenceNumberList != NULL && sequenceNumberCount <= *pSequenceNumberListLen) {
+                if (pSequenceNumberList != NULL && sequenceNumberCount < *pSequenceNumberListLen) {
                     pSequenceNumberList[sequenceNumberCount] = (currentSequenceNumber + j + 1);
                 }
                 sequenceNumberCount++;

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -168,6 +168,40 @@ TEST_F(RtcpFunctionalityTest, onRtcpPacketCompoundNack)
     freeRtpPacket(&pRtpPacket);
 }
 
+TEST_F(RtcpFunctionalityTest, createRetransmitterTest)
+{
+    PRtpPacket pRtpPacket = nullptr;
+    RtcOutboundRtpStreamStats stats{};
+    BYTE validRtcpPacket[] = {0x81, 0xcd, 0x00, 0x03, 0x2c, 0xd1, 0xa0, 0xde, 0x00, 0x00, 0xab, 0xe0, 0x00, 0x00, 0x00, 0x00};
+    initTransceiver(44000);
+    EXPECT_EQ(createRtpRollingBuffer(DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS * DEFAULT_EXPECTED_VIDEO_BIT_RATE / 8 / DEFAULT_MTU_SIZE_BYTES,
+                                     &pKvsRtpTransceiver->sender.packetBuffer), STATUS_SUCCESS);
+    EXPECT_EQ(createRetransmitter(1, 1, &pKvsRtpTransceiver->sender.retransmitter), STATUS_SUCCESS);
+
+    UINT16 x = 65000;
+    UINT64 y = 829482422;
+
+    pKvsRtpTransceiver->sender.retransmitter->sequenceNumberList[0] = x;
+    pKvsRtpTransceiver->sender.retransmitter->validIndexList[0] = y;
+
+    EXPECT_EQ(pKvsRtpTransceiver->sender.retransmitter->seqNumListLen, 1);
+    EXPECT_EQ(pKvsRtpTransceiver->sender.retransmitter->validIndexListLen, 1);
+
+    DLOGD("ReTransmitter:  \n%p\n%p\n%p\n%p\n%p\n", (void*)pKvsRtpTransceiver->sender.retransmitter, (void*)pKvsRtpTransceiver->sender.retransmitter->sequenceNumberList,
+          (void*)(&pKvsRtpTransceiver->sender.retransmitter->seqNumListLen),(void*)(&pKvsRtpTransceiver->sender.retransmitter->validIndexListLen),
+          (void*)pKvsRtpTransceiver->sender.retransmitter->validIndexList);
+
+    //EXPECT_EQ(createRtpPacketWithSeqNum(0, &pRtpPacket), STATUS_SUCCESS);
+    //EXPECT_EQ(rtpRollingBufferAddRtpPacket(pKvsRtpTransceiver->sender.packetBuffer, pRtpPacket), STATUS_SUCCESS);
+    //EXPECT_EQ(onRtcpPacket(pKvsPeerConnection, validRtcpPacket, SIZEOF(validRtcpPacket)), STATUS_SUCCESS);
+    //getRtpOutboundStats(pRtcPeerConnection, nullptr, &stats);
+    //EXPECT_EQ(stats.nackCount, 1);
+    //EXPECT_EQ(stats.retransmittedPacketsSent, 1);
+    //EXPECT_EQ(stats.retransmittedBytesSent, 10);
+    EXPECT_EQ(freePeerConnection(&pRtcPeerConnection), STATUS_SUCCESS);
+    //freeRtpPacket(&pRtpPacket);
+}
+
 TEST_F(RtcpFunctionalityTest, onRtcpPacketCompound)
 {
     KvsPeerConnection peerConnection{};

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -168,39 +168,6 @@ TEST_F(RtcpFunctionalityTest, onRtcpPacketCompoundNack)
     freeRtpPacket(&pRtpPacket);
 }
 
-TEST_F(RtcpFunctionalityTest, createRetransmitterTest)
-{
-    PRtpPacket pRtpPacket = nullptr;
-    RtcOutboundRtpStreamStats stats{};
-    BYTE validRtcpPacket[] = {0x81, 0xcd, 0x00, 0x03, 0x2c, 0xd1, 0xa0, 0xde, 0x00, 0x00, 0xab, 0xe0, 0x00, 0x00, 0x00, 0x00};
-    initTransceiver(44000);
-    EXPECT_EQ(createRtpRollingBuffer(DEFAULT_ROLLING_BUFFER_DURATION_IN_SECONDS * DEFAULT_EXPECTED_VIDEO_BIT_RATE / 8 / DEFAULT_MTU_SIZE_BYTES,
-                                     &pKvsRtpTransceiver->sender.packetBuffer), STATUS_SUCCESS);
-    EXPECT_EQ(createRetransmitter(1, 1, &pKvsRtpTransceiver->sender.retransmitter), STATUS_SUCCESS);
-
-    UINT16 x = 65000;
-    UINT64 y = 829482422;
-
-    pKvsRtpTransceiver->sender.retransmitter->sequenceNumberList[0] = x;
-    pKvsRtpTransceiver->sender.retransmitter->validIndexList[0] = y;
-
-    EXPECT_EQ(pKvsRtpTransceiver->sender.retransmitter->seqNumListLen, 1);
-    EXPECT_EQ(pKvsRtpTransceiver->sender.retransmitter->validIndexListLen, 1);
-
-    DLOGD("ReTransmitter:  \n%p\n%p\n%p\n%p\n%p\n", (void*)pKvsRtpTransceiver->sender.retransmitter, (void*)pKvsRtpTransceiver->sender.retransmitter->sequenceNumberList,
-          (void*)(&pKvsRtpTransceiver->sender.retransmitter->seqNumListLen),(void*)(&pKvsRtpTransceiver->sender.retransmitter->validIndexListLen),
-          (void*)pKvsRtpTransceiver->sender.retransmitter->validIndexList);
-
-    //EXPECT_EQ(createRtpPacketWithSeqNum(0, &pRtpPacket), STATUS_SUCCESS);
-    //EXPECT_EQ(rtpRollingBufferAddRtpPacket(pKvsRtpTransceiver->sender.packetBuffer, pRtpPacket), STATUS_SUCCESS);
-    //EXPECT_EQ(onRtcpPacket(pKvsPeerConnection, validRtcpPacket, SIZEOF(validRtcpPacket)), STATUS_SUCCESS);
-    //getRtpOutboundStats(pRtcPeerConnection, nullptr, &stats);
-    //EXPECT_EQ(stats.nackCount, 1);
-    //EXPECT_EQ(stats.retransmittedPacketsSent, 1);
-    //EXPECT_EQ(stats.retransmittedBytesSent, 10);
-    EXPECT_EQ(freePeerConnection(&pRtcPeerConnection), STATUS_SUCCESS);
-    //freeRtpPacket(&pRtpPacket);
-}
 
 TEST_F(RtcpFunctionalityTest, onRtcpPacketCompound)
 {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1991, https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/1453

*What was changed?*
* Added a diagram to show the memory layout for the ReTransmitter struct.
* Fixed a bug where where an index for `sequenceNumberList` may go out of bounds but is hard to detect / won't cause a crash because in memory the next memory spot when we go out of bounds is into the `validIndexList`, and unless it's size is zero (which is likely never the case) we will not actually go out of bounds but instead we will overwrite a value in the wrong list.
* Fixed an issue where we are reading an index from one list but updating the value in a different list.


*Why was it changed?*
* Multiple reported customer issues.

*How was it changed?*
See File Diff.

*What testing was done for the changes?*

CI.  [TODO] More targeted tests need to be added, will remove this once it has been added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
