### PR TITLE
Allow branches named with pattern 'test-pr-*' to trigger the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'test-pr-*'
   pull_request:
     branches:
       - develop

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'test-pr-*'
   pull_request:
     branches:
       - develop

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - develop
       - main
+      - 'test-pr-*'
   pull_request:
     branches:
       - develop

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,11 +2,17 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop, main ]
+    branches:
+      - develop
+      - main
+      - 'test-pr-*'
 
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop, main ]
+    branches:
+      - develop
+      - main
+      - 'test-pr-*'
 
 jobs:
   analyze:

--- a/.github/workflows/cross-compilation.yml
+++ b/.github/workflows/cross-compilation.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - develop
       - main
+      - 'test-pr-*'
   pull_request:
     branches:
       - develop

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - 'test-pr-*'
 
 jobs:
   generate-and-deploy-doxygen:

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'test-pr-*'
   pull_request:
     branches:
       - develop

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'test-pr-*'
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Adding 'test-pr-*' as a trigger for the CI.

*Why was it changed?*
- Currently, the way we test external contributor contributions is by creating a replica branch in this repository, then creating a dummy pull request to trigger the CI.
- Creating dummy pull requests clutters up the 'merged pull requests' tab.
- This change removes the requirement to create a dummy pull request to trigger the CI. Now, the CI will be automatically triggered on branches in this repository that fit the name: 'test-pr-*', where `*` is anything. 

*How was it changed?*
- Adjusted the CI trigger conditions in the configuration

*What testing was done for the changes?*
- Double-checked the spelling of the branch targets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
