### PR TITLE
Add MIPS32 cross compilation, refactor existing cross-compilation jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,60 +612,6 @@ jobs:
   #         cd D:\a\webrtc
   #         git config --system core.longpaths true
   #         .github\build_windows_mbedtls.bat
-  arm64-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: aarch64-linux-gnu-gcc
-      CXX: aarch64-linux-gnu-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
-          make
-  linux-aarch64-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: aarch64-linux-gnu-gcc
-      CXX: aarch64-linux-gnu-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
-          make
-  arm32-cross-compilation:
-    runs-on: ubuntu-20.04
-    env:
-      CC: arm-linux-gnueabi-gcc
-      CXX: arm-linux-gnueabi-g++
-    steps:
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Build Repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_OPENSSL=TRUE -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
-          make
 
   stack-size-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             export CC="clang"
             export CXX="clang++"
           fi
-          echo "Using $CC and $CXX"
+          echo "Using CC: $CC and CXX: $CXX"
           
           mkdir -p build
           cd build

--- a/.github/workflows/cross-compilation.yml
+++ b/.github/workflows/cross-compilation.yml
@@ -1,0 +1,104 @@
+name: WebRTC C SDK Cross Compilation
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+jobs:
+  linux-cross-compilation:
+    strategy:
+      matrix:
+        compiler:
+          - name: mips-32
+            runner: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+            install: gcc-mips-linux-gnu g++-mips-linux-gnu
+            cc: mips-linux-gnu-gcc
+            cxx: mips-linux-gnu-g++
+            cmake_flags: -DBUILD_OPENSSL_PLATFORM=linux-mips32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=mips-unknown-linux-gnu
+            file-expected-output: "ELF 32-bit MSB executable, MIPS, MIPS32"
+          - name: arm-32
+            runner: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+            install: gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+            cc: arm-linux-gnueabihf-gcc
+            cxx: arm-linux-gnueabihf-g++
+            cmake_flags: -DBUILD_OPENSSL_PLATFORM=linux-generic32 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+            file-expected-output: "ELF 32-bit LSB pie executable, ARM"
+          - name: arm-64
+            runner: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+            install: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+            cc: aarch64-linux-gnu-gcc
+            cxx: aarch64-linux-gnu-g++
+            cmake_flags: -DBUILD_OPENSSL_PLATFORM=linux-generic64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+            file-expected-output: "ELF 64-bit LSB pie executable, ARM"
+          - name: aarch-64
+            runner: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+            install: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+            cc: aarch64-linux-gnu-gcc
+            cxx: aarch64-linux-gnu-g++
+            cmake_flags: -DBUILD_OPENSSL_PLATFORM=linux-aarch64 -DBUILD_LIBSRTP_HOST_PLATFORM=x86_64-unknown-linux-gnu -DBUILD_LIBSRTP_DESTINATION_PLATFORM=arm-unknown-linux-uclibcgnueabi
+            file-expected-output: "ELF 64-bit LSB pie executable, ARM"
+
+        build-type:
+          - name: Shared
+            cmake_flags: -DBUILD_STATIC_LIBS=OFF
+          - name: Static
+            cmake_flags: -DBUILD_STATIC_LIBS=ON
+
+        crypto:
+          - name: OpenSSL
+            cmake_flags: -DUSE_OPENSSL=ON -DUSE_MBEDTLS=OFF
+          - name: MbedTLS
+            cmake_flags: -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+
+        threadpool:
+          - name: Threadpool On
+            cmake_flags: -DENABLE_KVS_THREADPOOL=ON
+          - name: Threadpool Off
+            cmake_flags: -DENABLE_KVS_THREADPOOL=OFF
+
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container:
+      image:  ${{ matrix.compiler.runner }}
+    name: ${{ matrix.compiler.name }}, ${{ matrix.build-type.name }}, ${{ matrix.crypto.name }}, ${{ matrix.threadpool.name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y build-essential cmake git pkg-config file ${{ matrix.compiler.install }}
+      - name: Configure and build ${{ matrix.compiler.name }}, ${{ matrix.build-type.name }}, ${{ matrix.crypto.name }}, ${{ matrix.threadpool.name }}
+        run: |
+          export CC=${{ matrix.compiler.cc }}
+          export CXX=${{ matrix.compiler.cxx }}
+          echo "Using $CC and $CXX"
+          
+          mkdir -p build
+          cd build
+          
+          cmake .. -DBUILD_TEST=ON \
+            -DENABLE_AWS_SDK_IN_TESTS=OFF \
+            ${{ matrix.build-type.cmake_flags }} \
+            ${{ matrix.crypto.cmake_flags }} \
+            ${{ matrix.compiler.cmake_flags }} \
+            ${{ matrix.threadpool.cmake_flags }}
+          make -j$(sysctl -n hw.ncpu)
+        shell: bash
+      - name: Check test file is compiled correctly
+        run: |
+          cd build
+          
+          file ./tst/webrtc_client_test
+          file ./samples/kvsWebrtcClientMaster
+          
+          readelf -a ./tst/webrtc_client_test
+          readelf -a ./samples/kvsWebrtcClientMaster
+          
+          file ./tst/webrtc_client_test | grep "${{ matrix.compiler.file-expected-output }}"
+          file ./samples/kvsWebrtcClientMaster | grep "${{ matrix.compiler.file-expected-output }}"
+        shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,7 +493,7 @@ endif()
 
 if(BUILD_TEST)
   # adding ZLIB because aws sdk static link seems to be broken when zlib is needed
-  if(NOT WIN32)
+  if(NOT WIN32 AND ENABLE_AWS_SDK_IN_TESTS)
     find_package(ZLIB REQUIRED)
   endif()
   add_subdirectory(tst)


### PR DESCRIPTION
*Issue #, if available:* N/A

*What was changed?*
- Updated the GitHub Actions CI configuration to include cross-compilation for `mips-32`, `arm-32`, `arm-64`, and `aarch-64` targets, using the `public.ecr.aws/ubuntu/ubuntu:22.04_stable` Docker image for each cross-compilation environment.
- Removed previous individual cross-compilation jobs for arm64, linux-aarch64, and arm32, consolidating the builds into a unified matrix approach.

*Why was it changed?*
- Using the docker images should stop the builds from breaking randomly due to updates to GitHub actions runner images.
- Enable cross-compilation for additional architectures (`mips-32`) in the CI pipeline while ensuring a cleaner, more maintainable configuration.
- Removed redundant individual job definitions (`arm-32`, `arm-64`, `aarch-64`) and consolidated them into the matrix strategy to streamline the CI process.

*How was it changed?*
- Added new cross-compilation matrix in the CI configuration.
- For each architecture, defined specific cross-compilation toolchains, install dependencies, and adjusted flags to match the respective target platform (e.g., OpenSSL or MbedTLS).
- Integrated the `public.ecr.aws/ubuntu/ubuntu:22.04_stable` Docker image for containerized cross-compilation.
- Use `file-expected-output` parameter for each architecture to correctly match the generated output file.

*What testing was done for the changes?*
- Ran the new job on a fork of the repository and these changes succeed there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
