### PR TITLE
Add cmake flag for iot creds

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -6,6 +6,11 @@ project(KinesisVideoWebRTCClientSamples LANGUAGES C)
 
 message("OPEN_SRC_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}")
 
+if(IOT_CORE_ENABLE_CREDENTIALS)
+  add_definitions(-DIOT_CORE_ENABLE_CREDENTIALS)
+  message("Use IoT credentials in the samples")
+endif()
+
 if (WIN32)
     if(NOT DEFINED PKG_CONFIG_EXECUTABLE)
       if(EXISTS "C:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe")
@@ -17,7 +22,7 @@ if (WIN32)
       message(FATAL_ERROR "Gstreamer not found in default path. Set the appropriate path with -DPKG_CONFIG_EXECUTABLE=<path>")
     endif()
 endif()
-  
+
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(GST gstreamer-1.0)

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -64,7 +64,8 @@ extern "C" {
 #define IOT_CORE_THING_NAME          ((PCHAR) "AWS_IOT_CORE_THING_NAME")
 #define IOT_CORE_CERTIFICATE_ID      ((PCHAR) "AWS_IOT_CORE_CERTIFICATE_ID")
 
-/* Uncomment the following line in order to enable IoT credentials checks in the provided samples */
+/* Uncomment the following line in order to enable IoT credentials checks in the provided samples
+   Or, you pass specify this through the CMake flag: cmake .. -DIOT_CORE_ENABLE_CREDENTIALS=ON */
 // #define IOT_CORE_ENABLE_CREDENTIALS  1
 
 #define MASTER_DATA_CHANNEL_MESSAGE "This message is from the KVS Master"

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -57,16 +57,14 @@ extern "C" {
 
 #define RTSP_PIPELINE_MAX_CHAR_COUNT 1000
 
+/* To enable IoT credentials checks in the provided samples, specify
+   this through the CMake flag: cmake .. -DIOT_CORE_ENABLE_CREDENTIALS=ON */
 #define IOT_CORE_CREDENTIAL_ENDPOINT ((PCHAR) "AWS_IOT_CORE_CREDENTIAL_ENDPOINT")
 #define IOT_CORE_CERT                ((PCHAR) "AWS_IOT_CORE_CERT")
 #define IOT_CORE_PRIVATE_KEY         ((PCHAR) "AWS_IOT_CORE_PRIVATE_KEY")
 #define IOT_CORE_ROLE_ALIAS          ((PCHAR) "AWS_IOT_CORE_ROLE_ALIAS")
 #define IOT_CORE_THING_NAME          ((PCHAR) "AWS_IOT_CORE_THING_NAME")
 #define IOT_CORE_CERTIFICATE_ID      ((PCHAR) "AWS_IOT_CORE_CERTIFICATE_ID")
-
-/* Uncomment the following line in order to enable IoT credentials checks in the provided samples
-   Or, you pass specify this through the CMake flag: cmake .. -DIOT_CORE_ENABLE_CREDENTIALS=ON */
-// #define IOT_CORE_ENABLE_CREDENTIALS  1
 
 #define MASTER_DATA_CHANNEL_MESSAGE "This message is from the KVS Master"
 #define VIEWER_DATA_CHANNEL_MESSAGE "This message is from the KVS Viewer"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
Add a CMake flag that defines the pre-processor macro: `IOT_CORE_ENABLE_CREDENTIALS`. This flag is used in the samples to enable IoT credentials. Otherwise, static credentials (AK, SK, (ST)) are used.

*Why was it changed?*
* Makes it easier to build.

*How was it changed?*
* If "-DIOT_CORE_ENABLE_CREDENTIALS=ON" cmake flag is present, it will add the pre-processor macro: `IOT_CORE_ENABLE_CREDENTIALS`. Also add a log line to indicate that it chose this path. To maintain backwards compatibility, this flag is OFF by default.

*What testing was done for the changes?*
1. `cmake ..`, run kvsWebrtcClientMaster
    - IoT credentials are not used.
2. `cmake .. -DIOT_CORE_ENABLE_CREDENTIALS=OFF`, run kvsWebrtcClientMaster
    - IoT credentials still not used.
3. `cmake .. -DIOT_CORE_ENABLE_CREDENTIALS=ON`, run kvsWebrtcClientMaster
    - IoT credentials are used.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
