### PR TITLE
Add job to run the sample and check for memory leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
           make
       - name: Run tests
-        run:  |
+        run: |
           cd build
           ./tst/webrtc_client_test
   mac-os-build-gcc:
@@ -71,7 +71,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE -DCOMPILER_WARNINGS=TRUE
           make
       - name: Run tests
-        run:  |
+        run: |
           cd build
           ./tst/webrtc_client_test
   mac-os-m1-build-clang:
@@ -100,7 +100,7 @@ jobs:
           sh -c 'cmake .. -DBUILD_TEST=TRUE -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++'
           make
       - name: Run tests
-        run:  |
+        run: |
           cd build
           ./tst/webrtc_client_test
   static-build-mac:
@@ -124,7 +124,7 @@ jobs:
           cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
           make
       - name: Run tests
-        run:  |
+        run: |
           cd build
           ./tst/webrtc_client_test
   address-sanitizer:
@@ -160,7 +160,7 @@ jobs:
           make
           ulimit -c unlimited -S
       - name: Run tests
-        run:  |
+        run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
   undefined-behavior-sanitizer:
@@ -195,7 +195,7 @@ jobs:
           make
           ulimit -c unlimited -S
       - name: Run tests
-        run:  |
+        run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
   # memory-sanitizer:
@@ -250,7 +250,7 @@ jobs:
           make
           ulimit -c unlimited -S
       - name: Run tests
-        run:  |
+        run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
   linux-gcc-4_4:
@@ -288,7 +288,7 @@ jobs:
           make
           ulimit -c unlimited -S
       - name: Run tests
-        run:  |
+        run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
   static-build-linux:
@@ -348,7 +348,7 @@ jobs:
           make
           ulimit -c unlimited -S
       - name: Run tests
-        run:  |
+        run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
   mbedtls-ubuntu-gcc-11:
@@ -382,7 +382,7 @@ jobs:
           make
           ulimit -c unlimited -S
       - name: Run tests
-        run:  |
+        run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
 
@@ -448,7 +448,7 @@ jobs:
           make
           ulimit -c unlimited -S
       - name: Run tests
-        run:  |
+        run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
   sample-check:
@@ -530,7 +530,7 @@ jobs:
           cmake .. -DBUILD_TEST=TRUE
           make
       - name: Run tests
-        run:  |
+        run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
   windows-msvc-openssl:
@@ -668,3 +668,78 @@ jobs:
           mkdir build && cd build
           cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
           make
+
+  valgrind-check:
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 7
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install deps
+        run: |
+          sudo apt clean && sudo apt update
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
+          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
+          sudo apt-get -q update
+          sudo apt-get -y install libcurl4-openssl-dev valgrind
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run: |
+          cd build
+          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-master.txt ./samples/kvsWebrtcClientMaster demo-channel-gh-actions &
+          PID_MASTER=$!
+          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-viewer.txt ./samples/kvsWebrtcClientViewer demo-channel-gh-actions &
+          PID_VIEWER=$!
+          
+          # Wait for processes to run initially
+          sleep 30 # Wait 30s
+          
+          # Send SIGINT (2) to both processes
+          kill -2 $PID_VIEWER
+          sleep 30
+          
+          kill -2 $PID_MASTER
+          
+          # Start a background task to enforce a timeout for graceful shutdown
+          (
+            sleep 10
+            kill -9 $PID_MASTER 2>/dev/null
+            kill -9 $PID_VIEWER 2>/dev/null
+          ) &
+          
+          wait $PID_MASTER
+          EXIT_STATUS_MASTER=$?
+          wait $PID_VIEWER
+          EXIT_STATUS_VIEWER=$?
+          
+          # Check exit statuses to determine if the interrupt was successful
+          if [ $EXIT_STATUS_MASTER -ne 0 ] || [ $EXIT_STATUS_VIEWER -ne 0 ]; then
+            echo "Process did not exit gracefully."
+            exit 1
+          else
+            echo "Processes exited successfully."
+          fi
+          
+          # Check for memory leaks in Valgrind output files
+          if grep "All heap blocks were freed -- no leaks are possible" valgrind-master.txt && grep "All heap blocks were freed -- no leaks are possible" valgrind-viewer.txt; then
+            echo "No memory leaks detected."
+          else
+            echo "Memory leaks detected."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,6 +731,8 @@ jobs:
           # Check exit statuses to determine if the interrupt was successful
           if [ $EXIT_STATUS_MASTER -ne 0 ] || [ $EXIT_STATUS_VIEWER -ne 0 ]; then
             echo "Process did not exit gracefully."
+            echo "Master exit code: $EXIT_STATUS_MASTER"
+            echo "Viewer exit code: $EXIT_STATUS_VIEWER"
             exit 1
           else
             echo "Processes exited successfully."

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -781,7 +781,7 @@ CleanUp:
 STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE roleType, BOOL trickleIce, BOOL useTurn, UINT32 logLevel,
                                  PSampleConfiguration* ppSampleConfiguration)
 {
-    PVOID test = MALLOC(10000);  // Test memory leak
+    PVOID test = MEMALLOC(10000);  // Test memory leak
     STATUS retStatus = STATUS_SUCCESS;
     PCHAR pAccessKey, pSecretKey, pSessionToken;
     PSampleConfiguration pSampleConfiguration = NULL;

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -781,6 +781,7 @@ CleanUp:
 STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE roleType, BOOL trickleIce, BOOL useTurn, UINT32 logLevel,
                                  PSampleConfiguration* ppSampleConfiguration)
 {
+    PVOID test = MALLOC(10000);  // Test memory leak
     STATUS retStatus = STATUS_SUCCESS;
     PCHAR pAccessKey, pSecretKey, pSessionToken;
     PSampleConfiguration pSampleConfiguration = NULL;

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -781,7 +781,6 @@ CleanUp:
 STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE roleType, BOOL trickleIce, BOOL useTurn, UINT32 logLevel,
                                  PSampleConfiguration* ppSampleConfiguration)
 {
-    PVOID test = MEMALLOC(10000);  // Test memory leak
     STATUS retStatus = STATUS_SUCCESS;
     PCHAR pAccessKey, pSecretKey, pSessionToken;
     PSampleConfiguration pSampleConfiguration = NULL;


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
- GitHub actions CI. Run the master and viewer samples both with `valgrind `to check for memory leaks. Instead of kill with signal 9, it interrupts the process (signal 2) and also checks for graceful exit.

*Why was it changed?*
- Reduce the number of times I need to manually run this check. Automating this check will also give confidence to future developers that their change did not introduce a memory leak.

*How was it changed?*
- Script overview:
  - Disable logs by setting log level to 7 (silent).
  - Run the master and viewer samples in the background with valgrind. The valgrind output is captured into two different files, one for each.
  - After 30 seconds, interrupt the viewer (disconnect)
  - After 30 more seconds, interrupt the master.
  - Wait for processes to exit & capture their exit status.
  - After 10 seconds, kill the master and viewer processes. Killing the processes will make them exit with non-zero exit status.
  - Check if both exited with status 0 (whether they exit gracefully on their own after interrupt).
  - Check the valgrind output files and verify that no memory leaks are detected.

*What testing was done for the changes?*
- Run it on the GitHub actions runner. Take a look at the image: ![image](https://github.com/user-attachments/assets/0a972bbf-2320-4c49-9830-9c44fdffeda0)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
