### PR TITLE
Fix: Twcc wraparound uint16 promotion case

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1909,7 +1909,7 @@ static STATUS twccRollingWindowDeletion(PKvsPeerConnection pKvsPeerConnection, P
         }
         // reset before next iteration
         tempTwccRtpPktInfo = NULL;
-    } while (!isCheckComplete && updatedSeqNum != (endingSeqNum + 1));
+    } while (!isCheckComplete && updatedSeqNum != (UINT16) (endingSeqNum + 1));
 
     // Update regardless. The loop checks until current RTP packets seq number irrespective of the failure
     pKvsPeerConnection->pTwccManager->firstSeqNumInRollingWindow = updatedSeqNum;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -344,7 +344,7 @@ STATUS updateTwccHashTable(PTwccManager pTwccManager, PINT64 duration, PUINT64 r
     // We also check for twcc->lastReportedSeqNum + 1 to include the last seq number in the
     // report. Without this, we do not check for the seqNum that could cause it to not be cleared
     // from memory
-    for (seqNum = baseSeqNum; seqNum != (pTwccManager->lastReportedSeqNum + 1); seqNum++) {
+    for (seqNum = baseSeqNum; seqNum != (UINT16) (pTwccManager->lastReportedSeqNum + 1); seqNum++) {
         if (!localStartTimeRecorded) {
             // This could happen if the prev packet was deleted as part of rolling window or if there
             // is an overlap of RTP packet statuses between TWCC packets. This could also fail if it is


### PR DESCRIPTION
*Issue #, if available:*
- #2100

*What was changed?*
- `PeerConnection.c`: Added type casting to prevent integer promotion issues when handling sequence number wraparound in the twccRollingWindowDeletion function.
- `Rtcp.c`: Added type casting to prevent integer promotion issues when handling sequence number wraparound in the updateTwccHashTable function.
- `RtcpFunctionalityTest.cpp`: Added a new test case to validate the behavior of sequence number handling when integer promotion occurs due to UINT16_MAX.

*Why was it changed?*
- Integer promotion issue was identified in the handling of sequence numbers during RTP processing by the user of the linked issue. Specifically, when the `lastReportedSeqNum` is exactly `UINT16_MAX`, the subsequent increment can cause incorrect behavior due to promotion to a larger integer type.
- This fix ensures that sequence number comparisons are performed correctly, even when the `lastReportedSeqNum` is at the value of `UINT16_MAX`.

*How was it changed?*
- In `PeerConnection.c` and `Rtcp.c`, explicit casting to `UINT16` was added to the sequence number comparisons to prevent unintentional integer promotion to a larger type. 
- Note: Although the expression (`lastReportedSeqNum` + 1) can be promoted to a larger integer type, the explicit casting ensures that the result remains within the bounds of UINT16, effectively voiding the promotion.
- In `RtcpFunctionalityTest.cpp`, a new test was added to simulate the case where `lastReportedSeqNum` is `UINT16_MAX` and ensure that the integer promotion does not cause any issues when updating the hash table.

*What testing was done for the changes?*
- A new unit test, updateTwccHashTableIntPromotionCase, was created to verify that the system correctly handles the sequence number wraparound and integer promotion scenario. This test checks the proper clearing of the hash table when sequence numbers wrap around from UINT16_MAX. On my Macbook Pro, the newly added test gets stuck in an infinite loop without the fix. After the fix, the new test exits the loop cleanly.
- Existing functionality was validated to ensure that no regressions were introduced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
