### PR TITLE
Add data channel option to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ You can pass the following options to `cmake ..`:
 
 * `-DBUILD_SAMPLE` -- Build the sample executables. ON by default.
 * `-DIOT_CORE_ENABLE_CREDENTIALS` -- Build the sample applications using IoT credentials. OFF by default.
+* `-DENABLE_DATA_CHANNEL` -- Build SDK & Samples with data channel. ON by default.
 * `-DBUILD_STATIC_LIBS` -- Build all KVS WebRTC and third-party libraries as static libraries. Default: OFF (shared build).
 * `-DADD_MUCLIBC`  -- Add -muclibc c flag
 * `-DBUILD_DEPENDENCIES` -- Whether or not to build depending libraries from source

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You can pass the following options to `cmake ..`:
 
 * `-DBUILD_SAMPLE` -- Build the sample executables. ON by default.
 * `-DIOT_CORE_ENABLE_CREDENTIALS` -- Build the sample applications using IoT credentials. OFF by default.
-* `-DENABLE_DATA_CHANNEL` -- Build SDK & Samples with data channel. ON by default.
+* `-DENABLE_DATA_CHANNEL` -- Build SDK & samples with data channel. ON by default.
 * `-DBUILD_STATIC_LIBS` -- Build all KVS WebRTC and third-party libraries as static libraries. Default: OFF (shared build).
 * `-DADD_MUCLIBC`  -- Add -muclibc c flag
 * `-DBUILD_DEPENDENCIES` -- Whether or not to build depending libraries from source


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- The readme was updated to have the data channel compile-time configuration.

*Why was it changed?*
- I noticed that it was missing when browsing the code.
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/v1.12.0/CMakeLists.txt#L20

*How was it changed?*
- Added to the readme.

*What testing was done for the changes?*
- Build it locally with this option set to OFF.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
