### PR TITLE
Specify `configureTransceiverRollingBuffer` as a Public API

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1620,7 +1620,7 @@ typedef struct {
  *
  * @return STATUS code of the execution. STATUS_SUCCESS on success
  */
-STATUS configureTransceiverRollingBuffer(PRtcRtpTransceiver, PRtcMediaStreamTrack, DOUBLE, DOUBLE);
+PUBLIC_API STATUS configureTransceiverRollingBuffer(PRtcRtpTransceiver, PRtcMediaStreamTrack, DOUBLE, DOUBLE);
 
 /**
  * @brief Initialize a RtcPeerConnection with the provided Configuration


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
Added the PUBLIC_API attribute to the new `configureTransceiverRollingBuffer` API.

*Why was it changed?*
To show `configureTransceiverRollingBuffer` as a public API in library documentation.

*How was it changed?*
By adding `PUBLIC_API` before the `configureTransceiverRollingBuffer` declaration in the webrtcclient include header file.

*What testing was done for the changes?*
Allowing for the CI to pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
