### PR TITLE
remove line which sets payloadType after it was already set

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -444,7 +444,6 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
             retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_VP8, &rtxPayloadType);
         } else if (pRtcMediaStreamTrack->codec == RTC_CODEC_H265) {
             retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_H265, &rtxPayloadType);
-            payloadType = DEFAULT_PAYLOAD_H265;
         } else {
             retStatus = STATUS_HASH_KEY_NOT_PRESENT;
         }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/2029

*What was changed?*
A single line was removed which re assigns a value to payloadType in the case of h265 codec.

*Why was it changed?*
There was asymmetric behavior in the code where for h265 we would set the payloadType twice which is confusing for the reader, all other codecs we do not do that.

*How was it changed?*
The extra line of code which assigned it for a second time was removed.

*What testing was done for the changes?*
Unit tests / CI.  No additional tests were added since no functional behavior was changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
