### PR TITLE
Add logs for socket creation fd

### DIFF
--- a/src/source/Ice/IceUtils.c
+++ b/src/source/Ice/IceUtils.c
@@ -172,11 +172,11 @@ STATUS iceUtilsSendStunPacket(PStunPacket pStunPacket, PBYTE password, UINT32 pa
     CHK(pDest != NULL, STATUS_NULL_ARG);
     switch (pStunPacket->header.stunMessageType) {
         case STUN_PACKET_TYPE_BINDING_REQUEST:
-            DLOGD("Sending BINDING_REQUEST to ip:%u.%u.%u.%u, port:%u", pDest->address[0], pDest->address[1], pDest->address[2], pDest->address[3],
+            DLOGD("Sending BINDING_REQUEST on socket id: %d, to ip:%u.%u.%u.%u, port:%u", pSocketConnection->localSocket, pDest->address[0], pDest->address[1], pDest->address[2], pDest->address[3],
                   (UINT16) getInt16(pDest->port));
             break;
         case STUN_PACKET_TYPE_BINDING_RESPONSE_SUCCESS:
-            DLOGD("Sending BINDING_RESPONSE_SUCCESS to ip:%u.%u.%u.%u, port:%u", pDest->address[0], pDest->address[1], pDest->address[2],
+            DLOGD("Sending BINDING_RESPONSE_SUCCESS on socket id: %d to ip:%u.%u.%u.%u, port:%u", pSocketConnection->localSocket, pDest->address[0], pDest->address[1], pDest->address[2],
                   pDest->address[3], (UINT16) getInt16(pDest->port));
             break;
         default:

--- a/src/source/Ice/IceUtils.c
+++ b/src/source/Ice/IceUtils.c
@@ -172,12 +172,12 @@ STATUS iceUtilsSendStunPacket(PStunPacket pStunPacket, PBYTE password, UINT32 pa
     CHK(pDest != NULL, STATUS_NULL_ARG);
     switch (pStunPacket->header.stunMessageType) {
         case STUN_PACKET_TYPE_BINDING_REQUEST:
-            DLOGD("Sending BINDING_REQUEST on socket id: %d, to ip:%u.%u.%u.%u, port:%u", pSocketConnection->localSocket, pDest->address[0], pDest->address[1], pDest->address[2], pDest->address[3],
-                  (UINT16) getInt16(pDest->port));
+            DLOGD("Sending BINDING_REQUEST on socket id: %d, to ip:%u.%u.%u.%u, port:%u", pSocketConnection->localSocket, pDest->address[0],
+                  pDest->address[1], pDest->address[2], pDest->address[3], (UINT16) getInt16(pDest->port));
             break;
         case STUN_PACKET_TYPE_BINDING_RESPONSE_SUCCESS:
-            DLOGD("Sending BINDING_RESPONSE_SUCCESS on socket id: %d to ip:%u.%u.%u.%u, port:%u", pSocketConnection->localSocket, pDest->address[0], pDest->address[1], pDest->address[2],
-                  pDest->address[3], (UINT16) getInt16(pDest->port));
+            DLOGD("Sending BINDING_RESPONSE_SUCCESS on socket id: %d to ip:%u.%u.%u.%u, port:%u", pSocketConnection->localSocket, pDest->address[0],
+                  pDest->address[1], pDest->address[2], pDest->address[3], (UINT16) getInt16(pDest->port));
             break;
         default:
             break;

--- a/src/source/Ice/IceUtils.h
+++ b/src/source/Ice/IceUtils.h
@@ -51,6 +51,7 @@ STATUS iceUtilsSendStunPacket(PStunPacket, PBYTE, UINT32, PKvsIpAddress, PSocket
 STATUS iceUtilsSendData(PBYTE, UINT32, PKvsIpAddress, PSocketConnection, struct __TurnConnection*, BOOL);
 
 typedef struct {
+    // isTurn ? TURN server : STUN server
     BOOL isTurn;
     BOOL isSecure;
     CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];

--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -47,7 +47,8 @@ CleanUp:
 
     if (pBindAddr) {
         getIpAddrStr(pBindAddr, ipAddr, ARRAY_SIZE(ipAddr));
-        DLOGD("create socket id: %d, with ip: %s:%u. family:%d", pSocketConnection->localSocket, ipAddr, (UINT16) getInt16(pBindAddr->port), pBindAddr->family);
+        DLOGD("create socket id: %d, with ip: %s:%u. family:%d", pSocketConnection->localSocket, ipAddr, (UINT16) getInt16(pBindAddr->port),
+              pBindAddr->family);
     } else {
         DLOGD("create socket id %d, without the bind address(%d:%d)", pSocketConnection->localSocket, familyType, protocol);
     }

--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -47,9 +47,9 @@ CleanUp:
 
     if (pBindAddr) {
         getIpAddrStr(pBindAddr, ipAddr, ARRAY_SIZE(ipAddr));
-        DLOGD("create socket with ip: %s:%u. family:%d", ipAddr, (UINT16) getInt16(pBindAddr->port), pBindAddr->family);
+        DLOGD("create socket id: %d, with ip: %s:%u. family:%d", pSocketConnection->localSocket, ipAddr, (UINT16) getInt16(pBindAddr->port), pBindAddr->family);
     } else {
-        DLOGD("create socket without the bind address(%d:%d)", familyType, protocol);
+        DLOGD("create socket id %d, without the bind address(%d:%d)", pSocketConnection->localSocket, familyType, protocol);
     }
     if (protocol == KVS_SOCKET_PROTOCOL_TCP) {
         getIpAddrStr(pPeerIpAddr, ipAddr, ARRAY_SIZE(ipAddr));
@@ -408,7 +408,7 @@ STATUS socketSendDataWithRetry(PSocketConnection pSocketConnection, PBYTE buf, U
                 /* nothing need to be done, just retry */
             } else {
                 /* fatal error from send() */
-                DLOGE("sendto() failed with errno %s(%d)", getErrorString(errorNum), errorNum);
+                DLOGE("sendto() socket %d failed with errno %s(%d)", pSocketConnection->localSocket, getErrorString(errorNum), errorNum);
                 CHAR ipAddr[KVS_IP_ADDRESS_STRING_BUFFER_LEN];
 
                 if (pDestIp != NULL) {


### PR DESCRIPTION
*Issue #, if available:*
- Did not create an issue for it. I observed the log in my runs, which indicates that the STUN server is unreachable:

```
2025-05-06 00:43:43.406 INFO    getIpWithHostName(): ICE SERVER Hostname received: stun.kinesisvideo.us-west-2.amazonaws.com
2025-05-06 00:43:43.456 PROFILE parseIceServer(): ICE Server address for stun.kinesisvideo.us-west-2.amazonaws.com: 35.165.173.98

...

2025-05-06 00:43:43.526 DEBUG   iceUtilsSendStunPacket(): Sending BINDING_REQUEST to ip:35.165.173.98, port:443
2025-05-06 00:43:43.526 ERROR   socketSendDataWithRetry(): sendto() failed with errno No route to host(65)
2025-05-06 00:43:43.526 DEBUG   socketSendDataWithRetry(): Dest Ip: 35.165.173.98:443. family:1
2025-05-06 00:43:43.526 DEBUG   socketSendDataWithRetry(): hostIpAddr Ip: 11.112.x.x:58688. family:1
2025-05-06 00:43:43.526 DEBUG   socketSendDataWithRetry(): Close socket 14
2025-05-06 00:43:43.526 DEBUG   socketSendDataWithRetry(): Failed to send data. Bytes sent 0. Data len 28. Retry count 0
2025-05-06 00:43:43.526 DEBUG   socketSendDataWithRetry(): Warning: Send data failed with 0x5800001a
```

*What was changed?*
- Add additional logs. Specifically, the socket id (file descriptor) for each socket created.

*Why was it changed?*
- The socket ID helped me to troubleshoot the issue. By adding the socket id to its creation log, I was able to match the IP with the closing log (above). We can see it says "Close socket 14", but there is no corresponding 'open' log. It turns out that my socket 14 corresponded to:

```
2025-05-06 02:22:33.739 DEBUG   createSocketConnection(): create socket id: 12, with ip: 192.168.1.112:57914. family:1
2025-05-06 02:22:33.739 DEBUG   createSocketConnection(): create socket id: 13, with ip: 11.112.x.x:56696. family:1
2025-05-06 02:22:33.739 PROFILE iceAgentStartGathering(): [Host candidates setup time] Time taken: 0 ms
2025-05-06 02:22:33.739 DEBUG   createSocketConnection(): create socket id: 14, with ip: 11.112.x.x:57142. family:1
2025-05-06 02:22:33.739 DEBUG   createSocketConnection(): create socket id: 15, with ip: 192.168.1.112:63430. family:1
```

the `utun1000` network interface, which seems to not be working (no route to host). I added the `utun*` interface to the network interface filter and all the logs got cleaned up on my end.

*How was it changed?*
- Print the socket id (file descriptor) when the socket is created and when `sendto` fails to send the packet.

*What testing was done for the changes?*
- Run the changes locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
