### PR TITLE
Add tests for getIpAddrStr

### DIFF
--- a/tst/NetworkApiTest.cpp
+++ b/tst/NetworkApiTest.cpp
@@ -30,6 +30,89 @@ TEST_F(NetworkApiTest, ipIpAddrTest)
     EXPECT_EQ(FALSE, isIpAddr((PCHAR) "2001:85a3:0000:0000:8a2e:0370:7334", STRLEN("2001:85a3:0000:0000:8a2e:0370:7334")));
 }
 
+// ------------------------------- getIpAddrStr ----------------------
+
+STATUS initTestKvsIpv4Address(PKvsIpAddress pKvsIpAddress)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT8 addr[] = {192, 168, 1, 1};
+
+    CHK(pKvsIpAddress != NULL, STATUS_NULL_ARG);
+
+    MEMSET(pKvsIpAddress, 0, SIZEOF(KvsIpAddress));
+    pKvsIpAddress->family = KVS_IP_FAMILY_TYPE_IPV4;
+
+    MEMCPY(pKvsIpAddress->address, addr, IPV4_ADDRESS_LENGTH);
+
+CleanUp:
+    return retStatus;
+}
+
+TEST_F(NetworkApiTest, GetIpAddrStrNullIpAddress)
+{
+    CHAR buffer[KVS_IP_ADDRESS_STRING_BUFFER_LEN];
+
+    EXPECT_EQ(STATUS_NULL_ARG, getIpAddrStr(NULL, buffer, SIZEOF(buffer)));
+}
+
+TEST_F(NetworkApiTest, GetIpAddrStrInvalidBuffer)
+{
+    CHAR buffer[KVS_IP_ADDRESS_STRING_BUFFER_LEN];
+
+    KvsIpAddress ipAddress;
+    EXPECT_EQ(STATUS_SUCCESS, initTestKvsIpv4Address(&ipAddress));
+
+    EXPECT_EQ(STATUS_INVALID_ARG, getIpAddrStr(&ipAddress, NULL, SIZEOF(buffer)));
+    EXPECT_EQ(STATUS_INVALID_ARG, getIpAddrStr(&ipAddress, buffer, 0));
+}
+
+TEST_F(NetworkApiTest, GetIpAddrStrBufferTooSmall)
+{
+    KvsIpAddress ipAddress;
+    EXPECT_EQ(STATUS_SUCCESS, initTestKvsIpv4Address(&ipAddress));
+
+    // Test with increasingly small buffers
+    CHAR tinyBuffer[1];
+    EXPECT_EQ(STATUS_BUFFER_TOO_SMALL, getIpAddrStr(&ipAddress, tinyBuffer, SIZEOF(tinyBuffer)));
+
+    CHAR smallBuffer[5];
+    EXPECT_EQ(STATUS_BUFFER_TOO_SMALL, getIpAddrStr(&ipAddress, smallBuffer, SIZEOF(smallBuffer)));
+}
+
+TEST_F(NetworkApiTest, GetIpAddrStrIpv4Addr)
+{
+    CHAR buffer[KVS_IP_ADDRESS_STRING_BUFFER_LEN];
+
+    KvsIpAddress ipAddress;
+    EXPECT_EQ(STATUS_SUCCESS, initTestKvsIpv4Address(&ipAddress));
+
+    EXPECT_EQ(STATUS_SUCCESS, getIpAddrStr(&ipAddress, buffer, SIZEOF(buffer)));
+    EXPECT_STREQ("192.168.1.1", buffer);
+}
+
+TEST_F(NetworkApiTest, GetIpAddrStrIpv6Addr)
+{
+    CHAR buffer[KVS_IP_ADDRESS_STRING_BUFFER_LEN];
+
+    KvsIpAddress ipAddress;
+    MEMSET(&ipAddress, 0, SIZEOF(KvsIpAddress));
+    ipAddress.family = KVS_IP_FAMILY_TYPE_IPV6;
+
+    // rfc3849 - 2001:db8::/32 as a documentation-only prefix in the IPv6
+    //   address registry.  No end party is to be assigned this address.
+    UINT8 addr[] = {0x20, 0x01,
+                    0x0d, 0xb8,
+                    0x12, 0x34,
+                    0x56, 0x78,
+                    0x9a, 0xbc,
+                    0xde, 0xf0,
+                    0x12, 0x34,
+                    0x56, 0x78};
+    MEMCPY(ipAddress.address, addr, IPV6_ADDRESS_LENGTH);
+
+    EXPECT_EQ(STATUS_SUCCESS, getIpAddrStr(&ipAddress, buffer, SIZEOF(buffer)));
+    EXPECT_STREQ("2001:0db8:1234:5678:9abc:def0:1234:5678", buffer);
+}
 
 } // namespace webrtcclient
 } // namespace video


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Unit tests were added for GetIpAddrStr in Network.c

*Why was it changed?*
- According to codecov, this method is already covered, however I was unable to locate a test that validated correctness of the out parameter buffer.
- Since we rely on logs heavily during debugging, want to add additional checks to make certain that the IP addresses printed are correct and never accidentally broken in the future.

*How was it changed?*
- Added additional checks for getIpAddrStr, which is a toString for the IP addresses.

*What testing was done for the changes?*
- Ran the tests locally, they pass. Source code wasn't touched.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
