### PR TITLE
Configure LWS logs with KVS log level

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -27,7 +27,6 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
     PSingleListNode pCurNode;
     UINT64 item, serverTime;
     UINT32 headerCount;
-    UINT32 logLevel;
     PRequestHeader pRequestHeader;
     PSignalingClient pSignalingClient = NULL;
     BOOL locked = FALSE;
@@ -37,7 +36,6 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
     PStateMachineState pStateMachineState;
     BOOL skewMapContains = FALSE;
 
-    UNUSED_PARAM(logLevel);
     DLOGV("HTTPS callback with reason %d", reason);
 
     // Early check before accessing the custom data field to see if we are interested in processing the message
@@ -58,7 +56,7 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
     customData = lws_get_opaque_user_data(wsi);
     pLwsCallInfo = (PLwsCallInfo) customData;
 
-    lws_set_log_level(LLL_NOTICE | LLL_WARN | LLL_ERR, NULL);
+    CHK_STATUS(configureLwsLogging(loggerGetLogLevel()));
 
     CHK(pLwsCallInfo != NULL && pLwsCallInfo->pSignalingClient != NULL && pLwsCallInfo->pSignalingClient->pLwsContext != NULL &&
             pLwsCallInfo->callInfo.pRequestInfo != NULL && pLwsCallInfo->protocolIndex == PROTOCOL_INDEX_HTTPS,
@@ -76,8 +74,6 @@ INT32 lwsHttpCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, 
 
     pRequestInfo = pLwsCallInfo->callInfo.pRequestInfo;
     pBuffer = pLwsCallInfo->buffer + LWS_PRE;
-
-    logLevel = loggerGetLogLevel();
 
     MUTEX_LOCK(pSignalingClient->lwsServiceLock);
     locked = TRUE;
@@ -319,7 +315,7 @@ INT32 lwsWssCallbackRoutine(struct lws* wsi, enum lws_callback_reasons reason, P
     customData = lws_get_opaque_user_data(wsi);
     pLwsCallInfo = (PLwsCallInfo) customData;
 
-    lws_set_log_level(LLL_NOTICE | LLL_WARN | LLL_ERR, NULL);
+    CHK_STATUS(configureLwsLogging(loggerGetLogLevel()));
 
     CHK(pLwsCallInfo != NULL && pLwsCallInfo->pSignalingClient != NULL && pLwsCallInfo->pSignalingClient->pOngoingCallInfo != NULL &&
             pLwsCallInfo->pSignalingClient->pLwsContext != NULL && pLwsCallInfo->pSignalingClient->pOngoingCallInfo->callInfo.pRequestInfo != NULL &&
@@ -2422,6 +2418,35 @@ STATUS wakeLwsServiceEventLoop(PSignalingClient pSignalingClient, UINT32 protoco
     }
 
 CleanUp:
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS configureLwsLogging(UINT32 kvsLogLevel)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    INT32 lws_levels = 0;
+
+    if (kvsLogLevel <= LOG_LEVEL_ERROR) {
+        lws_levels |= LLL_ERR;
+    }
+    if (kvsLogLevel <= LOG_LEVEL_WARN) {
+        lws_levels |= LLL_WARN;
+    }
+    if (kvsLogLevel <= LOG_LEVEL_INFO || kvsLogLevel == LOG_LEVEL_PROFILE) {
+        lws_levels |= LLL_NOTICE;
+    }
+    if (kvsLogLevel <= LOG_LEVEL_DEBUG) {
+        lws_levels |= LLL_INFO;
+    }
+
+    lws_set_log_level(lws_levels, NULL);
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;

--- a/src/source/Signaling/LwsApiCalls.h
+++ b/src/source/Signaling/LwsApiCalls.h
@@ -279,6 +279,7 @@ STATUS getMessageTypeFromString(PCHAR, UINT32, SIGNALING_MESSAGE_TYPE*);
 PCHAR getMessageTypeInString(SIGNALING_MESSAGE_TYPE);
 STATUS wakeLwsServiceEventLoop(PSignalingClient, UINT32);
 STATUS terminateConnectionWithStatus(PSignalingClient, SERVICE_CALL_RESULT);
+STATUS configureLwsLogging(UINT32 kvsLogLevel);
 
 #ifdef __cplusplus
 }

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -163,6 +163,8 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
     // Create the ongoing message list
     CHK_STATUS(stackQueueCreate(&pSignalingClient->pMessageQueue));
 
+    CHK_STATUS(configureLwsLogging(loggerGetLogLevel()));
+
     pSignalingClient->pLwsContext = lws_create_context(&creationInfo);
     CHK(pSignalingClient->pLwsContext != NULL, STATUS_SIGNALING_LWS_CREATE_CONTEXT_FAILED);
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Ability to change LWS logs at runtime, based on KVS log level

*Why was it changed?*
- It was previously hard-coded to `LLL_NOTICE | LLL_WARN | LLL_ERR`, so even with LOG_LEVEL_SILENT (7), it will still print logs.
- Here is an example of the logs the PR is referring to:

```
[2025/04/30 20:42:40:4048] N: lws_create_context: LWS: 4.3.3-v4.3.3, NET CLI H1 H2 WS ConMon IPV6-on
[2025/04/30 20:42:40:4053] N: __lws_lc_tag:  ++ [wsi|0|pipe] (1)
[2025/04/30 20:42:40:4053] N: __lws_lc_tag:  ++ [vh|0|netlink] (1)
[2025/04/30 20:42:40:4053] N: __lws_lc_tag:  ++ [vh|1|default||-1] (2)
[2025/04/30 20:42:40:4057] N: __lws_lc_tag:  ++ [wsicli|0|POST/h1/default/kinesisvideo.us-west-2.amazonaws.com] (1)
```

*How was it changed?*
- Created a new function configureLwsLogging which sets the log level.

*What testing was done for the changes?*
- Run it locally with log level 7 to confirm that it doesn't show those logs anymore. It does show mbedtls_ssl_conf_alpn_protocols absent still though, which we can look at in a future PR.
```
./samples/kvsWebrtcClientMaster demo-channel
mbedtls_ssl_conf_alpn_protocols absent
mbedtls_ssl_conf_alpn_protocols absent
mbedtls_ssl_conf_alpn_protocols absent
mbedtls_ssl_conf_alpn_protocols absent
mbedtls_ssl_conf_alpn_protocols absent
mbedtls_ssl_conf_alpn_protocols absent
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
