### PR TITLE
Increase the signaling message receive buffer size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CheckIncludeFiles)
 include(CheckFunctionExists)
 
 # The version MUST be updated before every release
-project(KinesisVideoWebRTCClient VERSION 1.12.0 LANGUAGES C)
+project(KinesisVideoWebRTCClient VERSION 1.12.1 LANGUAGES C)
 
 # User Flags
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -518,7 +518,7 @@ extern "C" {
 /**
  * Maximum length of signaling message
  */
-#define MAX_SIGNALING_MESSAGE_LEN (10 * 1024)
+#define MAX_SIGNALING_MESSAGE_LEN (10 * 1024 * 2)
 /*!@} */
 
 /////////////////////////////////////////////////////

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -518,7 +518,7 @@ extern "C" {
 /**
  * Maximum length of signaling message
  */
-#define MAX_SIGNALING_MESSAGE_LEN (10 * 1024 * 2)
+#define MAX_SIGNALING_MESSAGE_LEN 18750
 /*!@} */
 
 /////////////////////////////////////////////////////

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1897,6 +1897,7 @@ STATUS sendLwsMessage(PSignalingClient pSignalingClient, SIGNALING_MESSAGE_TYPE 
     ATOMIC_STORE(&pSignalingClient->pOngoingCallInfo->sendOffset, 0);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -1963,6 +1964,7 @@ STATUS writeLwsData(PSignalingClient pSignalingClient, BOOL awaitForResponse)
     CHK((SERVICE_CALL_RESULT) ATOMIC_LOAD(&pSignalingClient->messageResult) == SERVICE_CALL_RESULT_OK, STATUS_SIGNALING_MESSAGE_DELIVERY_FAILED);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (sendLocked) {
         MUTEX_UNLOCK(pSignalingClient->sendLock);

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -789,6 +789,7 @@ STATUS signalingStoreOngoingMessage(PSignalingClient pSignalingClient, PSignalin
     CHK_STATUS(stackQueueEnqueue(pSignalingClient->pMessageQueue, (UINT64) pSignalingMessage));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (locked) {
         MUTEX_UNLOCK(pSignalingClient->messageQueueLock);


### PR DESCRIPTION
*Issue #, if available:*
- We observed the following error message only on Chrome, and only after updating from 135 to 136, with the JS viewer with send video ❌  and send audio ✅ :
```
2025-05-06 18:33:11.823 WARN    lwsWssCallbackRoutine(): Failed in LWS handling routine with 0x5d000028
```
This corresponds to:
```
#define STATUS_SIGNALING_RECEIVED_MESSAGE_LARGER_THAN_MAX_DATA_LEN STATUS_SIGNALING_BASE + 0x00000028
```
- We did not observe the issue when both are enabled.

*What was changed?*
- Increase the size of the signaling message buffer.

*Why was it changed?*
- The buffer was too small. Looking at the release notes, Chrome added support for H.265 and the SDP offer generated by the browser increased in size.

*How was it changed?*
- ~~Doubled~~ ~1.83x'd the size of the constant. We can look into optimizing the size in the future.

*What testing was done for the changes?*
- Run it locally, which was previously not working and checked that it is able to connect with the JS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
