### PR TITLE
Samples: Fit the RTP transceiver rolling buffers to fit the set of sample frames

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -533,7 +533,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
                               &pSampleStreamingSession->pVideoRtcRtpTransceiver));
 
     CHK_STATUS(configureTransceiverRollingBuffer(pSampleStreamingSession->pVideoRtcRtpTransceiver, &videoTrack,
-                                      pSampleConfiguration->videoRollingBufferDurationSec, pSampleConfiguration->videoRollingBufferBitratebps));
+                                                 pSampleConfiguration->videoRollingBufferDurationSec,
+                                                 pSampleConfiguration->videoRollingBufferBitratebps));
 
     CHK_STATUS(transceiverOnBandwidthEstimation(pSampleStreamingSession->pVideoRtcRtpTransceiver, (UINT64) pSampleStreamingSession,
                                                 sampleBandwidthEstimationHandler));
@@ -548,7 +549,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
                               &pSampleStreamingSession->pAudioRtcRtpTransceiver));
 
     CHK_STATUS(configureTransceiverRollingBuffer(pSampleStreamingSession->pAudioRtcRtpTransceiver, &audioTrack,
-                                      pSampleConfiguration->audioRollingBufferDurationSec, pSampleConfiguration->audioRollingBufferBitratebps));
+                                                 pSampleConfiguration->audioRollingBufferDurationSec,
+                                                 pSampleConfiguration->audioRollingBufferBitratebps));
 
     CHK_STATUS(transceiverOnBandwidthEstimation(pSampleStreamingSession->pAudioRtcRtpTransceiver, (UINT64) pSampleStreamingSession,
                                                 sampleBandwidthEstimationHandler));

--- a/samples/Common.c
+++ b/samples/Common.c
@@ -532,6 +532,9 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &videoTrack, &videoRtpTransceiverInit,
                               &pSampleStreamingSession->pVideoRtcRtpTransceiver));
 
+    CHK_STATUS(configureTransceiverRollingBuffer(pSampleStreamingSession->pVideoRtcRtpTransceiver, &videoTrack,
+                                      pSampleConfiguration->videoRollingBufferDurationSec, pSampleConfiguration->videoRollingBufferBitratebps));
+
     CHK_STATUS(transceiverOnBandwidthEstimation(pSampleStreamingSession->pVideoRtcRtpTransceiver, (UINT64) pSampleStreamingSession,
                                                 sampleBandwidthEstimationHandler));
 
@@ -543,6 +546,9 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
     STRCPY(audioTrack.trackId, "myAudioTrack");
     CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &audioTrack, &audioRtpTransceiverInit,
                               &pSampleStreamingSession->pAudioRtcRtpTransceiver));
+
+    CHK_STATUS(configureTransceiverRollingBuffer(pSampleStreamingSession->pAudioRtcRtpTransceiver, &audioTrack,
+                                      pSampleConfiguration->audioRollingBufferDurationSec, pSampleConfiguration->audioRollingBufferBitratebps));
 
     CHK_STATUS(transceiverOnBandwidthEstimation(pSampleStreamingSession->pAudioRtcRtpTransceiver, (UINT64) pSampleStreamingSession,
                                                 sampleBandwidthEstimationHandler));

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -128,6 +128,10 @@ typedef struct {
     SIGNALING_CLIENT_HANDLE signalingClientHandle;
     RTC_CODEC audioCodec;
     RTC_CODEC videoCodec;
+    DOUBLE videoRollingBufferDurationSec;
+    DOUBLE videoRollingBufferBitratebps;
+    DOUBLE audioRollingBufferDurationSec;
+    DOUBLE audioRollingBufferBitratebps;
     PBYTE pAudioFrameBuffer;
     UINT32 audioBufferSize;
     PBYTE pVideoFrameBuffer;

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -50,6 +50,20 @@ INT32 main(INT32 argc, CHAR* argv[])
     pSampleConfiguration->audioCodec = audioCodec;
     pSampleConfiguration->videoCodec = videoCodec;
 
+    // Configure the RTP rolling buffer sizes for the set of pre-canned sample frames (add a bit extra for padding)
+    if (pSampleConfiguration->videoCodec == RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE) {
+        pSampleConfiguration->videoRollingBufferDurationSec = 3;
+        pSampleConfiguration->videoRollingBufferBitratebps = 1.4 * 1024 * 1024;
+    } else if (pSampleConfiguration->videoCodec == RTC_CODEC_H265) {
+        pSampleConfiguration->videoRollingBufferDurationSec = 3;
+        pSampleConfiguration->videoRollingBufferBitratebps = 462 * 1024;
+    }
+
+    if (pSampleConfiguration->audioCodec == RTC_CODEC_OPUS) {
+        pSampleConfiguration->audioRollingBufferDurationSec = 3;
+        pSampleConfiguration->audioRollingBufferBitratebps = 512 * 1024;
+    }
+
     if (argc > 2 && STRNCMP(argv[2], "1", 2) == 0) {
         pSampleConfiguration->channelInfo.useMediaStorage = TRUE;
     }

--- a/samples/kvsWebRTCClientMaster.c
+++ b/samples/kvsWebRTCClientMaster.c
@@ -50,7 +50,8 @@ INT32 main(INT32 argc, CHAR* argv[])
     pSampleConfiguration->audioCodec = audioCodec;
     pSampleConfiguration->videoCodec = videoCodec;
 
-    // Configure the RTP rolling buffer sizes for the set of pre-canned sample frames (add a bit extra for padding)
+    // Configure the RTP rolling buffer sizes for the set of sample frames
+    // to be smaller than the default settings (plus some extra for padding).
     if (pSampleConfiguration->videoCodec == RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE) {
         pSampleConfiguration->videoRollingBufferDurationSec = 3;
         pSampleConfiguration->videoRollingBufferBitratebps = 1.4 * 1024 * 1024;


### PR DESCRIPTION
*Issue #, if available:*
-N/A

*What was changed?*
- Rolling buffer configuration for audio and video streams in the sample Master WebRTC client application was updated to better fit the pre-canned sample frames.
- This uses the new optional configuration API introduced in #2077.

*Why was it changed?*
- Reduce the memory usage of the sample application. The default rolling buffers are too big, causing extra RTP packets to get stored for the retransmitter (nacks) that the other peer would have considered too old to get retransmitted.

*How was it changed?*
- Reduced the bitrate in the rolling buffer parameter for the sample frames.
- Added calls to configure transceiver rolling buffers with the new parameters, for audio and video separately.

*What testing was done for the changes?*
- Ran the updated master sample Ingenic T31, M1 Mac and Ubuntu EC2 and checked the playback (past 3 seconds when the rolling buffer fills up) with the [JS](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html) and to check for regressions.
- Added some print statements when the rolling buffer fills up (not committed) to confirm it takes longer than 3 seconds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
