### PR TITLE
Shorten Stats String Lengths

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1500,14 +1500,14 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit
  */
 typedef struct {
-    BOOL ordered;                                     //!< Decides the order in which data is sent. If true, data is sent in order
-    NullableUint16 maxPacketLifeTime;                 //!< Limits the time (in milliseconds) during which the channel will (re)transmit
-                                                      //!< data if not acknowledged. This value may be clamped if it exceeds the maximum
-                                                      //!< value supported by the user agent.
-    NullableUint16 maxRetransmits;                    //!< Control number of times a channel retransmits data if not delivered successfully
-    CHAR protocol[MAX_DATA_CHANNEL_PROTOCOL_LEN + 1]; //!< Sub protocol name for the channel
-    BOOL negotiated;                                  //!< If set to true, it is up to the application to negotiate the channel and create an
-                                                      //!< RTCDataChannel object with the same id as the other peer.
+    BOOL ordered;                           //!< Decides the order in which data is sent. If true, data is sent in order
+    NullableUint16 maxPacketLifeTime;       //!< Limits the time (in milliseconds) during which the channel will (re)transmit
+                                            //!< data if not acknowledged. This value may be clamped if it exceeds the maximum
+                                            //!< value supported by the user agent.
+    NullableUint16 maxRetransmits;          //!< Control number of times a channel retransmits data if not delivered successfully
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1]; //!< Sub protocol name for the channel
+    BOOL negotiated;                        //!< If set to true, it is up to the application to negotiate the channel and create an
+                                            //!< RTCDataChannel object with the same id as the other peer.
 } RtcDataChannelInit, *PRtcDataChannelInit;
 /*!@} */
 

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -461,11 +461,6 @@ extern "C" {
 #define MAX_SIGNALING_ENDPOINT_URI_LEN 512
 
 /**
- * Maximum allowed ICE URI length
- */
-#define MAX_ICE_CONFIG_URI_LEN 256
-
-/**
  * Maximum allowed correlation ID length
  */
 #define MAX_CORRELATION_ID_LEN 256

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1505,7 +1505,7 @@ typedef struct {
                                             //!< data if not acknowledged. This value may be clamped if it exceeds the maximum
                                             //!< value supported by the user agent.
     NullableUint16 maxRetransmits;          //!< Control number of times a channel retransmits data if not delivered successfully
-    CHAR protocol[MAX_PROTOCOL_LENGTH + 1]; //!< Sub protocol name for the channel
+    CHAR protocol[MAX_DATA_CHANNEL_PROTOCOL_LEN + 1]; //!< Sub protocol name for the channel
     BOOL negotiated;                        //!< If set to true, it is up to the application to negotiate the channel and create an
                                             //!< RTCDataChannel object with the same id as the other peer.
 } RtcDataChannelInit, *PRtcDataChannelInit;

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1500,14 +1500,14 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc/#dom-rtcdatachannelinit
  */
 typedef struct {
-    BOOL ordered;                           //!< Decides the order in which data is sent. If true, data is sent in order
-    NullableUint16 maxPacketLifeTime;       //!< Limits the time (in milliseconds) during which the channel will (re)transmit
-                                            //!< data if not acknowledged. This value may be clamped if it exceeds the maximum
-                                            //!< value supported by the user agent.
-    NullableUint16 maxRetransmits;          //!< Control number of times a channel retransmits data if not delivered successfully
+    BOOL ordered;                                     //!< Decides the order in which data is sent. If true, data is sent in order
+    NullableUint16 maxPacketLifeTime;                 //!< Limits the time (in milliseconds) during which the channel will (re)transmit
+                                                      //!< data if not acknowledged. This value may be clamped if it exceeds the maximum
+                                                      //!< value supported by the user agent.
+    NullableUint16 maxRetransmits;                    //!< Control number of times a channel retransmits data if not delivered successfully
     CHAR protocol[MAX_DATA_CHANNEL_PROTOCOL_LEN + 1]; //!< Sub protocol name for the channel
-    BOOL negotiated;                        //!< If set to true, it is up to the application to negotiate the channel and create an
-                                            //!< RTCDataChannel object with the same id as the other peer.
+    BOOL negotiated;                                  //!< If set to true, it is up to the application to negotiate the channel and create an
+                                                      //!< RTCDataChannel object with the same id as the other peer.
 } RtcDataChannelInit, *PRtcDataChannelInit;
 /*!@} */
 

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -73,7 +73,7 @@ extern "C" {
 /**
  * Maximum length of candidate type (host, srflx, relay, prflx, unknown)
  */
-#define MAX_CANDIDATE_TYPE_LENGTH 10U
+#define MAX_CANDIDATE_TYPE_LENGTH 7U
 /*!@} */
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -25,6 +25,11 @@ extern "C" {
 #define MAX_CANDIDATE_ID_LENGTH 9U
 
 /**
+ * Maximum allowed ICE URI length
+ */
+#define MAX_ICE_CONFIG_URI_LEN 256
+
+/**
  * Maximum allowed relay protocol length
  */
 #define MAX_RELAY_PROTOCOL_LENGTH 8U
@@ -63,6 +68,12 @@ extern "C" {
  * Maximum allowed generic length used in DOMString
  */
 #define MAX_STATS_STRING_LENGTH 255U
+/*!@} */
+
+/**
+ * Maximum length of candidate type (host, srflx, relay, prflx, unknown)
+ */
+#define MAX_CANDIDATE_TYPE_LENGTH 10U
 /*!@} */
 
 /**
@@ -233,8 +244,8 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc-stats/#ice-server-dict*
  */
 typedef struct {
-    DOMString url;                 //!< STUN/TURN server URL
-    DOMString protocol;            //!< Valid values: UDP, TCP
+    CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];                 //!< STUN/TURN server URL
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];            //!< Valid values: UDP, TCP
     UINT32 iceServerIndex;         //!< Ice server index to get stats from. Not available in spec! Needs to be
                                    //!< populated by the application to get specific server stats
     INT32 port;                    //!< Port number used by client
@@ -268,14 +279,13 @@ typedef struct {
 
 typedef struct {
     DOMString url;                        //!< For local candidates this is the URL of the ICE server from which the candidate was obtained
-    DOMString transportId;                //!< Not used currently. ID of object that was inspected for RTCTransportStats
     CHAR address[IP_ADDR_STR_LENGTH + 1]; //!< IPv4 or IPv6 address of the candidate
-    DOMString protocol;                   //!< Valid values: UDP, TCP
-    DOMString relayProtocol;              //!< Protocol used by endpoint to communicate with TURN server. (Only for local candidate)
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];                   //!< Valid values: UDP, TCP
+    CHAR relayProtocol[MAX_PROTOCOL_LENGTH + 1];              //!< Protocol used by endpoint to communicate with TURN server. (Only for local candidate)
                                           //!< Valid values: UDP, TCP, TLS
     INT32 priority;                       //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
     INT32 port;                           //!< Port number of the candidate
-    DOMString candidateType;              //!< Type of local/remote ICE candidate
+    CHAR candidateType[MAX_CANDIDATE_TYPE_LENGTH + 1]; //!< Type of local/remote ICE candidate
 } RtcIceCandidateStats, *PRtcIceCandidateStats;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -27,7 +27,7 @@ extern "C" {
 /**
  * Maximum allowed ICE URI length
  */
-#define MAX_ICE_CONFIG_URI_LEN 256
+#define MAX_ICE_CONFIG_URI_LEN 127
 
 /**
  * Maximum allowed relay protocol length
@@ -57,7 +57,7 @@ extern "C" {
 /**
  * Maximum allowed maximum protocol length (allowed values: tcp, udp)
  */
-#define MAX_PROTOCOL_LENGTH 8U
+#define MAX_PROTOCOL_LENGTH 7U
 
 /**
  * Maximum allowed length of IP address string
@@ -244,14 +244,14 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc-stats/#ice-server-dict*
  */
 typedef struct {
-    CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];                 //!< STUN/TURN server URL
-    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];            //!< Valid values: UDP, TCP
-    UINT32 iceServerIndex;         //!< Ice server index to get stats from. Not available in spec! Needs to be
-                                   //!< populated by the application to get specific server stats
-    INT32 port;                    //!< Port number used by client
-    UINT64 totalRequestsSent;      //!< Total amount of requests that have been sent to the server
-    UINT64 totalResponsesReceived; //!< Total number of responses received from the server
-    UINT64 totalRoundTripTime;     //!< Sum of RTTs of all the requests for which response has been received
+    CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];   //!< STUN/TURN server URL
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1]; //!< Valid values: UDP, TCP
+    UINT32 iceServerIndex;                  //!< Ice server index to get stats from. Not available in spec! Needs to be
+                                            //!< populated by the application to get specific server stats
+    INT32 port;                             //!< Port number used by client
+    UINT64 totalRequestsSent;               //!< Total amount of requests that have been sent to the server
+    UINT64 totalResponsesReceived;          //!< Total number of responses received from the server
+    UINT64 totalRoundTripTime;              //!< Sum of RTTs of all the requests for which response has been received
 } RtcIceServerStats, *PRtcIceServerStats;
 
 /**
@@ -278,13 +278,13 @@ typedef struct {
  */
 
 typedef struct {
-    DOMString url;                        //!< For local candidates this is the URL of the ICE server from which the candidate was obtained
-    CHAR address[IP_ADDR_STR_LENGTH + 1]; //!< IPv4 or IPv6 address of the candidate
-    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];                   //!< Valid values: UDP, TCP
-    CHAR relayProtocol[MAX_PROTOCOL_LENGTH + 1];              //!< Protocol used by endpoint to communicate with TURN server. (Only for local candidate)
-                                          //!< Valid values: UDP, TCP, TLS
-    INT32 priority;                       //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
-    INT32 port;                           //!< Port number of the candidate
+    DOMString url;                               //!< For local candidates this is the URL of the ICE server from which the candidate was obtained
+    CHAR address[IP_ADDR_STR_LENGTH + 1];        //!< IPv4 or IPv6 address of the candidate
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];      //!< Valid values: UDP, TCP
+    CHAR relayProtocol[MAX_PROTOCOL_LENGTH + 1]; //!< Protocol used by endpoint to communicate with TURN server. (Only for local candidate)
+                                                 //!< Valid values: UDP, TCP, TLS
+    INT32 priority;                              //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
+    INT32 port;                                  //!< Port number of the candidate
     CHAR candidateType[MAX_CANDIDATE_TYPE_LENGTH + 1]; //!< Type of local/remote ICE candidate
 } RtcIceCandidateStats, *PRtcIceCandidateStats;
 

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -80,7 +80,7 @@ typedef struct __IceAgent* PIceAgent;
  * Internal structure tracking ICE server parameters for diagnostics and metrics/stats
  */
 typedef struct {
-    CHAR url[MAX_STATS_STRING_LENGTH + 1];  //!< STUN/TURN server URL
+    CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];   //!< STUN/TURN server URL
     CHAR protocol[MAX_PROTOCOL_LENGTH + 1]; //!< Valid values: UDP, TCP
     INT32 port;                             //!< Port number used by client
     UINT64 totalRequestsSent;               //!< Total amount of requests that have been sent to the server
@@ -89,7 +89,7 @@ typedef struct {
 } RtcIceServerDiagnostics, *PRtcIceServerDiagnostics;
 
 typedef struct {
-    DOMString url;                                  //!< For local candidates this is the URL of the ICE server from which the candidate was obtained
+    CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];           //!< For local candidates this is the URL of the ICE server from which the candidate was obtained
     CHAR address[KVS_IP_ADDRESS_STRING_BUFFER_LEN]; //!< IPv4 or IPv6 address of the candidate
     CHAR protocol[MAX_PROTOCOL_LENGTH + 1];         //!< Valid values: UDP, TCP
     CHAR relayProtocol[MAX_PROTOCOL_LENGTH + 1];    //!< Protocol used by endpoint to communicate with TURN server.

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -90,14 +90,13 @@ typedef struct {
 
 typedef struct {
     DOMString url; //!< For local candidates this is the URL of the ICE server from which the candidate was obtained
-    DOMString transportId[MAX_STATS_STRING_LENGTH + 1]; //!< ID of object that was inspected for RTCTransportStats
     CHAR address[KVS_IP_ADDRESS_STRING_BUFFER_LEN];     //!< IPv4 or IPv6 address of the candidate
-    DOMString protocol;                                 //!< Valid values: UDP, TCP
-    DOMString relayProtocol;                            //!< Protocol used by endpoint to communicate with TURN server.
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];                                 //!< Valid values: UDP, TCP
+    CHAR relayProtocol[MAX_PROTOCOL_LENGTH + 1];                            //!< Protocol used by endpoint to communicate with TURN server.
                                                         //!< Valid values: UDP, TCP, TLS
     INT32 priority;                                     //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
     INT32 port;                                         //!< Port number of the candidate
-    DOMString candidateType;                            //!< Type of local/remote ICE candidate
+    CHAR candidateType[MAX_CANDIDATE_TYPE_LENGTH + 1]                            //!< Type of local/remote ICE candidate
 } RtcIceCandidateDiagnostics, *PRtcIceCandidateDiagnostics;
 
 typedef struct {

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -80,23 +80,23 @@ typedef struct __IceAgent* PIceAgent;
  * Internal structure tracking ICE server parameters for diagnostics and metrics/stats
  */
 typedef struct {
-    CHAR url[MAX_STATS_STRING_LENGTH + 1];      //!< STUN/TURN server URL
-    CHAR protocol[MAX_STATS_STRING_LENGTH + 1]; //!< Valid values: UDP, TCP
-    INT32 port;                                 //!< Port number used by client
-    UINT64 totalRequestsSent;                   //!< Total amount of requests that have been sent to the server
-    UINT64 totalResponsesReceived;              //!< Total number of responses received from the server
-    UINT64 totalRoundTripTime;                  //!< Sum of RTTs of all the requests for which response has been received
+    CHAR url[MAX_STATS_STRING_LENGTH + 1];  //!< STUN/TURN server URL
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1]; //!< Valid values: UDP, TCP
+    INT32 port;                             //!< Port number used by client
+    UINT64 totalRequestsSent;               //!< Total amount of requests that have been sent to the server
+    UINT64 totalResponsesReceived;          //!< Total number of responses received from the server
+    UINT64 totalRoundTripTime;              //!< Sum of RTTs of all the requests for which response has been received
 } RtcIceServerDiagnostics, *PRtcIceServerDiagnostics;
 
 typedef struct {
-    DOMString url; //!< For local candidates this is the URL of the ICE server from which the candidate was obtained
-    CHAR address[KVS_IP_ADDRESS_STRING_BUFFER_LEN];     //!< IPv4 or IPv6 address of the candidate
-    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];                                 //!< Valid values: UDP, TCP
-    CHAR relayProtocol[MAX_PROTOCOL_LENGTH + 1];                            //!< Protocol used by endpoint to communicate with TURN server.
-                                                        //!< Valid values: UDP, TCP, TLS
-    INT32 priority;                                     //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
-    INT32 port;                                         //!< Port number of the candidate
-    CHAR candidateType[MAX_CANDIDATE_TYPE_LENGTH + 1];                            //!< Type of local/remote ICE candidate
+    DOMString url;                                  //!< For local candidates this is the URL of the ICE server from which the candidate was obtained
+    CHAR address[KVS_IP_ADDRESS_STRING_BUFFER_LEN]; //!< IPv4 or IPv6 address of the candidate
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];         //!< Valid values: UDP, TCP
+    CHAR relayProtocol[MAX_PROTOCOL_LENGTH + 1];    //!< Protocol used by endpoint to communicate with TURN server.
+                                                    //!< Valid values: UDP, TCP, TLS
+    INT32 priority;                                 //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
+    INT32 port;                                     //!< Port number of the candidate
+    CHAR candidateType[MAX_CANDIDATE_TYPE_LENGTH + 1]; //!< Type of local/remote ICE candidate
 } RtcIceCandidateDiagnostics, *PRtcIceCandidateDiagnostics;
 
 typedef struct {

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -96,7 +96,7 @@ typedef struct {
                                                         //!< Valid values: UDP, TCP, TLS
     INT32 priority;                                     //!< Computed using the formula in https://tools.ietf.org/html/rfc5245#section-15.1
     INT32 port;                                         //!< Port number of the candidate
-    CHAR candidateType[MAX_CANDIDATE_TYPE_LENGTH + 1]                            //!< Type of local/remote ICE candidate
+    CHAR candidateType[MAX_CANDIDATE_TYPE_LENGTH + 1];                            //!< Type of local/remote ICE candidate
 } RtcIceCandidateDiagnostics, *PRtcIceCandidateDiagnostics;
 
 typedef struct {


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
* Brought it string member length changes from the https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/1947 memory optimization PR.
* Further reduced the length of some members.

*Why was it changed?*
* To reduce excess memory allocated through `char[length]`.

*How was it changed?*
* Copying the relevant changes from the above PR and adding additional improvements.

*What testing was done for the changes?*
* Allowing for CI to pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
