### PR TITLE
getNatBehaviorStr: Fix function return value compile error

### DIFF
--- a/src/source/Ice/NatBehaviorDiscovery.c
+++ b/src/source/Ice/NatBehaviorDiscovery.c
@@ -381,4 +381,5 @@ PCHAR getNatBehaviorStr(NAT_BEHAVIOR natBehavior)
         case NAT_BEHAVIOR_PORT_DEPENDENT:
             return NAT_BEHAVIOR_PORT_DEPENDENT_STR;
     }
+    return NAT_BEHAVIOR_NONE_STR;
 }


### PR DESCRIPTION
*Issue #, if available:*
- Running the CI for external contributor's PR. Will close this PR afterwards.

*What was changed?*
- See the original PR for the details

*Why was it changed?*
- See the original PR for the details

*How was it changed?*
- See the original PR for the details

*What testing was done for the changes?*
- See the original PR for the details

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
