### PR TITLE
Bugfix: getNatBehavior return

### DIFF
--- a/src/source/Ice/NatBehaviorDiscovery.c
+++ b/src/source/Ice/NatBehaviorDiscovery.c
@@ -381,4 +381,5 @@ PCHAR getNatBehaviorStr(NAT_BEHAVIOR natBehavior)
         case NAT_BEHAVIOR_PORT_DEPENDENT:
             return NAT_BEHAVIOR_PORT_DEPENDENT_STR;
     }
+    return NAT_BEHAVIOR_NONE_STR;
 }


### PR DESCRIPTION
Fix issue where compiler complains on function return type!

- Following error was seen:
  `In function 'getNatBehaviorStr': NatBehaviorDiscovery.c:385:1: error: control reaches end of non-void function [-Werror=return-type]`
 - Fixed this by returning `NAT_BEHAVIOR_NONE_STR`