### PR TITLE
Skip hostname parsing for stun servers

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -724,6 +724,7 @@ extern "C" {
  */
 #define KINESIS_VIDEO_STUN_URL_POSTFIX      "amazonaws.com"
 #define KINESIS_VIDEO_STUN_URL_POSTFIX_CN   "amazonaws.com.cn"
+#define KINESIS_VIDEO_STUN_URL_PREFIX       "stun."
 #define KINESIS_VIDEO_STUN_URL              "stun:stun.kinesisvideo.%s.%s:443"
 #define KINESIS_VIDEO_STUN_URL_WITHOUT_PORT "stun.kinesisvideo.%s.%s"
 

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -722,11 +722,12 @@ extern "C" {
 /**
  * Parameterized string for KVS STUN Server
  */
-#define KINESIS_VIDEO_STUN_URL_POSTFIX      "amazonaws.com"
-#define KINESIS_VIDEO_STUN_URL_POSTFIX_CN   "amazonaws.com.cn"
-#define KINESIS_VIDEO_STUN_URL_PREFIX       "stun."
-#define KINESIS_VIDEO_STUN_URL              "stun:stun.kinesisvideo.%s.%s:443"
-#define KINESIS_VIDEO_STUN_URL_WITHOUT_PORT "stun.kinesisvideo.%s.%s"
+#define KINESIS_VIDEO_STUN_URL_POSTFIX       "amazonaws.com"
+#define KINESIS_VIDEO_STUN_URL_POSTFIX_CN    "amazonaws.com.cn"
+#define KINESIS_VIDEO_STUN_URL_PREFIX        "stun."
+#define KINESIS_VIDEO_STUN_URL_PREFIX_LENGTH 5
+#define KINESIS_VIDEO_STUN_URL               "stun:stun.kinesisvideo.%s.%s:443"
+#define KINESIS_VIDEO_STUN_URL_WITHOUT_PORT  "stun.kinesisvideo.%s.%s"
 
 /**
  * Default signaling SSL port

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -425,7 +425,6 @@ STATUS getIpWithHostName(PCHAR hostname, PKvsIpAddress destIp)
 
     // Verify the generated address has the format x.x.x.x
     if (!isIpAddr(addr, hostnameLen) || retStatus != STATUS_SUCCESS) {
-
         // Only print the message for TURN servers since STUN addresses don't have the IP in the URL
         if (!isStunServer) {
             DLOGW("Parsing for address failed for %s, fallback to getaddrinfo", hostname);

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -406,6 +406,7 @@ STATUS getIpWithHostName(PCHAR hostname, PKvsIpAddress destIp)
     struct in_addr inaddr;
 
     CHAR addr[KVS_IP_ADDRESS_STRING_BUFFER_LEN + 1] = {'\0'};
+    BOOL isStunServer = STRNCMP(hostname, KINESIS_VIDEO_STUN_URL_PREFIX, ARRAY_SIZE(KINESIS_VIDEO_STUN_URL_PREFIX)) == 0;
 
     CHK(hostname != NULL, STATUS_NULL_ARG);
     DLOGI("ICE SERVER Hostname received: %s", hostname);
@@ -418,13 +419,18 @@ STATUS getIpWithHostName(PCHAR hostname, PKvsIpAddress destIp)
     // in place anyways
     if (isIpAddr(hostname, hostnameLen)) {
         MEMCPY(addr, hostname, hostnameLen);
-    } else {
+    } else if (!isStunServer) {
         retStatus = getIpAddrFromDnsHostname(hostname, addr, hostnameLen, addrLen);
     }
 
     // Verify the generated address has the format x.x.x.x
     if (!isIpAddr(addr, hostnameLen) || retStatus != STATUS_SUCCESS) {
-        DLOGW("Parsing for address failed for %s, fallback to getaddrinfo", hostname);
+
+        // Only print the message for TURN servers since STUN addresses don't have the IP in the URL
+        if (!isStunServer) {
+            DLOGW("Parsing for address failed for %s, fallback to getaddrinfo", hostname);
+        }
+
         errCode = getaddrinfo(hostname, NULL, NULL, &res);
         if (errCode != 0) {
             errStr = errCode == EAI_SYSTEM ? (strerror(errno)) : ((PCHAR) gai_strerror(errCode));

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -406,13 +406,14 @@ STATUS getIpWithHostName(PCHAR hostname, PKvsIpAddress destIp)
     struct in_addr inaddr;
 
     CHAR addr[KVS_IP_ADDRESS_STRING_BUFFER_LEN + 1] = {'\0'};
-    BOOL isStunServer = STRNCMP(hostname, KINESIS_VIDEO_STUN_URL_PREFIX, ARRAY_SIZE(KINESIS_VIDEO_STUN_URL_PREFIX)) == 0;
+    BOOL isStunServer;
 
     CHK(hostname != NULL, STATUS_NULL_ARG);
     DLOGI("ICE SERVER Hostname received: %s", hostname);
 
     hostnameLen = STRLEN(hostname);
     addrLen = SIZEOF(addr);
+    isStunServer = STRNCMP(hostname, KINESIS_VIDEO_STUN_URL_PREFIX, KINESIS_VIDEO_STUN_URL_PREFIX_LENGTH) == 0;
 
     // Adding this check in case we directly get an IP address. With the current usage pattern,
     // there is no way this function would receive an address directly, but having this check


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Skip the hostname parsing optimization for the STUN server

*Why was it changed?*
- As an optimization (to skip the getaddrinfo call), we can parse the URL of the TURN servers. However, the STUN server doesn't have the IP address in the URL that we can extract.
- This causes a useless warning log to get printed every time ([example](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/14790248732/job/41548268381#step:6:295)):

```
2025-05-02 14:54:05.947 INFO    getIpWithHostName(): ICE SERVER Hostname received: stun.kinesisvideo.***.amazonaws.com
2025-05-02 14:54:05.947 WARN    getIpAddrFromDnsHostname(): Received unexpected hostname format: stun.kinesisvideo.***.amazonaws.com
2025-05-02 14:54:05.947 WARN    getIpWithHostName(): Parsing for address failed for stun.kinesisvideo.***.amazonaws.com, fallback to getaddrinfo
2025-05-02 14:54:05.961 PROFILE parseIceServer(): ICE Server address for stun.kinesisvideo.***.amazonaws.com: 54.200.157.178
```

*How was it changed?*
- Don't attempt parsing the ICE server if the hostname starts with `stun.`.
- Don't print that log that the hostname failed to parse, if it the hostname starts with `stun.`.

*What testing was done for the changes?*
- Ran it locally and confirmed the log is no longer there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
