### PR TITLE
fix nack pli overwrite bug

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -666,6 +666,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 rtcp-fb nack value could not be written");
+        attributeCount++;
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack pli", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 rtcp-fb nack-pli value could not be written");
@@ -764,6 +765,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H265 rtcp-fb nack value could not be written");
+        attributeCount++;
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack pli", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H265 rtcp-fb nack-pli value could not be written");

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -407,6 +407,14 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendRecv)
     EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendrecv", sessionDescriptionInit.sdp);
 
+    std::string offerSdp(sessionDescriptionInit.sdp);
+
+    // check nack and nack pli lines
+    // We assume here DEFAULT_PAYLOAD_H264 is 125 so we know what our offer will generate.
+    std::string::size_type posPliOnly = offerSdp.find("a=rtcp-fb:125 nack");
+    std::string::size_type posPliNack = offerSdp.find("a=rtcp-fb:125 nack pli");
+    EXPECT_NE(posPliOnly, posPliNack);
+
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);
 }
@@ -477,6 +485,14 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly)
     EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendonly", sessionDescriptionInit.sdp);
 
+    std::string offerSdp(sessionDescriptionInit.sdp);
+
+    // check nack and nack pli lines
+    // We assume here DEFAULT_PAYLOAD_H264 is 125 so we know what our offer will generate.
+    std::string::size_type posPliOnly = offerSdp.find("a=rtcp-fb:125 nack");
+    std::string::size_type posPliNack = offerSdp.find("a=rtcp-fb:125 nack pli");
+    EXPECT_NE(posPliOnly, posPliNack);
+
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);
 }
@@ -507,6 +523,14 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly_H265)
     EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
     EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendonly", sessionDescriptionInit.sdp);
+
+    std::string offerSdp(sessionDescriptionInit.sdp);
+
+    // check nack and nack pli lines
+    // We assume here DEFAULT_PAYLOAD_H265 is 127 so we know what our offer will generate.
+    std::string::size_type posPliOnly = offerSdp.find("a=rtcp-fb:127 nack");
+    std::string::size_type posPliNack = offerSdp.find("a=rtcp-fb:127 nack pli");
+    EXPECT_NE(posPliOnly, posPliNack);
 
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -415,7 +415,6 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendRecv)
     std::string offerSdp(sessionDescriptionInit.sdp);
 
     // check nack and nack pli lines
-    // We assume here DEFAULT_PAYLOAD_H264 is 125 so we know what our offer will generate.
     std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h264_nack_line);
     std::string::size_type posPliNack = offerSdp.find(m_rtcp_h264_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);
@@ -493,7 +492,6 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly)
     std::string offerSdp(sessionDescriptionInit.sdp);
 
     // check nack and nack pli lines
-    // We assume here DEFAULT_PAYLOAD_H264 is 125 so we know what our offer will generate.
     std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h264_nack_line);
     std::string::size_type posPliNack = offerSdp.find(m_rtcp_h264_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);
@@ -532,7 +530,6 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly_H265)
     std::string offerSdp(sessionDescriptionInit.sdp);
 
     // check nack and nack pli lines
-    // We assume here DEFAULT_PAYLOAD_H265 is 127 so we know what our offer will generate.
     std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h265_nack_line);
     std::string::size_type posPliNack = offerSdp.find(m_rtcp_h265_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -12,6 +12,11 @@ namespace video {
 namespace webrtcclient {
 
 class SdpApiTest : public WebRtcClientTestBase {
+  public:
+    const std::string m_rtcp_h264_nack_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H264) + " nack";
+    const std::string m_rtcp_h264_nack_pli_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H264) + " nack pli";
+    const std::string m_rtcp_h265_nack_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H265) + " nack";
+    const std::string m_rtcp_h265_nack_pli_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H265) + " nack pli";
 };
 
 /*
@@ -411,8 +416,8 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendRecv)
 
     // check nack and nack pli lines
     // We assume here DEFAULT_PAYLOAD_H264 is 125 so we know what our offer will generate.
-    std::string::size_type posPliOnly = offerSdp.find("a=rtcp-fb:125 nack");
-    std::string::size_type posPliNack = offerSdp.find("a=rtcp-fb:125 nack pli");
+    std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h264_nack_line);
+    std::string::size_type posPliNack = offerSdp.find(m_rtcp_h264_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);
 
     closePeerConnection(offerPc);
@@ -489,8 +494,8 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly)
 
     // check nack and nack pli lines
     // We assume here DEFAULT_PAYLOAD_H264 is 125 so we know what our offer will generate.
-    std::string::size_type posPliOnly = offerSdp.find("a=rtcp-fb:125 nack");
-    std::string::size_type posPliNack = offerSdp.find("a=rtcp-fb:125 nack pli");
+    std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h264_nack_line);
+    std::string::size_type posPliNack = offerSdp.find(m_rtcp_h264_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);
 
     closePeerConnection(offerPc);
@@ -528,8 +533,8 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly_H265)
 
     // check nack and nack pli lines
     // We assume here DEFAULT_PAYLOAD_H265 is 127 so we know what our offer will generate.
-    std::string::size_type posPliOnly = offerSdp.find("a=rtcp-fb:127 nack");
-    std::string::size_type posPliNack = offerSdp.find("a=rtcp-fb:127 nack pli");
+    std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h265_nack_line);
+    std::string::size_type posPliNack = offerSdp.find(m_rtcp_h265_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);
 
     closePeerConnection(offerPc);


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/2007

*What was changed?*
We were previously failing to increment index in an array which held the strings for rtcp-fb sdp attribute which contained `pli` and `pli nack`.  This means the line which contains `pli nack` overwrite the line which contained `pli`, but this is not the expected behavior.

*Why was it changed?*
It was brought to our attention via a GitHub issue referenced at the top.

*How was it changed?*
There is an existing pattern where after copying over an attribute we increment the attribute number.  This was mistakenly missed, and it looks like that bug was copy/paste from the H264 section to the H265 section so it was corrected there as well.

*What testing was done for the changes?*
New tests were added to validate the correct sdp string which I verified fail with the existing code but pass with the new code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
