### PR TITLE
Change branch target from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - develop
-      - master
+      - main
   pull_request:
     branches:
       - develop
-      - master
+      - main
 jobs:
   clang-format-check:
     runs-on: macos-12
@@ -385,7 +385,7 @@ jobs:
         run:  |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  
+
   mbedtls-ubuntu-gcc-4_4-build:
     runs-on: ubuntu-20.04
     env:
@@ -417,7 +417,7 @@ jobs:
           mkdir build && cd build
           cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
           make
-          
+
   mbedtls-ubuntu-clang:
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - develop
-      - master
+      - main
   pull_request:
     branches:
       - develop
-      - master
+      - main
 jobs:
   linux-gcc-codecov:
     runs-on: ubuntu-20.04

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,11 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ develop, main ]
 
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop, master ]
+    branches: [ develop, main ]
 
 jobs:
   analyze:

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -3,7 +3,7 @@ name: Doxygen GitHub Pages Deploy Action WebRTC C SDK
 on:
   push:
     branches:
-      - master
+      - main
       - develop
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      
+
       - name: Install requirements
         run: sudo apt-get install doxygen graphviz -y
         shell: bash
@@ -20,10 +20,9 @@ jobs:
       - name: Generate Doxygen Documentation
         run: doxygen Doxyfile
         shell: bash
-      
+
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.5
         with:
           folder: doc/html
           branch: gh-pages
-      

--- a/.github/workflows/pr-desc-lint.yml
+++ b/.github/workflows/pr-desc-lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - develop
-      - master
+      - main
     types:
       - opened
       - synchronize

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -3,7 +3,7 @@ name: Check Version Mismatch between PR branch and master.
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   check-version:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Compare versions
         run: |
-          echo "Comparing PR Version: $PR_VERSION with Master Version: $MASTER_VERSION"
+          echo "Comparing PR Version: $PR_VERSION with Main Version: $MASTER_VERSION"
           if [ "$MASTER_VERSION" == "$PR_VERSION" ]; then
-            echo "Please update the version in CMakeLists.txt file (project(KinesisVideoWebRTCClient VERSION <ver-string> LANGUAGES C). Any PR getting merged to master requires a version update"
+            echo "Please update the version in CMakeLists.txt file (project(KinesisVideoWebRTCClient VERSION <ver-string> LANGUAGES C). Any PR getting merged to main requires a version update"
             exit 1
           else
             echo "Version update detected."

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,4 +1,4 @@
-name: Check Version Mismatch between PR branch and master.
+name: Check Version Mismatch between PR branch and main.
 
 on:
   pull_request:
@@ -19,17 +19,17 @@ jobs:
           echo "PR_VERSION=$PR_VERSION" >> "$GITHUB_ENV"
           echo "PR Version: $PR_VERSION"
 
-      - name: Checkout master branch
+      - name: Checkout main branch
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: main
 
-      - name: Get version from master
+      - name: Get version from main
         id: master_version
         run: |
           MASTER_VERSION=$(grep -Po 'KinesisVideoWebRTCClient VERSION \K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
           echo "MASTER_VERSION=$MASTER_VERSION" >> "$GITHUB_ENV"
-          echo "Master version: $MASTER_VERSION"
+          echo "Main version: $MASTER_VERSION"
 
       - name: Compare versions
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ reported the issue. Please try to include as much information as you can. Detail
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -56,6 +56,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/workflows/ci.yml"> <img src="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/workflows/ci.yml/badge.svg"> </a>
-  <a href="https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c"> <img src="https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/branch/master/graph/badge.svg" alt="Coverage Status"> </a>
+  <a href="https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c"> <img src="https://codecov.io/gh/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/branch/main/graph/badge.svg" alt="Coverage Status"> </a>
 </p>
 
 <p align="center">
@@ -395,7 +395,7 @@ https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html
 
 Note: "kinesisvideo:CreateSignalingChannel" can be removed if you are running with existing KVS signaling channels. Viewer sample requires "kinesisvideo:ConnectAsViewer" permission. Integration test requires both "kinesisvideo:ConnectAsViewer" and "kinesisvideo:DeleteSignalingChannel" permission.
 
-* With the IoT certificate, IoT credentials provider endpoint (Note: it is not the endpoint on IoT AWS Console!), public key and private key ready, you can replace the static credentials provider createStaticCredentialProvider() and freeStaticCredentialProvider() with IoT credentials provider like below, the credentials provider for [samples](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/samples/Common.c) is in createSampleConfiguration():
+* With the IoT certificate, IoT credentials provider endpoint (Note: it is not the endpoint on IoT AWS Console!), public key and private key ready, you can replace the static credentials provider createStaticCredentialProvider() and freeStaticCredentialProvider() with IoT credentials provider like below, the credentials provider for [samples](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/main/samples/Common.c) is in createSampleConfiguration():
 
 ```c
 createLwsIotCredentialProvider(
@@ -489,7 +489,7 @@ If you would like to print out the SDPs, run this command:
 `export DEBUG_LOG_SDP=TRUE`
 
 ### Adjust MTU
-If ICE connection can be established successfully but media can not be transferred, make sure the actual MTU is higher than the MTU setting here: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/source/PeerConnection/Rtp.h#L12.
+If ICE connection can be established successfully but media can not be transferred, make sure the actual MTU is higher than the MTU setting here: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/main/src/source/PeerConnection/Rtp.h#L12.
 
 You can also change settings such as buffer size, number of log files for rotation and log file path in the samples
 
@@ -588,13 +588,13 @@ Let us look into when each of these could be changed:
 4. `iceConnectionCheckPollingInterval`: This value is set to a default of 50 ms per [spec](https://datatracker.ietf.org/doc/html/rfc8445#section-14.2). Changing this would change the frequency of connectivity checks and essentially, the ICE state machine transitions. Decreasing the value could help in faster connection establishment in a reliable high performant network setting with good system resources. Increasing the value could help in reducing the network load, however, the connection establishment could slow down. Unless there is a strong reasoning, it is **NOT** recommended to deviate from spec/default.
 
 ## Documentation
-All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/master/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.
+All Public APIs are documented in our [Include.h](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/main/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h), we also generate a [Doxygen](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-c/) each commit for easier navigation.
 
 Refer to [related](#related) for more about WebRTC and KVS.
 
 ## Development
 
-If you would like to contribute to the development of this project, please base your pull requests off of the `origin/develop` branch, and to the `origin/develop` branch. Commits from `develop` will be merged into master periodically as a part of each release cycle.
+If you would like to contribute to the development of this project, please base your pull requests off of the `origin/develop` branch, and to the `origin/develop` branch. Commits from `develop` will be merged into main periodically as a part of each release cycle.
 
 ## Outbound hostname and port requirements
 * KVS endpoint : TCP 443 (ex: kinesisvideo.us-west-2.amazonaws.com)


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
* GitHub Actions CI configuration files
* README
* Contributing guide

*Why was it changed?*
* Because `master` branch is deprecated.

*How was it changed?*
* The branch target in the GitHub Actions CI configuration files were changed from `master` to `main`.
* The CI check for the version bump branch target was also changed from `master` to `main`.
* Links in the README were changed to target the `main` branch.
* Contributing guide references to `master` branch were changed to `main` branch.

*What testing was done for the changes?*
* Double check the spelling of the branch name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.