### PR TITLE
Fix CI - unused vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           bash scripts/check-clang.sh
   mac-os-build-clang:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       CC: /usr/bin/clang
       CXX: /usr/bin/clang++
@@ -49,7 +49,7 @@ jobs:
           cd build
           ./tst/webrtc_client_test
   mac-os-build-gcc:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       CC: gcc
       CXX: g++
@@ -104,7 +104,7 @@ jobs:
           cd build
           ./tst/webrtc_client_test
   static-build-mac:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       AWS_KVS_LOG_LEVEL: 2
     permissions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,7 +455,14 @@ if(COMPILER_WARNINGS)
   target_compile_options(kvsWebrtcSignalingClient PUBLIC -Wall -Werror -pedantic -Wextra -Wno-unknown-warning-option)
 endif()
 
-install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient kvsWebRtcThreadpool
+if(ENABLE_KVS_THREADPOOL)
+  install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient kvsWebRtcThreadpool
+          LIBRARY DESTINATION lib
+          ARCHIVE DESTINATION lib
+  )
+endif()
+
+install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,7 +456,7 @@ if(COMPILER_WARNINGS)
 endif()
 
 if(ENABLE_KVS_THREADPOOL)
-  install(TARGETS kvsWebrtcClient kvsWebrtcSignalingClient kvsWebRtcThreadpool
+  install(TARGETS kvsWebRtcThreadpool
           LIBRARY DESTINATION lib
           ARCHIVE DESTINATION lib
   )

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -1033,6 +1033,7 @@ STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
     PStunAttributeChannelNumber pStunAttributeChannelNumber = NULL;
     UINT32 i = 0;
 
+    UNUSED_PARAM(sendStatus);
     // turn mutex is assumed to be locked.
     CHK(pTurnConnection != NULL, STATUS_NULL_ARG);
     for (i = 0; i < pTurnConnection->turnPeerCount; ++i) {

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -87,6 +87,15 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     UINT32 rttPropDelayMsec = 0, rttPropDelay, delaySinceLastSR, lastSR, interarrivalJitter, extHiSeqNumReceived, cumulativeLost, senderSSRC, ssrc1;
     UINT64 currentTimeNTP = convertTimestampToNTP(GETTIME());
 
+    UNUSED_PARAM(rttPropDelayMsec);
+    UNUSED_PARAM(rttPropDelay);
+    UNUSED_PARAM(delaySinceLastSR);
+    UNUSED_PARAM(lastSR);
+    UNUSED_PARAM(interarrivalJitter);
+    UNUSED_PARAM(extHiSeqNumReceived);
+    UNUSED_PARAM(cumulativeLost);
+    UNUSED_PARAM(senderSSRC);
+
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
     // https://tools.ietf.org/html/rfc3550#section-6.4.2
     if (pRtcpPacket->payloadLength != RTCP_PACKET_RECEIVER_REPORT_MINLEN) {

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -366,5 +366,9 @@ CleanUp:
         free(data);
     }
 
+    if (STATUS_FAILED(retStatus)) {
+        return -1;
+    }
+
     return 1;
 }

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -37,6 +37,7 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
     PStateMachineState pStateMachineState;
     BOOL skewMapContains = FALSE;
 
+    UNUSED_PARAM(logLevel);
     DLOGV("HTTPS callback with reason %d", reason);
 
     // Early check before accessing the custom data field to see if we are interested in processing the message
@@ -1492,6 +1493,9 @@ STATUS joinStorageSessionLws(PSignalingClient pSignalingClient, UINT64 time)
     PLwsCallInfo pLwsCallInfo = NULL;
     PCHAR pResponseStr;
     UINT32 resultLen;
+
+    UNUSED_PARAM(pResponseStr);
+    UNUSED_PARAM(resultLen);
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     CHK(pSignalingClient->channelEndpointWebrtc[0] != '\0', STATUS_INTERNAL_ERROR);

--- a/src/source/Stun/Stun.c
+++ b/src/source/Stun/Stun.c
@@ -379,6 +379,7 @@ STATUS deserializeStunPacket(PBYTE pStunBuffer, UINT32 bufferSize, PBYTE passwor
     UINT8 *pErrorPhrase, *pBuffer = NULL;
     UINT16 errorPhraseLength, channelNumber, buffereLength, errorCode;
 
+    UNUSED_PARAM(pStunAttributeFingerprint);
     CHK(pStunBuffer != NULL && ppStunPacket != NULL, STATUS_NULL_ARG);
     CHK(bufferSize >= STUN_HEADER_LEN, STATUS_INVALID_ARG);
 

--- a/tst/JitterBufferFunctionalityTest.cpp
+++ b/tst/JitterBufferFunctionalityTest.cpp
@@ -1146,11 +1146,9 @@ TEST_F(JitterBufferFunctionalityTest, timestampOverflowTest)
     UINT32 pktCount = 7;
     UINT32 startingSequenceNumber = 0;
     UINT32 missingSequenceNumber = 0;
-    UINT32 firstSequenceNumber = 0;
     initializeJitterBuffer(4, 0, pktCount);
     srand(time(0));
     startingSequenceNumber = rand()%UINT16_MAX;
-    firstSequenceNumber = startingSequenceNumber - 1;
 
     // First frame "1"
     mPRtpPackets[0]->payloadLength = 1;


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Updated GHA runner to macos-12 since macos-11 is going to be deprecated ([The macos-11 label has been deprecated and will no longer be available after 28 June 2024.)](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners)

*Why was it changed?*
- The jobs do not start with macos-11 runner anymore.

*How was it changed?*
- Changed the label on CI files
- Fixed all unused variable errors reported by mac CI.

*What testing was done for the changes?*
- CI being run to test out the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
