### PR TITLE
Enhance the ice config parser

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -450,10 +450,25 @@ extern "C" {
 #define MAX_ICE_CONFIG_USER_NAME_LEN 256
 
 /**
+ * Buffer length for ICE configuration user name, including null terminator.
+ *
+ * \sa MAX_ICE_CONFIG_USER_NAME_LEN
+ */
+#define MAX_ICE_CONFIG_USER_NAME_BUFFER_LEN (MAX_ICE_CONFIG_USER_NAME_LEN + 1)
+
+/**
  * Maximum allowed ICE configuration password length
- * https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_AWSAcuitySignalingService_IceServer.html#KinesisVideo-Type-AWSAcuitySignalingService_IceServer-Password
+ *
+ * \sa https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_signaling_IceServer.html#KinesisVideo-Type-signaling_IceServer-Password
  */
 #define MAX_ICE_CONFIG_CREDENTIAL_LEN 256
+
+/**
+ * Buffer length for ICE configuration password, including null terminator.
+ *
+ * \sa MAX_ICE_CONFIG_USER_NAME_LEN
+ */
+#define MAX_ICE_CONFIG_CREDENTIAL_BUFFER_LEN (MAX_ICE_CONFIG_CREDENTIAL_LEN + 1)
 
 /**
  * Maximum allowed signaling URI length
@@ -1137,9 +1152,9 @@ typedef struct {
  * https://www.w3.org/TR/webrtc/#rtciceserver-dictionary
  */
 typedef struct {
-    CHAR urls[MAX_ICE_CONFIG_URI_LEN + 1];              //!< URL of STUN/TURN Server
-    CHAR username[MAX_ICE_CONFIG_USER_NAME_LEN + 1];    //!< Username to be used with TURN server
-    CHAR credential[MAX_ICE_CONFIG_CREDENTIAL_LEN + 1]; //!< Password to be used with TURN server
+    CHAR urls[MAX_ICE_CONFIG_URI_LEN + 1];                 //!< URL of STUN/TURN Server
+    CHAR username[MAX_ICE_CONFIG_USER_NAME_BUFFER_LEN];    //!< Username to be used with TURN server
+    CHAR credential[MAX_ICE_CONFIG_CREDENTIAL_BUFFER_LEN]; //!< Password to be used with TURN server
 } RtcIceServer, *PRtcIceServer;
 
 /**
@@ -1388,12 +1403,12 @@ typedef struct {
  * NOTE:TTL is given in default which is 100ns duration
  */
 typedef struct {
-    UINT32 version;                                                  //!< Version of the struct
-    UINT64 ttl;                                                      //!< TTL of the configuration is 100ns
-    UINT32 uriCount;                                                 //!<  Number of Ice URI objects
-    CHAR uris[MAX_ICE_CONFIG_URI_COUNT][MAX_ICE_CONFIG_URI_LEN + 1]; //!< List of Ice server URIs
-    CHAR userName[MAX_ICE_CONFIG_USER_NAME_LEN + 1];                 //!< Username for the server
-    CHAR password[MAX_ICE_CONFIG_CREDENTIAL_LEN + 1];                //!< Password for the server
+    UINT32 version;                                                     //!< Version of the struct
+    UINT64 ttl;                                                         //!< TTL of the configuration is 100ns
+    UINT32 uriCount;                                                    //!<  Number of Ice URI objects
+    CHAR uris[MAX_ICE_CONFIG_URI_COUNT][MAX_ICE_CONFIG_URI_BUFFER_LEN]; //!< List of Ice server URIs
+    CHAR userName[MAX_ICE_CONFIG_USER_NAME_BUFFER_LEN];                 //!< Username for the server
+    CHAR password[MAX_ICE_CONFIG_CREDENTIAL_BUFFER_LEN];                //!< Password for the server
 } IceConfigInfo, *PIceConfigInfo;
 
 typedef struct {

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -30,6 +30,13 @@ extern "C" {
 #define MAX_ICE_CONFIG_URI_LEN 127
 
 /**
+ * Maximum allowed ICE URI buffer length, including the null terminator.
+ *
+ * \sa MAX_ICE_CONFIG_URI_LEN
+ */
+#define MAX_ICE_CONFIG_URI_BUFFER_LEN (MAX_ICE_CONFIG_URI_LEN + 1)
+
+/**
  * Maximum allowed relay protocol length
  */
 #define MAX_RELAY_PROTOCOL_LENGTH 8U
@@ -244,14 +251,14 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc-stats/#ice-server-dict*
  */
 typedef struct {
-    CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];   //!< STUN/TURN server URL
-    CHAR protocol[MAX_PROTOCOL_LENGTH + 1]; //!< Valid values: UDP, TCP
-    UINT32 iceServerIndex;                  //!< Ice server index to get stats from. Not available in spec! Needs to be
-                                            //!< populated by the application to get specific server stats
-    INT32 port;                             //!< Port number used by client
-    UINT64 totalRequestsSent;               //!< Total amount of requests that have been sent to the server
-    UINT64 totalResponsesReceived;          //!< Total number of responses received from the server
-    UINT64 totalRoundTripTime;              //!< Sum of RTTs of all the requests for which response has been received
+    CHAR url[MAX_ICE_CONFIG_URI_BUFFER_LEN]; //!< STUN/TURN server URL
+    CHAR protocol[MAX_PROTOCOL_LENGTH + 1];  //!< Valid values: UDP, TCP
+    UINT32 iceServerIndex;                   //!< Ice server index to get stats from. Not available in spec! Needs to be
+                                             //!< populated by the application to get specific server stats
+    INT32 port;                              //!< Port number used by client
+    UINT64 totalRequestsSent;                //!< Total amount of requests that have been sent to the server
+    UINT64 totalResponsesReceived;           //!< Total number of responses received from the server
+    UINT64 totalRoundTripTime;               //!< Sum of RTTs of all the requests for which response has been received
 } RtcIceServerStats, *PRtcIceServerStats;
 
 /**

--- a/src/source/Ice/IceUtils.h
+++ b/src/source/Ice/IceUtils.h
@@ -53,10 +53,10 @@ STATUS iceUtilsSendData(PBYTE, UINT32, PKvsIpAddress, PSocketConnection, struct 
 typedef struct {
     BOOL isTurn;
     BOOL isSecure;
-    CHAR url[MAX_ICE_CONFIG_URI_LEN + 1];
+    CHAR url[MAX_ICE_CONFIG_URI_BUFFER_LEN];
     KvsIpAddress ipAddress;
-    CHAR username[MAX_ICE_CONFIG_USER_NAME_LEN + 1];
-    CHAR credential[MAX_ICE_CONFIG_CREDENTIAL_LEN + 1];
+    CHAR username[MAX_ICE_CONFIG_USER_NAME_BUFFER_LEN];
+    CHAR credential[MAX_ICE_CONFIG_CREDENTIAL_BUFFER_LEN];
     KVS_SOCKET_PROTOCOL transport;
     IceServerSetIpFunc setIpFn;
 } IceServer, *PIceServer;

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1237,7 +1237,9 @@ STATUS parseIceConfigResponse(PCHAR pResponseStr, UINT32 responseLen, UINT8 maxI
                 jsonInIceServerList = TRUE;
 
                 CHK(tokens[i + 1].type == JSMN_ARRAY, STATUS_INVALID_API_CALL_RETURN_JSON);
-                CHK(tokens[i + 1].size <= maxIceConfigs, STATUS_SIGNALING_MAX_ICE_CONFIG_COUNT);
+                if (tokens[i + 1].size > maxIceConfigs) {
+                    DLOGW("Received more ice configs (%d) than supported (%d). Will ignore the rest.", tokens[i + 1].size, maxIceConfigs);
+                }
             }
         } else {
             pToken = &tokens[i];
@@ -1250,6 +1252,10 @@ STATUS parseIceConfigResponse(PCHAR pResponseStr, UINT32 responseLen, UINT8 maxI
                 }
                 continue;
             } else if (pToken->type == JSMN_OBJECT) {
+                if (configCount + 1 > maxIceConfigs) {
+                    // That's all we have room to parse
+                    break;
+                }
                 configCount++;
             } else if (compareJsonString(pResponseStr, pToken, JSMN_STRING, (PCHAR) "Username")) {
                 strLen = (UINT32) (pToken[1].end - pToken[1].start);

--- a/src/source/Signaling/LwsApiCalls.h
+++ b/src/source/Signaling/LwsApiCalls.h
@@ -281,6 +281,24 @@ STATUS wakeLwsServiceEventLoop(PSignalingClient, UINT32);
 STATUS terminateConnectionWithStatus(PSignalingClient, SERVICE_CALL_RESULT);
 STATUS configureLwsLogging(UINT32 kvsLogLevel);
 
+/**
+ * Parses ICE configuration from a JSON response string.
+ *
+ * @param[in] pResponseStr JSON string containing ICE server configuration.
+ * @param[in] responseLen Length of the JSON string (excluding null-terminator).
+ * @param[in] maxIceConfigs Maximum number of ICE configurations the array can hold.
+ * @param[out] pIceConfigs Pointer to array of IceConfigInfo structures to be populated.
+ * @param[out] pIceConfigCount Pointer to receive the number of ICE configurations parsed.
+ *
+ * @return STATUS code of the execution:
+ * - STATUS_SUCCESS: Successfully parsed ICE configuration.
+ * - STATUS_NULL_ARG: Invalid NULL argument provided.
+ * - STATUS_INVALID_API_CALL_RETURN_JSON: Malformed JSON or missing required fields.
+ * - STATUS_SIGNALING_MAX_ICE_CONFIG_COUNT: Too many ICE configurations in the string (more than maxIceConfigs).
+ * - STATUS_SIGNALING_MAX_ICE_URI_COUNT: Too many URIs in configuration (more than MAX_ICE_CONFIG_URI_COUNT).
+ */
+STATUS parseIceConfigResponse(const char*, UINT32, UINT8, PIceConfigInfo, PUINT32);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/source/Signaling/LwsApiCalls.h
+++ b/src/source/Signaling/LwsApiCalls.h
@@ -297,7 +297,7 @@ STATUS configureLwsLogging(UINT32 kvsLogLevel);
  * - STATUS_SIGNALING_MAX_ICE_CONFIG_COUNT: Too many ICE configurations in the string (more than maxIceConfigs).
  * - STATUS_SIGNALING_MAX_ICE_URI_COUNT: Too many URIs in configuration (more than MAX_ICE_CONFIG_URI_COUNT).
  */
-STATUS parseIceConfigResponse(const char*, UINT32, UINT8, PIceConfigInfo, PUINT32);
+STATUS parseIceConfigResponse(PCHAR, UINT32, UINT8, PIceConfigInfo, PUINT32);
 
 #ifdef __cplusplus
 }

--- a/src/source/Signaling/LwsApiCalls.h
+++ b/src/source/Signaling/LwsApiCalls.h
@@ -283,6 +283,8 @@ STATUS configureLwsLogging(UINT32 kvsLogLevel);
 
 /**
  * Parses ICE configuration from a JSON response string.
+ * If there are more ICE configurations in the string than maxIceConfigs, we will only
+ * parse up until maxIceConfigs.
  *
  * @param[in] pResponseStr JSON string containing ICE server configuration.
  * @param[in] responseLen Length of the JSON string (excluding null-terminator).
@@ -294,7 +296,6 @@ STATUS configureLwsLogging(UINT32 kvsLogLevel);
  * - STATUS_SUCCESS: Successfully parsed ICE configuration.
  * - STATUS_NULL_ARG: Invalid NULL argument provided.
  * - STATUS_INVALID_API_CALL_RETURN_JSON: Malformed JSON or missing required fields.
- * - STATUS_SIGNALING_MAX_ICE_CONFIG_COUNT: Too many ICE configurations in the string (more than maxIceConfigs).
  * - STATUS_SIGNALING_MAX_ICE_URI_COUNT: Too many URIs in configuration (more than MAX_ICE_CONFIG_URI_COUNT).
  */
 STATUS parseIceConfigResponse(PCHAR, UINT32, UINT8, PIceConfigInfo, PUINT32);

--- a/tst/IceConfigParsingTest.cpp
+++ b/tst/IceConfigParsingTest.cpp
@@ -1,0 +1,169 @@
+
+#include "WebRTCClientTestFixture.h"
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+class IceConfigParsingTest : public WebRtcClientTestBase {};
+
+TEST_F(IceConfigParsingTest, ParseSuccess)
+{
+    IceConfigInfo iceConfigs[MAX_ICE_CONFIG_COUNT];
+    UINT32 iceConfigCount;
+
+    const std::string mockResponse = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1",
+                "Password": "testPass1",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example1.com:443?transport=udp",
+                    "turn:example1.com:443?transport=tcp"
+                ]
+            },
+            {
+                "Username": "testUser2",
+                "Password": "testPass2",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example2.com:443?transport=udp"
+                ]
+            }
+        ]
+    })";
+    UINT32 mockResponseLen = mockResponse.length();
+
+    EXPECT_EQ(STATUS_SUCCESS, parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+
+    EXPECT_EQ(2, iceConfigCount);
+
+    // First config
+    EXPECT_STREQ("testUser1", iceConfigs[0].userName);
+    EXPECT_STREQ("testPass1", iceConfigs[0].password);
+    EXPECT_EQ(300 * HUNDREDS_OF_NANOS_IN_A_SECOND, iceConfigs[0].ttl);
+    EXPECT_EQ(2, iceConfigs[0].uriCount);
+    EXPECT_STREQ("turn:example1.com:443?transport=udp", iceConfigs[0].uris[0]);
+    EXPECT_STREQ("turn:example1.com:443?transport=tcp", iceConfigs[0].uris[1]);
+
+    // Second config
+    EXPECT_STREQ("testUser2", iceConfigs[1].userName);
+    EXPECT_STREQ("testPass2", iceConfigs[1].password);
+    EXPECT_EQ(300 * HUNDREDS_OF_NANOS_IN_A_SECOND, iceConfigs[1].ttl);
+    EXPECT_EQ(1, iceConfigs[1].uriCount);
+    EXPECT_STREQ("turn:example2.com:443?transport=udp", iceConfigs[1].uris[0]);
+}
+
+TEST_F(IceConfigParsingTest, InvalidArgs)
+{
+    IceConfigInfo iceConfigs[MAX_ICE_CONFIG_COUNT];
+    UINT32 iceConfigCount;
+
+    const std::string emptyResponse = "";
+    UINT32 emptyResponseLen = emptyResponse.length();
+
+    const std::string mockResponse = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1",
+                "Password": "testPass1",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example1.com:443?transport=udp"
+                ]
+            }
+        ]
+    })";
+    UINT32 mockResponseLen = mockResponse.length();
+
+    // NULL in a parameter
+    EXPECT_EQ(STATUS_NULL_ARG, parseIceConfigResponse(NULL, mockResponseLen, MAX_ICE_CONFIG_COUNT, iceConfigs, &iceConfigCount));
+    EXPECT_EQ(STATUS_NULL_ARG, parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, MAX_ICE_CONFIG_COUNT, NULL, &iceConfigCount));
+    EXPECT_EQ(STATUS_NULL_ARG, parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, MAX_ICE_CONFIG_COUNT, iceConfigs, NULL));
+
+    // Empty input string
+    EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON,
+              parseIceConfigResponse(emptyResponse.c_str(), emptyResponseLen, MAX_ICE_CONFIG_COUNT, iceConfigs, &iceConfigCount));
+
+    // 0 output parameter length
+    EXPECT_EQ(STATUS_INVALID_ARG, parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, 0, iceConfigs, &iceConfigCount));
+}
+
+TEST_F(IceConfigParsingTest, TooManyIceConfigsReturned)
+{
+    // Array size = 1
+    IceConfigInfo iceConfigs[1];
+    UINT32 iceConfigCount;
+
+    // But there are 2 ICE configurations returned in the response
+    const std::string mockResponse = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1",
+                "Password": "testPass1",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example1.com:443?transport=udp",
+                    "turn:example1.com:443?transport=tcp"
+                ]
+            },
+            {
+                "Username": "testUser2",
+                "Password": "testPass2",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example2.com:443?transport=udp"
+                ]
+            }
+        ]
+    })";
+    UINT32 mockResponseLen = mockResponse.length();
+
+    EXPECT_EQ(STATUS_SIGNALING_MAX_ICE_CONFIG_COUNT,
+              parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+}
+
+TEST_F(IceConfigParsingTest, TooManyUrisReturned)
+{
+    IceConfigInfo iceConfigs[MAX_ICE_CONFIG_COUNT];
+    UINT32 iceConfigCount;
+
+    // Create exactly MAX_ICE_CONFIG_URI_COUNT + 1 URIs to test the boundary
+    std::string uris;
+    for (UINT32 i = 0; i <= MAX_ICE_CONFIG_URI_COUNT; i++) {
+        if (i > 0) {
+            uris += ",\n                ";
+        }
+        uris += "\"turn:example" + std::to_string(i) + ".com:443?transport=udp\"";
+    }
+
+    const std::string mockResponse = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1",
+                "Password": "testPass1",
+                "Ttl": 300,
+                "Uris": [
+                    )" +
+        uris + R"(
+                ]
+            }
+        ]
+    })";
+
+    // Verify the error is returned
+    EXPECT_EQ(STATUS_SIGNALING_MAX_ICE_URI_COUNT,
+              parseIceConfigResponse(mockResponse.c_str(), mockResponse.length(), ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+
+    // Optionally verify the state wasn't modified
+    EXPECT_EQ(0, iceConfigCount);
+}
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/IceConfigParsingTest.cpp
+++ b/tst/IceConfigParsingTest.cpp
@@ -138,8 +138,17 @@ TEST_F(IceConfigParsingTest, TooManyIceConfigsReturned)
     })";
     UINT32 mockResponseLen = mockResponse.length();
 
-    EXPECT_EQ(STATUS_SIGNALING_MAX_ICE_CONFIG_COUNT,
+    EXPECT_EQ(STATUS_SUCCESS,
               parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+
+    EXPECT_EQ(1, iceConfigCount);
+    EXPECT_STREQ("testUser1", iceConfigs[0].userName);
+    EXPECT_STREQ("testPass1", iceConfigs[0].password);
+    EXPECT_EQ(300 * HUNDREDS_OF_NANOS_IN_A_SECOND, iceConfigs[0].ttl);
+    EXPECT_EQ(2, iceConfigs[0].uriCount);
+    EXPECT_STREQ("turn:example1.com:443?transport=udp", iceConfigs[0].uris[0]);
+    EXPECT_STREQ("turn:example1.com:443?transport=tcp", iceConfigs[0].uris[1]);
+
 }
 
 TEST_F(IceConfigParsingTest, UsernameIsTooLong)

--- a/tst/IceConfigParsingTest.cpp
+++ b/tst/IceConfigParsingTest.cpp
@@ -32,14 +32,23 @@ TEST_F(IceConfigParsingTest, ParseSuccess)
                 "Uris": [
                     "turn:example2.com:443?transport=udp"
                 ]
+            },
+            {
+                "Username": "testUser3",
+                "Password": "testPass3",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example3.com:443?transport=udp"
+                ]
             }
         ]
     })";
     UINT32 mockResponseLen = mockResponse.length();
 
-    EXPECT_EQ(STATUS_SUCCESS, parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+    EXPECT_EQ(STATUS_SUCCESS,
+              parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
 
-    EXPECT_EQ(2, iceConfigCount);
+    EXPECT_EQ(3, iceConfigCount);
 
     // First config
     EXPECT_STREQ("testUser1", iceConfigs[0].userName);
@@ -55,6 +64,13 @@ TEST_F(IceConfigParsingTest, ParseSuccess)
     EXPECT_EQ(300 * HUNDREDS_OF_NANOS_IN_A_SECOND, iceConfigs[1].ttl);
     EXPECT_EQ(1, iceConfigs[1].uriCount);
     EXPECT_STREQ("turn:example2.com:443?transport=udp", iceConfigs[1].uris[0]);
+
+    // Third config
+    EXPECT_STREQ("testUser3", iceConfigs[2].userName);
+    EXPECT_STREQ("testPass3", iceConfigs[2].password);
+    EXPECT_EQ(300 * HUNDREDS_OF_NANOS_IN_A_SECOND, iceConfigs[2].ttl);
+    EXPECT_EQ(1, iceConfigs[2].uriCount);
+    EXPECT_STREQ("turn:example3.com:443?transport=udp", iceConfigs[2].uris[0]);
 }
 
 TEST_F(IceConfigParsingTest, InvalidArgs)
@@ -81,15 +97,15 @@ TEST_F(IceConfigParsingTest, InvalidArgs)
 
     // NULL in a parameter
     EXPECT_EQ(STATUS_NULL_ARG, parseIceConfigResponse(NULL, mockResponseLen, MAX_ICE_CONFIG_COUNT, iceConfigs, &iceConfigCount));
-    EXPECT_EQ(STATUS_NULL_ARG, parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, MAX_ICE_CONFIG_COUNT, NULL, &iceConfigCount));
-    EXPECT_EQ(STATUS_NULL_ARG, parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, MAX_ICE_CONFIG_COUNT, iceConfigs, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, MAX_ICE_CONFIG_COUNT, NULL, &iceConfigCount));
+    EXPECT_EQ(STATUS_NULL_ARG, parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, MAX_ICE_CONFIG_COUNT, iceConfigs, NULL));
 
     // Empty input string
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON,
-              parseIceConfigResponse(emptyResponse.c_str(), emptyResponseLen, MAX_ICE_CONFIG_COUNT, iceConfigs, &iceConfigCount));
+              parseIceConfigResponse((PCHAR) emptyResponse.c_str(), emptyResponseLen, MAX_ICE_CONFIG_COUNT, iceConfigs, &iceConfigCount));
 
     // 0 output parameter length
-    EXPECT_EQ(STATUS_INVALID_ARG, parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, 0, iceConfigs, &iceConfigCount));
+    EXPECT_EQ(STATUS_INVALID_ARG, parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, 0, iceConfigs, &iceConfigCount));
 }
 
 TEST_F(IceConfigParsingTest, TooManyIceConfigsReturned)
@@ -123,7 +139,88 @@ TEST_F(IceConfigParsingTest, TooManyIceConfigsReturned)
     UINT32 mockResponseLen = mockResponse.length();
 
     EXPECT_EQ(STATUS_SIGNALING_MAX_ICE_CONFIG_COUNT,
-              parseIceConfigResponse(mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+              parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+}
+
+TEST_F(IceConfigParsingTest, UsernameIsTooLong)
+{
+    IceConfigInfo iceConfigs[MAX_ICE_CONFIG_COUNT];
+    UINT32 iceConfigCount;
+
+    // Username is one character too long
+    const std::string longUsername(MAX_ICE_CONFIG_USER_NAME_LEN + 1, 'M');
+
+    const std::string mockResponse = R"({
+        "IceServerList": [
+            {
+                "Username": ")" +
+        longUsername + R"(",
+                "Password": "testPass1",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example2.com:443?transport=udp"
+                ]
+            }
+        ]
+    })";
+    UINT32 mockResponseLen = mockResponse.length();
+
+    EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON,
+              parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+}
+
+TEST_F(IceConfigParsingTest, PasswordIsTooLong)
+{
+    IceConfigInfo iceConfigs[MAX_ICE_CONFIG_COUNT];
+    UINT32 iceConfigCount;
+
+    // Password is one character too long
+    const std::string longPassword(MAX_ICE_CONFIG_CREDENTIAL_LEN + 1, 'V');
+
+    const std::string mockResponse = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1"
+                "Password": ")" +
+        longPassword + R"(",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example2.com:443?transport=udp"
+                ]
+            }
+        ]
+    })";
+    UINT32 mockResponseLen = mockResponse.length();
+
+    EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON,
+              parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+}
+
+TEST_F(IceConfigParsingTest, UriIsTooLong)
+{
+    IceConfigInfo iceConfigs[MAX_ICE_CONFIG_COUNT];
+    UINT32 iceConfigCount;
+
+    // URI is one character too long
+    const std::string longUri(MAX_ICE_CONFIG_URI_LEN + 1, 'N');
+
+    const std::string mockResponse = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1",
+                "Password": "testPass1",
+                "Ttl": 300,
+                "Uris": [
+                    ")" +
+        longUri + R"("
+                ]
+            }
+        ]
+    })";
+    UINT32 mockResponseLen = mockResponse.length();
+
+    EXPECT_EQ(STATUS_SIGNALING_MAX_ICE_URI_LEN,
+              parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
 }
 
 TEST_F(IceConfigParsingTest, TooManyUrisReturned)
@@ -156,10 +253,96 @@ TEST_F(IceConfigParsingTest, TooManyUrisReturned)
 
     // Verify the error is returned
     EXPECT_EQ(STATUS_SIGNALING_MAX_ICE_URI_COUNT,
-              parseIceConfigResponse(mockResponse.c_str(), mockResponse.length(), ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+              parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponse.length(), ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
 
-    // Optionally verify the state wasn't modified
+    // Parsing failure, expecting nothing returned
     EXPECT_EQ(0, iceConfigCount);
+}
+
+TEST_F(IceConfigParsingTest, MalformedJson)
+{
+    IceConfigInfo iceConfigs[MAX_ICE_CONFIG_COUNT];
+    UINT32 iceConfigCount = 0;
+
+    // Missing closing brace
+    const std::string malformedJson1 = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1",
+                "Password": "testPass1",
+                "Ttl": 300,
+                "Uris": [
+                    "turn:example1.com:443?transport=udp"
+                ]
+    })";
+
+    // Invalid JSON structure
+    const std::string malformedJson2 = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1",
+                "Password": "testPass1",
+                "Ttl": "not_a_number",
+                "Uris": "not_an_array"
+            }
+        ]
+    })";
+
+    // Invalid array structure
+    const std::string malformedJson3 = R"({
+        "IceServerList": {
+            "not": "an array"
+        }
+    })";
+
+    EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON,
+              parseIceConfigResponse((PCHAR) malformedJson1.c_str(), malformedJson1.length(), ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+
+    EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON,
+              parseIceConfigResponse((PCHAR) malformedJson2.c_str(), malformedJson2.length(), ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+
+    EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON,
+              parseIceConfigResponse((PCHAR) malformedJson3.c_str(), malformedJson3.length(), ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+
+    // Parsing failure, expecting nothing returned
+    EXPECT_EQ(0, iceConfigCount);
+}
+
+TEST_F(IceConfigParsingTest, IgnoreExtraFieldsInTheJson)
+{
+    IceConfigInfo iceConfigs[MAX_ICE_CONFIG_COUNT];
+    UINT32 iceConfigCount;
+
+    const std::string mockResponse = R"({
+        "IceServerList": [
+            {
+                "Username": "testUser1",
+                "Password": "testPass1",
+                "Ttl": 250,
+                "Extra": "field",
+                "Uris": [
+                    "turn:example1.com:443?transport=udp",
+                    "turn:example1.com:443?transport=tcp"
+                ],
+                "SecondExtra": [
+                    "field"
+                ]
+            }
+        ]
+    })";
+    UINT32 mockResponseLen = mockResponse.length();
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              parseIceConfigResponse((PCHAR) mockResponse.c_str(), mockResponseLen, ARRAY_SIZE(iceConfigs), iceConfigs, &iceConfigCount));
+
+    EXPECT_EQ(1, iceConfigCount);
+
+    EXPECT_STREQ("testUser1", iceConfigs[0].userName);
+    EXPECT_STREQ("testPass1", iceConfigs[0].password);
+    EXPECT_EQ(250 * HUNDREDS_OF_NANOS_IN_A_SECOND, iceConfigs[0].ttl);
+    EXPECT_EQ(2, iceConfigs[0].uriCount);
+    EXPECT_STREQ("turn:example1.com:443?transport=udp", iceConfigs[0].uris[0]);
+    EXPECT_STREQ("turn:example1.com:443?transport=tcp", iceConfigs[0].uris[1]);
 }
 
 } // namespace webrtcclient


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Refactored ICE server configuration parsing into a dedicated function `parseIceConfigResponse`
- Fixed potential buffer overflow in string handling
- Added proper buffer length macros to clearly distinguish between string length and buffer size
- Improved error handling for malformed JSON responses
- Fixed incorrect array indexing in password field null termination

*Why was it changed?*
- Initially investigated to fix a bug where password field wasn't being properly null-terminated:

```
// Before: Incorrectly using userName instead of password
pSignalingClient->iceConfigs[configCount - 1].userName[MAX_ICE_CONFIG_CREDENTIAL_LEN] = '\0';
```

> [!NOTE]
> This fixes a potential non-null terminated password string. This is not currently an issue since the buffer is 257 long (to match [256 limit](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/API_signaling_IceServer.html#KinesisVideo-Type-signaling_IceServer-Password)). From calling getIceServer config a handful of times, the passwords returned to me were all under 50 characters long. The buffer is memset to 0 beforehand, so the string is always currently null-terminated.

- While fixing this, identified several opportunities for improvement:
  - String handling safety: Previous implementation used STRNCPY which required manual null termination
  - Buffer size clarity: Added explicit BUFFER_LEN macros to distinguish between content length and total buffer size
  - JSON parsing robustness: Made tokenCount signed to properly handle [jsmn_parse error codes](https://github.com/zserge/jsmn/blob/25647e692c7906b96ffd2b05ca54c097948e879c/jsmn.h#L54C1-L61C3)
  - Code maintainability: Extracted parsing logic to separate function for better testing and readability

*How was it changed?*
- Introduced new `BUFFER_LEN` macros (e.g., `MAX_ICE_CONFIG_URI_BUFFER_LEN`) to explicitly include null terminator
- Replaced `STRNCPY` with `SNPRINTF` for safer string handling
- Added comprehensive error handling for malformed JSON
- Made tokenCount signed (INT32) instead of UINT32 to properly handle JSON parser error codes
- Created dedicated unit tests to verify parsing behavior

*What testing was done for the changes?*
- Added comprehensive unit test suite (IceConfigParsingTest) covering:
  - Successful parsing scenarios (happy path)
  - Invalid argument handling
  - Buffer overflow prevention
  - Malformed JSON handling
  - Extra field handling
  - Maximum URI/config count and length handling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
