### PR TITLE
Upgrade to Ubuntu 22, refactor CI to use DRY, seperate the jobs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,16 @@
 *Issue #, if available:*
+- N/A
 
 *What was changed?*
+- 
 
 *Why was it changed?*
+- 
 
 *How was it changed?*
+- 
 
 *What testing was done for the changes?*
+- 
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,12 @@ on:
     branches:
       - develop
       - main
+
+env:
+  AWS_KVS_LOG_LEVEL: 7
+  DEBIAN_FRONTEND: noninteractive
+
 jobs:
-  clang-format-check:
-    runs-on: macos-13
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Install clang-format
-        run: |
-          brew install clang-format
-          clang-format --version
-      - name: Run clang format check
-        run: |
-          bash scripts/check-clang.sh
   mac-tests:
     strategy:
       matrix:
@@ -42,18 +35,22 @@ jobs:
             cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON"
       fail-fast: false
 
-    env:
-      AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write
       contents: read
 
     runs-on: ${{ matrix.os.runner }}
     name: ${{ matrix.os.name }}, ${{ matrix.compiler }}, ${{ matrix.config.name }}
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -90,177 +87,56 @@ jobs:
         shell: bash
 
       - name: Run tests
+        working-directory: ./build
         run: |
-          cd build
           ./tst/webrtc_client_test
         shell: bash
 
-  address-sanitizer:
-    runs-on: ubuntu-20.04
-    env:
-      ASAN_OPTIONS: detect_odr_violation=0:detect_leaks=1
-      LSAN_OPTIONS: suppressions=../tst/suppressions/LSAN.supp
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  undefined-behavior-sanitizer:
-    runs-on: ubuntu-20.04
-    env:
-      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  # memory-sanitizer:
-  #   runs-on: ubuntu-18.04
-  #   env:
-  #     CC: clang-7
-  #     CXX: clang++-7
-  #     AWS_KVS_LOG_LEVEL: 2
-  #   steps:
-  #     - name: Clone repository
-  #       uses: actions/checkout@v4
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt clean && sudo apt update
-  #         sudo apt-get -y install clang-7
-  #     - name: Build repository
-  #       run: |
-  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  #         mkdir build && cd build
-  #         cmake .. -DMEMORY_SANITIZER=TRUE -DBUILD_TEST=TRUE
-  #         make
-  #         ulimit -c unlimited -S
-  #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
-  thread-sanitizer:
-    runs-on: ubuntu-20.04
-    env:
-      TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DTHREAD_SANITIZER=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  linux-gcc-4_4:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-      CC: gcc-4.4
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install deps
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-          sudo apt-get -q update
-          sudo apt-get -y install gcc-4.4
-          sudo apt-get -y install gdb
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          # As per REAMDE here: https://github.com/aws/aws-sdk-cpp minimum supported GCC is 4.9 so we do not run those tests here
-          cmake .. -DBUILD_TEST=TRUE -DENABLE_AWS_SDK_IN_TESTS=OFF
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  static-build-linux:
-    runs-on: ubuntu-20.04
+#  linux-gcc-4_4:
+#    runs-on: ubuntu-20.04
+#    env:
+#      AWS_KVS_LOG_LEVEL: 2
+#      CC: gcc-4.4
+#    permissions:
+#      id-token: write
+#      contents: read
+#    steps:
+#      - name: Clone repository
+#        uses: actions/checkout@v4
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#      - name: Install deps
+#        run: |
+#          sudo apt clean && sudo apt update
+#          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+#          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+#          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+#          sudo apt-get -q update
+#          sudo apt-get -y install gcc-4.4
+#          sudo apt-get -y install gdb
+#          sudo apt-get -y install libcurl4-openssl-dev
+#      - name: Setup cmake
+#        uses: jwlawson/actions-setup-cmake@v2
+#        with:
+#          cmake-version: '3.x'
+#      - name: Build repository
+#        run: |
+#          mkdir build && cd build
+#          # As per REAMDE here: https://github.com/aws/aws-sdk-cpp minimum supported GCC is 4.9 so we do not run those tests here
+#          cmake .. -DBUILD_TEST=TRUE -DENABLE_AWS_SDK_IN_TESTS=OFF
+#          make
+#          ulimit -c unlimited -S
+#      - name: Run tests
+#        run: |
+#          cd build
+#          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+
+  static-build-alpine-linux:
+    runs-on: ubuntu-22.04
     container:
       image: alpine:3.15.4
     env:
@@ -282,255 +158,136 @@ jobs:
         run: |
           mkdir build && cd build
           cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
-          make
-  mbedtls-ubuntu-gcc:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install deps
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-          sudo apt-get -q update
-          sudo apt-get -y install gcc-4.4
-          sudo apt-get -y install gdb
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  mbedtls-ubuntu-gcc-11:
-    runs-on: ubuntu-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install deps
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
-          sudo apt-get -q update
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+          make -j
 
-  mbedtls-ubuntu-gcc-4_4-build:
-    runs-on: ubuntu-20.04
+  mbedtls-ubuntu-gcc-4-4:
+    permissions:
+      id-token: write
+      contents: read
+
+    runs-on: ubuntu-latest
+    container: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+
     env:
-      AWS_KVS_LOG_LEVEL: 2
       CC: gcc-4.4
-    permissions:
-      id-token: write
-      contents: read
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
       - name: Install deps
         run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-          sudo apt-get -q update
-          sudo apt-get -y install gcc-4.4
-          sudo apt-get -y install gdb
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
+          apt-get update
+          apt-get install -y software-properties-common cmake git pkg-config build-essential
 
-  mbedtls-ubuntu-clang:
-    runs-on: ubuntu-20.04
-    env:
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
+          add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+          add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+          apt-get -q update
+          apt-get -y install gcc-4.4
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+
+      - name: Build repository
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DBUILD_TEST=ON -DENABLE_AWS_SDK_IN_TESTS=OFF -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          make -j
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
-          ulimit -c unlimited -S
+
       - name: Run tests
         run: |
           cd build
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  sample-check:
-    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
+
+  ubuntu:
+    strategy:
+      matrix:
+        container:
+          - name: Ubuntu 20.04
+            image: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+          - name: Ubuntu 22.04
+            image: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+            test: ON
+        compiler:
+          - gcc
+          - clang
+        build-configuration:
+          - name: curl
+            cmake-args: "-DUSE_OPENSSL=ON -DUSE_MBEDTLS=OFF"
+          - name: lws
+            cmake-args: "-DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON"
+      fail-fast: false
+
     runs-on: ubuntu-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
+    container:
+      image: ${{ matrix.container.image }}
+
     permissions:
       id-token: write
       contents: read
+
+    name: ${{ matrix.container.name }}-${{ matrix.compiler }}-${{ matrix.build-configuration.name }}
+    timeout-minutes: 60
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Build repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake ..
-          make
-      - name: Sample check
-        run: |
-          ./scripts/check-sample.sh
-  sample-check-no-data-channel:
-    if: github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c'
-    runs-on: ubuntu-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-          role-duration-seconds: 10800
-      - name: Build repository
-        run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DENABLE_DATA_CHANNEL=OFF
-          make
-      - name: Sample check without data channel
-        run: |
-          ./scripts/check-sample.sh
-  ubuntu-os-build:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Install dependencies
         run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install libcurl4-openssl-dev
+          apt-get update
+          apt-get install -y git cmake build-essential pkg-config file
+
+      - name: Setup GCC
+        if: ${{ matrix.compiler == 'gcc' }}
+        run: |
+          gcc --version
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
+
+      - name: Setup Clang
+        if: ${{ matrix.compiler == 'clang' }}
+        run: |
+          apt-get -y install clang
+          clang --version
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+
       - name: Build repository
         run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE
-          make
-      - name: Run tests
-        run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
-  ubuntu-os-build-stats-calc-control:
-    runs-on: ubuntu-20.04
-    env:
-      AWS_KVS_LOG_LEVEL: 2
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
+          cmake .. -DBUILD_TEST=ON -DENABLE_AWS_SDK_IN_TESTS=OFF ${{ matrix.build-configuration.cmake-args }}
+          make -j
+          file ./tst/webrtc_client_test
+
       - name: Configure AWS Credentials
+        if: ${{ matrix.container.test == 'ON' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install dependencies
-        run: |
-          sudo apt clean && sudo apt update
-          sudo apt-get -y install libcurl4-openssl-dev
-      - name: Build repository
-        run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DENABLE_STATS_CALCULATION_CONTROL=TRUE
-          make
+
       - name: Run tests
+        # Don't run all the tests multiple times for each configuration (duplicate)
+        if: ${{ matrix.container.test == 'ON' }}
+        working-directory: ./build
         run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+          ./tst/webrtc_client_test
+
   windows-msvc-openssl:
     runs-on: windows-2022
     env:
@@ -573,6 +330,10 @@ jobs:
       #     cd build
       #     cmake .. -DLWS_HAVE_PTHREAD_H=1 -DLWS_EXT_PTHREAD_INCLUDE_DIR="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\include" -DLWS_EXT_PTHREAD_LIBRARIES="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\lib\\x64\\libpthreadGC2.a" -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_OPENSSL_INCLUDE_DIRS="C:\\Program Files\\OpenSSL\\include" -DLWS_OPENSSL_LIBRARIES="C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib"
       #     cmake --build . --config DEBUG
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Build repository
         shell: powershell
         run: |
@@ -613,11 +374,50 @@ jobs:
   #         git config --system core.longpaths true
   #         .github\build_windows_mbedtls.bat
 
+  # ----------------------------------------------------
+
+  stats-calc-control-check:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libcurl4-openssl-dev
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+
+      - name: Build repository
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DBUILD_TEST=ON -DENABLE_STATS_CALCULATION_CONTROL=ON
+          make -j
+
+      - name: Run tests
+        working-directory: ./build
+        run: |
+          ./tst/webrtc_client_test --gtest_filter="*MetricsApiTest*"
+
   stack-size-check:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
       - name: Check StackSize with Invalid Value
         run: |
           mkdir build && cd build
@@ -637,81 +437,4 @@ jobs:
             echo "Stack size was not sent to PIC properly. See the logs below:"
             echo "$CMAKE_LOGS"
             exit 1
-          fi
-
-  valgrind-check:
-    runs-on: ubuntu-latest
-    env:
-      AWS_KVS_LOG_LEVEL: 7
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v3
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Install deps
-        run: |
-          sudo apt clean && sudo apt update
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ jammy universe'
-          sudo apt-get -q update
-          sudo apt-get -y install libcurl4-openssl-dev valgrind
-      - name: Build repository
-        run: |
-          mkdir build && cd build
-          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
-          cd build
-          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-master.txt ./samples/kvsWebrtcClientMaster demo-channel-gh-actions &
-          PID_MASTER=$!
-          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-viewer.txt ./samples/kvsWebrtcClientViewer demo-channel-gh-actions &
-          PID_VIEWER=$!
-          
-          # Wait for processes to run initially
-          sleep 30 # Wait 30s
-          
-          # Send SIGINT (2) to both processes
-          kill -2 $PID_VIEWER
-          sleep 30
-          
-          kill -2 $PID_MASTER
-          
-          # Start a background task to enforce a timeout for graceful shutdown
-          (
-            sleep 10
-            kill -9 $PID_MASTER 2>/dev/null
-            kill -9 $PID_VIEWER 2>/dev/null
-          ) &
-          
-          wait $PID_MASTER
-          EXIT_STATUS_MASTER=$?
-          wait $PID_VIEWER
-          EXIT_STATUS_VIEWER=$?
-          
-          # Check exit statuses to determine if the interrupt was successful
-          if [ $EXIT_STATUS_MASTER -ne 0 ] || [ $EXIT_STATUS_VIEWER -ne 0 ]; then
-            echo "Process did not exit gracefully."
-            echo "Master exit code: $EXIT_STATUS_MASTER"
-            echo "Viewer exit code: $EXIT_STATUS_VIEWER"
-            exit 1
-          else
-          
-            echo "Processes exited successfully."
-          fi
-          
-          # Check for memory leaks in Valgrind output files
-          if grep "All heap blocks were freed -- no leaks are possible" valgrind-master.txt && grep "All heap blocks were freed -- no leaks are possible" valgrind-viewer.txt; then
-            echo "No memory leaks detected."
-          else
-            echo "Memory leaks detected."
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
           - name: Shared OpenSSL
             cmake_flags: "-DBUILD_TEST=ON"
           - name: Static OpenSSL
-            cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=TRUE"
+            cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=ON"
           - name: Shared MbedTLS
             cmake_flags: "-DBUILD_TEST=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON"
           - name: Static MbedTLS
-            cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=TRUE -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON"
+            cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON"
       fail-fast: false
 
     permissions:
@@ -167,6 +167,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+    timeout-minutes: 60
 
     env:
       CC: gcc-4.4
@@ -378,6 +379,7 @@ jobs:
 
   stats-calc-control-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     permissions:
       id-token: write
@@ -386,11 +388,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libcurl4-openssl-dev
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
@@ -401,7 +398,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DBUILD_TEST=ON -DENABLE_STATS_CALCULATION_CONTROL=ON
+          cmake .. -DBUILD_TEST=ON -DENABLE_STATS_CALCULATION_CONTROL=ON -DENABLE_AWS_SDK_IN_TESTS=OFF
           make -j
 
       - name: Run tests
@@ -411,16 +408,21 @@ jobs:
 
   stack-size-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
+
       - name: Check StackSize with Invalid Value
         run: |
-          mkdir build && cd build
+          mkdir build
+          cd build
           set +e  # Allow the script to continue even if cmake fails (expected)
           cmake .. -DKVS_STACK_SIZE=65536asdfsadf
           cmake_exit_code=$?
@@ -429,9 +431,10 @@ jobs:
             echo "CMake unexpectedly succeeded with invalid KVS_STACK_SIZE"
             exit 1
           fi
+
       - name: Check Stack Size is Set
+        working-directory: ./build
         run: |
-          cd build
           CMAKE_LOGS=$(cmake .. -DKVS_STACK_SIZE=65536 -DBUILD_SAMPLE=OFF 2>&1)
           if ! echo "$CMAKE_LOGS" | grep -q "Building with default stack size: 65536 bytes"; then
             echo "Stack size was not sent to PIC properly. See the logs below:"

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   clang-format-check:
     runs-on: macos-13
+    timeout-minutes: 15
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -1,0 +1,25 @@
+name: WebRTC C Clang Format
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  clang-format-check:
+    runs-on: macos-13
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install clang-format
+        run: |
+          brew install clang-format
+          clang-format --version
+      - name: Run clang format check
+        run: |
+          bash scripts/check-clang.sh

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,38 +8,48 @@ on:
     branches:
       - develop
       - main
+
+env:
+  AWS_KVS_LOG_LEVEL: 7
+
 jobs:
   linux-gcc-codecov:
-    runs-on: ubuntu-20.04
+    if: ${{ github.repo == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c' }}
+    runs-on: ubuntu-latest
     env:
-      AWS_KVS_LOG_LEVEL: 2
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
     permissions:
       id-token: write
       contents: read
+
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Install dependencies
         run: |
-          sudo apt clean && sudo apt update
+          sudo apt-get update
           sudo apt-get -y install libcurl4-openssl-dev
+
       - name: Build repository
         run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run:  |
+          mkdir build 
           cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
+          make -j
+
+      - name: Run tests
+        working-directory: ./build
+        run: |
+          timeout --signal=SIGKILL 60m ./tst/webrtc_client_test
+
       - name: Code coverage
         run: |
           for test_file in $(find CMakeFiles/kvsWebrtcClient.dir CMakeFiles/kvsWebrtcSignalingClient.dir -name '*.gcno'); do gcov $test_file; done

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,6 +16,8 @@ jobs:
   linux-gcc-codecov:
     if: ${{ github.repo == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -33,22 +35,17 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libcurl4-openssl-dev
-
       - name: Build repository
         run: |
           mkdir build 
           cd build
-          cmake .. -DCODE_COVERAGE=TRUE -DBUILD_TEST=TRUE
+          cmake .. -DCODE_COVERAGE=ON -DBUILD_TEST=ON
           make -j
 
       - name: Run tests
         working-directory: ./build
         run: |
-          timeout --signal=SIGKILL 60m ./tst/webrtc_client_test
+          ./tst/webrtc_client_test
 
       - name: Code coverage
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,11 +23,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -38,7 +38,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -52,4 +52,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/cross-compilation.yml
+++ b/.github/workflows/cross-compilation.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - develop
       - main
+
 jobs:
   linux-cross-compilation:
     strategy:

--- a/.github/workflows/cross-compilation.yml
+++ b/.github/workflows/cross-compilation.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   linux-cross-compilation:
+    timeout-minutes: 15
+
     strategy:
       matrix:
         compiler:
@@ -62,17 +64,22 @@ jobs:
             cmake_flags: -DENABLE_KVS_THREADPOOL=OFF
 
       fail-fast: false
+
     runs-on: ubuntu-latest
     container:
       image:  ${{ matrix.compiler.runner }}
+
     name: ${{ matrix.compiler.name }}, ${{ matrix.build-type.name }}, ${{ matrix.crypto.name }}, ${{ matrix.threadpool.name }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Install dependencies
         run: |
           apt-get update
           apt-get install -y build-essential cmake git pkg-config file ${{ matrix.compiler.install }}
+
       - name: Configure and build ${{ matrix.compiler.name }}, ${{ matrix.build-type.name }}, ${{ matrix.crypto.name }}, ${{ matrix.threadpool.name }}
         run: |
           export CC=${{ matrix.compiler.cc }}
@@ -90,6 +97,7 @@ jobs:
             ${{ matrix.threadpool.cmake_flags }}
           make -j$(sysctl -n hw.ncpu)
         shell: bash
+
       - name: Check test file is compiled correctly
         run: |
           cd build

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install requirements
         run: sudo apt-get install doxygen graphviz -y

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -15,27 +15,32 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AWS_KVS_LOG_LEVEL: 2
+
     permissions:
       id-token: write
       contents: read
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Build repository
         run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
           cmake ..
-          make
+          make -j
+
       - name: Sample check
         run: |
           ./scripts/check-sample.sh
@@ -71,33 +76,40 @@ jobs:
 
   valgrind-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
     env:
       AWS_KVS_LOG_LEVEL: 7
+
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Install deps
         run: |
           sudo apt-get update
           sudo apt-get -y install valgrind
+
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
+
       - name: Build repository
         run: |
           mkdir build && cd build
           cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
-          make
-          ulimit -c unlimited -S
+          make -j
+
       - name: Run tests
         run: |
           cd build

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -1,0 +1,146 @@
+name: WebRTC C Samples
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  sample-check:
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake ..
+          make
+      - name: Sample check
+        run: |
+          ./scripts/check-sample.sh
+
+  sample-check-no-data-channel:
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DENABLE_DATA_CHANNEL=OFF
+          make
+      - name: Sample check without data channel
+        run: |
+          ./scripts/check-sample.sh
+
+  valgrind-check:
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 7
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install valgrind
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run: |
+          cd build
+          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-master.txt ./samples/kvsWebrtcClientMaster demo-channel-gh-actions &
+          PID_MASTER=$!
+          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-viewer.txt ./samples/kvsWebrtcClientViewer demo-channel-gh-actions &
+          PID_VIEWER=$!
+
+          # Wait for processes to run initially
+          sleep 30 # Wait 30s
+
+          # Send SIGINT (2) to both processes
+          kill -2 $PID_VIEWER
+          sleep 30
+
+          kill -2 $PID_MASTER
+
+          # Start a background task to enforce a timeout for graceful shutdown
+          (
+            sleep 10
+            kill -9 $PID_MASTER 2>/dev/null
+            kill -9 $PID_VIEWER 2>/dev/null
+          ) &
+
+          wait $PID_MASTER
+          EXIT_STATUS_MASTER=$?
+          wait $PID_VIEWER
+          EXIT_STATUS_VIEWER=$?
+
+          # Check exit statuses to determine if the interrupt was successful
+          if [ $EXIT_STATUS_MASTER -ne 0 ] || [ $EXIT_STATUS_VIEWER -ne 0 ]; then
+            echo "Process did not exit gracefully."
+            echo "Master exit code: $EXIT_STATUS_MASTER"
+            echo "Viewer exit code: $EXIT_STATUS_VIEWER"
+            exit 1
+          else
+
+            echo "Processes exited successfully."
+          fi
+
+          # Check for memory leaks in Valgrind output files
+          if grep "All heap blocks were freed -- no leaks are possible" valgrind-master.txt && grep "All heap blocks were freed -- no leaks are possible" valgrind-viewer.txt; then
+            echo "No memory leaks detected."
+          else
+            echo "Memory leaks detected."
+          fi

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -1,0 +1,160 @@
+name: WebRTC C Sanitizers
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+
+env:
+  AWS_KVS_LOG_LEVEL: 7
+  DEBIAN_FRONTEND: noninteractive
+
+jobs:
+  address-sanitizer:
+    runs-on: ubuntu-22.04
+    env:
+      ASAN_OPTIONS: detect_odr_violation=0:detect_leaks=1
+      LSAN_OPTIONS: suppressions=../tst/suppressions/LSAN.supp
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install clang
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+      - name: Build repository
+        run: |
+          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run: |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  undefined-behavior-sanitizer:
+    runs-on: ubuntu-22.04
+    env:
+      UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      CC: clang
+      CXX: clang++
+      AWS_KVS_LOG_LEVEL: 2
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Install dependencies
+        run: |
+          sudo apt clean && sudo apt update
+          sudo apt-get -y install clang
+          sudo apt-get -y install libcurl4-openssl-dev
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+      - name: Build repository
+        run: |
+          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+          mkdir build && cd build
+          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
+          make
+          ulimit -c unlimited -S
+      - name: Run tests
+        run: |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+  # memory-sanitizer:
+  #   runs-on: ubuntu-18.04
+  #   env:
+  #     CC: clang-7
+  #     CXX: clang++-7
+  #     AWS_KVS_LOG_LEVEL: 2
+  #   steps:
+  #     - name: Clone repository
+  #       uses: actions/checkout@v4
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt clean && sudo apt update
+  #         sudo apt-get -y install clang-7
+  #     - name: Build repository
+  #       run: |
+  #         sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  #         mkdir build && cd build
+  #         cmake .. -DMEMORY_SANITIZER=TRUE -DBUILD_TEST=TRUE
+  #         make
+  #         ulimit -c unlimited -S
+  #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
+  thread-sanitizer:
+    runs-on: ubuntu-latest
+    container: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+    env:
+      TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
+      CC: clang
+      CXX: clang++
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get -y install clang cmake build-essential git pkg-config zlib1g-dev
+          apt-get -y install libcurl4-openssl-dev
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+
+      - name: Build repository
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DBUILD_TEST=ON -DTHREAD_SANITIZER=ON
+          make -j
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Run tests
+        run: |
+          cd build
+          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -13,87 +13,103 @@ on:
 env:
   AWS_KVS_LOG_LEVEL: 7
   DEBIAN_FRONTEND: noninteractive
+  CC: clang
+  CXX: clang++
 
 jobs:
   address-sanitizer:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
     env:
       ASAN_OPTIONS: detect_odr_violation=0:detect_leaks=1
       LSAN_OPTIONS: suppressions=../tst/suppressions/LSAN.supp
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
+
     permissions:
       id-token: write
       contents: read
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Install dependencies
         run: |
-          sudo apt clean && sudo apt update
+          sudo apt-get update
           sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
+
+          # AWS SDK CPP dependencies (for tests)
+          sudo apt-get -y install zlib1g-dev libcurl4-openssl-dev
+
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
+
       - name: Build repository
         run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DADDRESS_SANITIZER=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
+          mkdir build
           cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+          cmake .. -DBUILD_TEST=ON -DADDRESS_SANITIZER=ON
+          make -j
+
+      - name: Run tests
+        working-directory: ./build
+        run: |
+          ./tst/webrtc_client_test
+
   undefined-behavior-sanitizer:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
     env:
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-      CC: clang
-      CXX: clang++
-      AWS_KVS_LOG_LEVEL: 2
+
     permissions:
       id-token: write
       contents: read
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Install dependencies
         run: |
-          sudo apt clean && sudo apt update
+          sudo apt-get update
           sudo apt-get -y install clang
-          sudo apt-get -y install libcurl4-openssl-dev
+
+          # AWS SDK CPP dependencies (for tests)
+          sudo apt-get -y install zlib1g-dev libcurl4-openssl-dev
+
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '3.x'
+
       - name: Build repository
         run: |
-          # TODO: Remove the following line. This is only a workaround for enabling IPv6, https://github.com/travis-ci/travis-ci/issues/8891.
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          mkdir build && cd build
-          cmake .. -DBUILD_TEST=TRUE -DUNDEFINED_BEHAVIOR_SANITIZER=TRUE
-          make
-          ulimit -c unlimited -S
-      - name: Run tests
-        run: |
+          mkdir build
           cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+          cmake .. -DBUILD_TEST=ON -DUNDEFINED_BEHAVIOR_SANITIZER=ON
+          make -j
+
+      - name: Run tests
+        working-directory: ./build
+        run: |
+          ./tst/webrtc_client_test
+
   # memory-sanitizer:
   #   runs-on: ubuntu-18.04
   #   env:
@@ -115,13 +131,14 @@ jobs:
   #         make
   #         ulimit -c unlimited -S
   #         timeout --signal=SIGABRT 60m build/tst/webrtc_client_test
+
   thread-sanitizer:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     container: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+
     env:
       TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=../tst/suppressions/TSAN.supp
-      CC: clang
-      CXX: clang++
 
     permissions:
       id-token: write
@@ -133,8 +150,10 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get -y install clang cmake build-essential git pkg-config zlib1g-dev
-          apt-get -y install libcurl4-openssl-dev
+          apt-get -y install clang cmake build-essential git pkg-config
+          
+          # AWS SDK CPP dependencies (for tests)
+          apt-get -y install zlib1g-dev libcurl4-openssl-dev
 
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
@@ -155,6 +174,6 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Run tests
+        working-directory: ./build
         run: |
-          cd build
-          timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
+          ./tst/webrtc_client_test


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- GitHub Actions deprecated the native Ubuntu 20.04 runner. Therefore, we are now using a container-based alternative for legacy builds. [Reference](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)
- CI was refactored to use DRY (reducing repetition) since updating the Ubuntu 20.04 GitHub actions image to the Ubuntu 20 ECR image needed to be repeated multiple times. Now, we can more quickly and easily perform future updates for any future deprecations.

*Why was it changed?*
- Ubuntu 20 deprecation. Current CI will fail and won't give us confidence that PRs won't break anything.

*How was it changed?*
- Separate the jobs by category into different files
- Pin the Cmake version
- Combine the various Ubuntu unit test jobs into one using matrix for the different build combinations.
- Add `parallel` (-j) flag for faster builds
- Use the ECR containers for Ubuntu 20 jobs instead, and for others, upgrade to Ubuntu 22. The Thread sanitizer reported some new issues on Ubuntu 22, so keeping it at Ubuntu 20.
- Removed extra things that were installed unnecessarily. (e.g. libcurl4-openssl-dev for non-tests)
  - AWS SDK CPP (for tests) requires some extra things to be pre-installed as a peer-dependency. Namely, zlib (zlib1g-dev and libcurl4-openssl-dev).
- Clean up extra commands (ulimit -c unlimited -S)
- **Reduce credentials duration** -- we don't need more than 1 hour. Also change the order so that we ask for credentials only after the build finishes.
- Use the `timeout` property instead of timeout command
- Use `working-directory` property instead of `cd`
- We had 3 of the same job running the same combination of tests. Removed the 2 duplicate ones since the tests all use the same signaling channel, reducing the repetition will decrease the likelihood of the tests interfering with each other.
- Add a condition to run the codecov job only in the main repo (this), not on forks by default, since it requires a codecov token.

*What testing was done for the changes?*
- Tested on a fork

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
