### PR TITLE
SDP Attribute Fixes

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -680,19 +680,11 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 rtcp-fb nack value could not be written");
         attributeCount++;
+        
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-fb");
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack pli", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 rtcp-fb nack-pli value could not be written");
-        attributeCount++;
-
-        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-fb");
-        SPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "%" PRId64 " nack", payloadType);
-        SPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "%" PRId64 " nack pli", payloadType);
-        attributeCount++;
-
-        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-fb");
-        SPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "%" PRId64 " nack", payloadType);
-        SPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "%" PRId64 " nack pli", payloadType);
         attributeCount++;
 
         // TODO: If level asymmetry is allowed, consider sending back DEFAULT_H264_FMTP instead of the received fmtp value.
@@ -789,6 +781,8 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H265 rtcp-fb nack value could not be written");
         attributeCount++;
+
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-fb");
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack pli", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H265 rtcp-fb nack-pli value could not be written");

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -680,7 +680,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 rtcp-fb nack value could not be written");
         attributeCount++;
-        
+
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-fb");
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack pli", payloadType);

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -679,6 +679,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 rtcp-fb nack value could not be written");
+        attributeCount++;
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack pli", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 rtcp-fb nack-pli value could not be written");
@@ -787,6 +788,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H265 rtcp-fb nack value could not be written");
+        attributeCount++;
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " nack pli", payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H265 rtcp-fb nack-pli value could not be written");

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -12,6 +12,11 @@ namespace video {
 namespace webrtcclient {
 
 class SdpApiTest : public WebRtcClientTestBase {
+  public:
+    const std::string m_rtcp_h264_nack_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H264) + " nack";
+    const std::string m_rtcp_h264_nack_pli_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H264) + " nack pli";
+    const std::string m_rtcp_h265_nack_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H265) + " nack";
+    const std::string m_rtcp_h265_nack_pli_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H265) + " nack pli";
 };
 
 /*
@@ -352,6 +357,13 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendRecv)
     EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendrecv", sessionDescriptionInit.sdp);
 
+    std::string offerSdp(sessionDescriptionInit.sdp);
+
+    // check nack and nack pli lines
+    std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h264_nack_line);
+    std::string::size_type posPliNack = offerSdp.find(m_rtcp_h264_nack_pli_line);
+    EXPECT_NE(posPliOnly, posPliNack);
+
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);
 }
@@ -422,6 +434,13 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly)
     EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendonly", sessionDescriptionInit.sdp);
 
+    std::string offerSdp(sessionDescriptionInit.sdp);
+
+    // check nack and nack pli lines
+    std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h264_nack_line);
+    std::string::size_type posPliNack = offerSdp.find(m_rtcp_h264_nack_pli_line);
+    EXPECT_NE(posPliOnly, posPliNack);
+
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);
 }
@@ -452,6 +471,13 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly_H265)
     EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
     EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "sendonly", sessionDescriptionInit.sdp);
+
+    std::string offerSdp(sessionDescriptionInit.sdp);
+
+    // check nack and nack pli lines
+    std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h265_nack_line);
+    std::string::size_type posPliNack = offerSdp.find(m_rtcp_h265_nack_pli_line);
+    EXPECT_NE(posPliOnly, posPliNack);
 
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -13,10 +13,10 @@ namespace webrtcclient {
 
 class SdpApiTest : public WebRtcClientTestBase {
   public:
-    const std::string m_rtcp_h264_nack_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H264) + " nack";
-    const std::string m_rtcp_h264_nack_pli_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H264) + " nack pli";
-    const std::string m_rtcp_h265_nack_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H265) + " nack";
-    const std::string m_rtcp_h265_nack_pli_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H265) + " nack pli";
+    const std::string m_rtcp_h264_nack_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H264) + " nack" + SDP_LINE_SEPARATOR;
+    const std::string m_rtcp_h264_nack_pli_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H264) + " nack pli" + SDP_LINE_SEPARATOR;
+    const std::string m_rtcp_h265_nack_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H265) + " nack" + SDP_LINE_SEPARATOR;
+    const std::string m_rtcp_h265_nack_pli_line = "a=rtcp-fb:" + std::to_string(DEFAULT_PAYLOAD_H265) + " nack pli" + SDP_LINE_SEPARATOR;
 };
 
 /*
@@ -363,6 +363,8 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendRecv)
     std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h264_nack_line);
     std::string::size_type posPliNack = offerSdp.find(m_rtcp_h264_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);
+    EXPECT_NE(posPliOnly, std::string::npos);
+    EXPECT_NE(posPliNack, std::string::npos);
 
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);
@@ -440,6 +442,8 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly)
     std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h264_nack_line);
     std::string::size_type posPliNack = offerSdp.find(m_rtcp_h264_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);
+    EXPECT_NE(posPliOnly, std::string::npos);
+    EXPECT_NE(posPliNack, std::string::npos);
 
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);
@@ -478,6 +482,8 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly_H265)
     std::string::size_type posPliOnly = offerSdp.find(m_rtcp_h265_nack_line);
     std::string::size_type posPliNack = offerSdp.find(m_rtcp_h265_nack_pli_line);
     EXPECT_NE(posPliOnly, posPliNack);
+    EXPECT_NE(posPliOnly, std::string::npos);
+    EXPECT_NE(posPliNack, std::string::npos);
 
     closePeerConnection(offerPc);
     freePeerConnection(&offerPc);


### PR DESCRIPTION
Original PR:
* #2035

*Issue #, if available:*

*What was changed?*
(in addition to original PR changes)
* Removed the duplication of the `nack pli` attribute for h.264.
* Added the `rtcp-fb` attribute name for h.265.
* Added the following to the unit tests:
  * `nack pli` and `nack` attribute lines used to validate SDP now end with an `SDP_LINE_SEPARATOR` ("\r\n") to consider that one of the lines might be a substring of another.
  * Validate that both the `nack pli` and `nack` lines are present in the SDP. Previously, the test passed if one of them was missing.

*Why was it changed?*
To correct the above issues and properly test that `nack pli` and `nack` feedback attributes are set in the SDP.

*How was it changed?*
By making the appropriate SDP changes and accounting for missed cases in the tests.

*What testing was done for the changes?*
* Test passed locally.
* CI to pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
