### PR TITLE
fix bug 32 bit system reading 8 bytes for pointer results in overwriting 4 bytes of payloadType when writing rtpMapValue

### DIFF
--- a/.github/workflows/pr-desc-lint.yml
+++ b/.github/workflows/pr-desc-lint.yml
@@ -35,19 +35,19 @@ jobs:
           how_changed=$(echo "$pr_description" | sed -n -e '/\*How was it changed?\*/,/\*/p' | wc -c)
           testing_done=$(echo "$pr_description" | sed -n -e '/\*What testing was done for the changes?\*/,/\*/p' | wc -c)
 
-          if [[ ${#what_changed} -lt $MIN_CHARS ]]; then
+          if [[ $what_changed -lt $MIN_CHARS ]]; then
             echo "PR description for what changed section is either missing or too short."
             error_occurred=1
           fi
-          if [[ ${#why_changed} -lt $MIN_CHARS ]]; then
+          if [[ $why_changed -lt $MIN_CHARS ]]; then
             echo "PR description for why it changed section is either missing or too short."
             error_occurred=1
           fi
-          if [[ ${#how_changed} -lt $MIN_CHARS ]]; then
+          if [[ $how_changed -lt $MIN_CHARS ]]; then
             echo "PR description for how was it changed section is either missing or too short."
             error_occurred=1
           fi
-          if [[ ${#testing_done} -lt $MIN_CHARS ]]; then
+          if [[ $testing_done -lt $MIN_CHARS ]]; then
             echo "PR description for testing section are either missing or too short."
             error_occurred=1
           fi

--- a/.github/workflows/pr-desc-lint.yml
+++ b/.github/workflows/pr-desc-lint.yml
@@ -30,10 +30,10 @@ jobs:
 
           # Extract contents
           # Extract contents
-          what_changed=$(echo "$pr_description" | sed -n -e '/\*What was changed?\*/,/\*/p' | sed '$d' | sed '1d')
-          why_changed=$(echo "$pr_description" | sed -n -e '/\*Why was it changed?\*/,/\*/p' | sed '$d' | sed '1d')
-          how_changed=$(echo "$pr_description" | sed -n -e '/\*How was it changed?\*/,/\*/p' | sed '$d' | sed '1d')
-          testing_done=$(echo "$pr_description" | sed -n -e '/\*What testing was done for the changes?\*/,/\*/p' | sed '$d' | sed '1d')
+          what_changed=$(echo "$pr_description" | sed -n -e '/\*What was changed?\*/,/\*/p' | wc -c)
+          why_changed=$(echo "$pr_description" | sed -n -e '/\*Why was it changed?\*/,/\*/p' | wc -c)
+          how_changed=$(echo "$pr_description" | sed -n -e '/\*How was it changed?\*/,/\*/p' | wc -c)
+          testing_done=$(echo "$pr_description" | sed -n -e '/\*What testing was done for the changes?\*/,/\*/p' | wc -c)
 
           if [[ ${#what_changed} -lt $MIN_CHARS ]]; then
             echo "PR description for what changed section is either missing or too short."

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -415,13 +415,13 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT64 payloadType, rtxPayloadType;
+    UINT64 payloadType, rtxPayloadType, rtpMapValue;
     BOOL containRtx = FALSE;
     BOOL directionFound = FALSE;
     UINT32 i, remoteAttributeCount, attributeCount = 0;
     PRtcMediaStreamTrack pRtcMediaStreamTrack = &(pKvsRtpTransceiver->sender.track);
     PSdpMediaDescription pSdpMediaDescriptionRemote;
-    PCHAR currentFmtp = NULL, rtpMapValue = NULL;
+    PCHAR currentFmtp = NULL, rtpMapValueChar = NULL;
     CHAR remoteSdpAttributeValue[MAX_SDP_ATTRIBUTE_VALUE_LENGTH];
     INT32 amountWritten = 0;
 
@@ -795,11 +795,12 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
             attributeCount++;
         }
     } else if (pRtcMediaStreamTrack->codec == RTC_CODEC_UNKNOWN) {
-        CHK_STATUS(hashTableGet(pUnknownCodecRtpmapTable, unknownCodecHashTableKey, (PUINT64) &rtpMapValue));
+        CHK_STATUS(hashTableGet(pUnknownCodecRtpmapTable, unknownCodecHashTableKey, &rtpMapValue));
+        rtpMapValueChar = (PCHAR) rtpMapValue;
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtpmap");
         amountWritten =
             SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
-                     SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " %s", payloadType, rtpMapValue);
+                     SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " %s", payloadType, rtpMapValueChar);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full Unknown rtpmap could not be written");
         attributeCount++;
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/2025

*What was changed?*
In the case viewer does not support a codec the master supports on 32 bit issues a bug was fixed which could cause a garbage value to be set in the sdp answer for the rtpmap attribute.

*Why was it changed?*
Customer reported issue, results in incorrect/buggy behavior

*How was it changed?*
The `hashTableGet` fills in a UINT64 so it is expecting 8 bytes, a char* was being cast to this, but a pointer on a 32 bit system is only 4 bytes wide. This was resolved by creating an intermediate 64 bit int to hold the value then cast it back down.

*What testing was done for the changes?*
Will request customer to test and confirm.  If I can get my hands on a 32 bit system I will try it out.
Linter that check's the PR description was modified to just use the linux utility `wc`.  Otherwise the current check breaks if you have any special characters in the description, since the description supports markdown there are many characters that when present would previously report a 0 char count when in fact they were not 0.  I tested the commands in my shell to confirm.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
