### PR TITLE
Update project version from 1.8.1 to 1.9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CheckIncludeFiles)
 include(CheckFunctionExists)
 
 # The version MUST be updated before every release
-project(KinesisVideoWebRTCClient VERSION 1.8.1 LANGUAGES C)
+project(KinesisVideoWebRTCClient VERSION 1.9.1 LANGUAGES C)
 
 
 # User Flags


### PR DESCRIPTION
*Issue #, if available:* N/A

*What was changed?*
The project version number in the CMakeLists.txt file was updated from 1.8.1 to 1.9.1.

*Why was it changed?*
The previous version number (1.8.1) was incorrect and outdated, and it needed to be updated to reflect the current version of the KinesisVideoWebRTCClient project.

*How was it changed?*
The version number was changed by modifying the project command in the CMakeLists.txt file. The line:
```
project(KinesisVideoWebRTCClient VERSION 1.8.1 LANGUAGES C)
```
was replaced with:
```
project(KinesisVideoWebRTCClient VERSION 1.9.1 LANGUAGES C)
```

*What testing was done for the changes?*
No specific testing was done for this change, as it is a version number update and does not directly affect the functionality of the project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
