### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,7 +455,7 @@ if(COMPILER_WARNINGS)
   target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)
 endif()
 
-install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient
+install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient kvsWebRtcThreadpool
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -61,18 +61,18 @@ add_executable(
   kvsWebrtcClientMaster
   Common.c
   kvsWebRTCClientMaster.c)
-target_link_libraries(kvsWebrtcClientMaster kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} kvsCommonLws kvspicUtils websockets kvssdp kvsstun kvsrtp)
+target_link_libraries(kvsWebrtcClientMaster kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} kvsCommonLws kvspicUtils websockets)
 
 add_executable(
   kvsWebrtcClientViewer
   Common.c
   kvsWebRTCClientViewer.c)
-target_link_libraries(kvsWebrtcClientViewer kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} kvsCommonLws kvspicUtils websockets kvssdp kvsstun kvsrtp)
+target_link_libraries(kvsWebrtcClientViewer kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} kvsCommonLws kvspicUtils websockets)
 
 add_executable(
         discoverNatBehavior
         discoverNatBehavior.c)
-target_link_libraries(discoverNatBehavior kvsWebrtcClient ${EXTRA_DEPS} kvssdp kvsstun kvsrtp)
+target_link_libraries(discoverNatBehavior kvsWebrtcClient ${EXTRA_DEPS})
 
 if(GST_FOUND)
   add_executable(

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -81,7 +81,7 @@ if(GST_FOUND)
     GstAudioVideoReceiver.c
     kvsWebRTCClientMasterGstSample.c
   )
-  target_link_libraries(kvsWebrtcClientMasterGstSample kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils websockets kvssdp kvsstun kvsrtp)
+  target_link_libraries(kvsWebrtcClientMasterGstSample kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils)
 
   install(TARGETS kvsWebrtcClientMasterGstSample
     RUNTIME DESTINATION bin
@@ -93,7 +93,7 @@ if(GST_FOUND)
     GstAudioVideoReceiver.c
     kvsWebRTCClientViewerGstSample.c
   )
-  target_link_libraries(kvsWebrtcClientViewerGstSample kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils websockets kvssdp kvsrtp)
+  target_link_libraries(kvsWebrtcClientViewerGstSample kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} ${GST_SAMPLE_LIBRARIES} kvsCommonLws kvspicUtils)
 
   install(TARGETS kvsWebrtcClientViewerGstSample
     RUNTIME DESTINATION bin


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Adding threadpool to ensure it is installed along with other webrtc libraries
- Removing the unnecessary linkage to stun, rtp and sdp libraries in samples since we do not directly use its APIs

*Why was it changed?*
- Threadpool was added to ensure custom path install works for threadpool and does not cause linkage failure.

*How was it changed?*
- Check the cmake file changes made in the PR

*What testing was done for the changes?*
- Allowing CI to run to ensure this does not break anything
- Ran local build by setting OPEN_SRC_INSTALL_PREFIX and CMAKE_INSTALL_PREFIX paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
