### PR TITLE
Fix MID_NTP macro definition

### DIFF
--- a/src/source/Rtcp/RtcpPacket.h
+++ b/src/source/Rtcp/RtcpPacket.h
@@ -93,7 +93,7 @@ UINT64 convertTimestampToNTP(UINT64 time100ns);
 // In some fields where a more compact representation is
 //   appropriate, only the middle 32 bits are used; that is, the low 16
 //   bits of the integer part and the high 16 bits of the fractional part.
-#define MID_NTP(ntp_time) (UINT32)((currentTimeNTP >> 16U) & 0xffffffffULL)
+#define MID_NTP(ntp_time) (UINT32)((ntp_time >> 16U) & 0xffffffffULL)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Updated the MID_NTP macro definition to use the parameter passed to it.

*Why was it changed?*
The macro definition was not using the parameter passed to it. It was working so far because the variable name used in the macro definition happened to be same as the one at the call site.

*How was it changed?*
Updated the macro definition to use the parameter passed.

*What testing was done for the changes?*
The change is pretty small and does not warrant any testing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
