### PR TITLE
Cleaning up stale resources, adjusted logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 env:
-  AWS_KVS_LOG_LEVEL: 7
+  AWS_KVS_LOG_LEVEL: 2
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
@@ -142,7 +142,6 @@ jobs:
     env:
       CC: gcc
       CXX: g++
-      AWS_KVS_LOG_LEVEL: 2
     permissions:
       id-token: write
       contents: read
@@ -291,8 +290,6 @@ jobs:
 
   windows-msvc-openssl:
     runs-on: windows-2022
-    env:
-      AWS_KVS_LOG_LEVEL: 1
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,61 @@ on:
       - main
 
 env:
-  AWS_KVS_LOG_LEVEL: 2
+  AWS_KVS_LOG_LEVEL: 7
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
+  check-aws-credentials:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+  cleanup-old-resources:
+    needs: check-aws-credentials
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: 'aws-samples/amazon-kinesis-video-streams-demos'
+          path: demos-repo
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        working-directory: ./demos-repo/python/cleanup
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Setup credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-west-2
+
+      - name: Run cleanup script
+        working-directory: ./demos-repo/python/cleanup
+        run: |
+          python kvs_cleanup.py
+
   mac-tests:
+    needs: cleanup-old-resources
     strategy:
       matrix:
         os:
@@ -160,6 +210,7 @@ jobs:
           make -j
 
   mbedtls-ubuntu-gcc-4-4:
+    needs: cleanup-old-resources
     permissions:
       id-token: write
       contents: read
@@ -209,6 +260,7 @@ jobs:
           timeout --signal=SIGABRT 60m ./tst/webrtc_client_test
 
   ubuntu:
+    needs: cleanup-old-resources
     strategy:
       matrix:
         container:
@@ -289,6 +341,7 @@ jobs:
           ./tst/webrtc_client_test
 
   windows-msvc-openssl:
+    needs: cleanup-old-resources
     runs-on: windows-2022
     permissions:
       id-token: write
@@ -296,11 +349,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
       - name: Move cloned repo
         shell: powershell
         run: |
@@ -338,6 +386,11 @@ jobs:
           cd C:\webrtc
           git config --system core.longpaths true
           .github\build_windows_openssl.bat
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
       - name: Run tests
         shell: powershell
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,6 +16,7 @@ jobs:
   linux-gcc-codecov:
     if: ${{ github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c' }}
     runs-on: ubuntu-latest
+    container: public.ecr.aws/ubuntu/ubuntu:22.04_stable
     timeout-minutes: 60
 
     env:
@@ -29,16 +30,16 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - name: Install dependencies for AWS SDK CPP
+      - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get -y install zlib1g-dev libcurl4-openssl-dev
+          apt-get update
+          apt-get -y install git cmake build-essential pkg-config
+          apt-get -y install zlib1g-dev libcurl4-openssl-dev
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Check versions
+        run: |
+          gcc --version
+          gcov --version
 
       - name: Build repository
         run: |
@@ -46,6 +47,12 @@ jobs:
           cd build
           cmake .. -DCODE_COVERAGE=ON -DBUILD_TEST=ON
           make -j
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Run tests
         working-directory: ./build

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,6 +36,7 @@ jobs:
           apt-get update
           apt-get -y install git cmake build-essential pkg-config
           apt-get -y install zlib1g-dev libcurl4-openssl-dev
+          apt-get -y install curl
 
       - name: Check versions
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   linux-gcc-codecov:
-    if: ${{ github.repo == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c' }}
+    if: ${{ github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,12 +11,13 @@ on:
 
 env:
   AWS_KVS_LOG_LEVEL: 7
+  DEBIAN_FRONTEND: noninteractive
 
 jobs:
   linux-gcc-codecov:
     if: ${{ github.repository == 'awslabs/amazon-kinesis-video-streams-webrtc-sdk-c' }}
     runs-on: ubuntu-latest
-    container: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+    container: public.ecr.aws/ubuntu/ubuntu:20.04_stable
     timeout-minutes: 60
 
     env:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
+      - name: Install dependencies for AWS SDK CPP
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install zlib1g-dev libcurl4-openssl-dev
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch all history, for Codecov
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -63,9 +63,13 @@ jobs:
         run: |
           ./tst/webrtc_client_test
 
-      - name: Code coverage
+      - name: Generate report
         working-directory: ./build
         shell: bash
         run: |
           for test_file in $(find CMakeFiles/kvsWebrtcClient.dir CMakeFiles/kvsWebrtcSignalingClient.dir -name '*.gcno'); do gcov $test_file; done
+
+      - name: Upload report
+        shell: bash
+        run: |
           bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -61,6 +61,8 @@ jobs:
           ./tst/webrtc_client_test
 
       - name: Code coverage
+        working-directory: ./build
+        shell: bash
         run: |
           for test_file in $(find CMakeFiles/kvsWebrtcClient.dir CMakeFiles/kvsWebrtcSignalingClient.dir -name '*.gcno'); do gcov $test_file; done
           bash <(curl -s https://codecov.io/bash)

--- a/CMake/Dependencies/libawscpp-CMakeLists.txt
+++ b/CMake/Dependencies/libawscpp-CMakeLists.txt
@@ -10,5 +10,7 @@ ExternalProject_Add(libawscpp-download
                      -DBUILD_ONLY=kinesisvideo|kinesis-video-webrtc-storage
                      -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
     BUILD_ALWAYS      TRUE
+    GIT_PROGRESS      TRUE
+    GIT_SHALLOW       TRUE
     TEST_COMMAND      ""
 )

--- a/CMake/Dependencies/libgtest-CMakeLists.txt
+++ b/CMake/Dependencies/libgtest-CMakeLists.txt
@@ -7,6 +7,8 @@ include(ExternalProject)
 ExternalProject_Add(libgtest-download
     GIT_REPOSITORY    https://github.com/google/googletest.git
     GIT_TAG           release-1.12.1
+    GIT_PROGRESS      TRUE
+    GIT_SHALLOW       TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -7,6 +7,8 @@ include(ExternalProject)
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
     GIT_TAG           v1.5.4
+    GIT_PROGRESS      TRUE
+    GIT_SHALLOW       TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     LIST_SEPARATOR    |
     CMAKE_ARGS        

--- a/CMake/Dependencies/libmbedtls-CMakeLists.txt
+++ b/CMake/Dependencies/libmbedtls-CMakeLists.txt
@@ -22,6 +22,8 @@ ExternalProject_Add(
   project_libmbedtls
   GIT_REPOSITORY  https://github.com/ARMmbed/mbedtls.git
   GIT_TAG         v2.28.8
+  GIT_PROGRESS      TRUE
+  GIT_SHALLOW       TRUE
   PREFIX          ${CMAKE_CURRENT_BINARY_DIR}/build
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMake/Dependencies/libmbedtls-CMakeLists.txt
+++ b/CMake/Dependencies/libmbedtls-CMakeLists.txt
@@ -22,8 +22,8 @@ ExternalProject_Add(
   project_libmbedtls
   GIT_REPOSITORY  https://github.com/ARMmbed/mbedtls.git
   GIT_TAG         v2.28.8
-  GIT_PROGRESS      TRUE
-  GIT_SHALLOW       TRUE
+  GIT_PROGRESS    TRUE
+  GIT_SHALLOW     TRUE
   PREFIX          ${CMAKE_CURRENT_BINARY_DIR}/build
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}

--- a/CMake/Dependencies/libopenssl-CMakeLists.txt
+++ b/CMake/Dependencies/libopenssl-CMakeLists.txt
@@ -40,6 +40,8 @@ include(ExternalProject)
 ExternalProject_Add(project_libopenssl
     GIT_REPOSITORY    https://github.com/openssl/openssl.git
     GIT_TAG           OpenSSL_1_1_1t
+    GIT_PROGRESS      TRUE
+    GIT_SHALLOW       TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CONFIGURE_COMMAND ${CONFIGURE_COMMAND}
     BUILD_COMMAND     ${MAKE_EXE}

--- a/CMake/Dependencies/libsrtp-CMakeLists.txt
+++ b/CMake/Dependencies/libsrtp-CMakeLists.txt
@@ -59,6 +59,8 @@ ExternalProject_Add(project_libsrtp
     GIT_REPOSITORY    https://github.com/cisco/libsrtp.git
     GIT_TAG           bd0f27ec0e299ad101a396dde3f7c90d48efc8fc
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
+    GIT_PROGRESS      TRUE
+    GIT_SHALLOW       TRUE
     CMAKE_ARGS        -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
                       -DCMAKE_INSTALL_PREFIX:STRING=${OPEN_SRC_INSTALL_PREFIX}
                       -DENABLE_OPENSSL=${LIBSRTP_ENABLE_OPENSSL}

--- a/CMake/Dependencies/libsrtp-CMakeLists.txt
+++ b/CMake/Dependencies/libsrtp-CMakeLists.txt
@@ -60,7 +60,6 @@ ExternalProject_Add(project_libsrtp
     GIT_TAG           bd0f27ec0e299ad101a396dde3f7c90d48efc8fc
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     GIT_PROGRESS      TRUE
-    GIT_SHALLOW       TRUE
     CMAKE_ARGS        -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
                       -DCMAKE_INSTALL_PREFIX:STRING=${OPEN_SRC_INSTALL_PREFIX}
                       -DENABLE_OPENSSL=${LIBSRTP_ENABLE_OPENSSL}

--- a/CMake/Dependencies/libusrsctp-CMakeLists.txt
+++ b/CMake/Dependencies/libusrsctp-CMakeLists.txt
@@ -7,6 +7,8 @@ include(ExternalProject)
 ExternalProject_Add(project_libusrsctp
     GIT_REPOSITORY    https://github.com/sctplab/usrsctp.git
     GIT_TAG           1ade45cbadfd19298d2c47dc538962d4425ad2dd
+    GIT_PROGRESS      TRUE
+    GIT_SHALLOW       TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/CMake/Dependencies/libusrsctp-CMakeLists.txt
+++ b/CMake/Dependencies/libusrsctp-CMakeLists.txt
@@ -8,7 +8,6 @@ ExternalProject_Add(project_libusrsctp
     GIT_REPOSITORY    https://github.com/sctplab/usrsctp.git
     GIT_TAG           1ade45cbadfd19298d2c47dc538962d4425ad2dd
     GIT_PROGRESS      TRUE
-    GIT_SHALLOW       TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
                       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}

--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -31,6 +31,8 @@ endif()
 ExternalProject_Add(project_libwebsockets
     GIT_REPOSITORY    https://github.com/warmcat/libwebsockets.git
     GIT_TAG           v4.3.3
+    GIT_PROGRESS      TRUE
+    GIT_SHALLOW       TRUE
     PATCH_COMMAND     ${PATCH_COMMAND}
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build
     LIST_SEPARATOR    |

--- a/tst/main.cpp
+++ b/tst/main.cpp
@@ -75,6 +75,16 @@ int main(int argc, char** argv)
         if (trial >= MAX_TRIALS) {
             ::testing::GTEST_FLAG(break_on_failure) = breakOnFailure;
         }
+
+        // Increase logging verbosity on retry
+        if (trial >= 1) {
+#ifdef _WIN32
+            _putenv_s("AWS_KVS_LOG_LEVEL", "1");
+#else
+            setenv("AWS_KVS_LOG_LEVEL", "1", 1);
+#endif
+        }
+
         rc = RUN_ALL_TESTS();
 
         // If there were some tests failed, set googletest filter flag to those failed tests.


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Added a script to clean up the old test resources since we hit the channel limit. It appears that the unit tests don't properly clean up their resources. That will be investigated at a later time.
- Set the log level to 7 (silent), and increase the verbosity on retries. This leads to cleaner CI output and quicker to debug what went wrong.
- Add GIT_PROGRESS and GIT_SHALLOW to make it both faster to clone, and to allow to see the cloning progress for larger dependencies like OpenSSL and AWS SDK CPP.

*Why was it changed?*
- Avoid getting billed for resources that are unused
- Tests currently fail and block the CI from passing.
- Improve developer experience by having less unimportant logs to load.

*How was it changed?*
- Run the script added in the demos repository to cleanup the stale resources based on a regex and staleness time.
- On the 2nd run of the tests (retry), set the log level to verbose (1).

*What testing was done for the changes?*
- CI is the testing.

Before: 47k lines of logs to load on passing scenario.
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/e287115b-ee78-41a8-be05-eba671d97846" />

After: 10k lines of logs to load on passing scenario.
<img width="1125" alt="image" src="https://github.com/user-attachments/assets/ea1e2c8b-54be-44eb-8917-fd4f108ff0ab" />

Additional logs we can look into disabling is the LWS logs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
