### PR TITLE
Fix undefined sanitizer reports for SDP

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -35,9 +35,8 @@ STATUS serializeSessionDescriptionInit(PRtcSessionDescriptionInit pSessionDescri
         if (sessionDescriptionJSON == NULL) {
             amountWritten = SNPRINTF(NULL, 0, "%*.*s%s", lineLen, lineLen, curr, SESSION_DESCRIPTION_INIT_LINE_ENDING);
         } else {
-            amountWritten = SNPRINTF(sessionDescriptionJSON + *sessionDescriptionJSONLen,
-                                     inputSize - *sessionDescriptionJSONLen, "%*.*s%s", lineLen, lineLen, curr,
-                                     SESSION_DESCRIPTION_INIT_LINE_ENDING);
+            amountWritten = SNPRINTF(sessionDescriptionJSON + *sessionDescriptionJSONLen, inputSize - *sessionDescriptionJSONLen, "%*.*s%s", lineLen,
+                                     lineLen, curr, SESSION_DESCRIPTION_INIT_LINE_ENDING);
         }
         CHK(sessionDescriptionJSON == NULL || ((inputSize - *sessionDescriptionJSONLen) >= amountWritten), STATUS_BUFFER_TOO_SMALL);
 
@@ -48,8 +47,8 @@ STATUS serializeSessionDescriptionInit(PRtcSessionDescriptionInit pSessionDescri
     if (sessionDescriptionJSON == NULL) {
         amountWritten = SNPRINTF(NULL, 0, SESSION_DESCRIPTION_INIT_TEMPLATE_TAIL);
     } else {
-        amountWritten = SNPRINTF(sessionDescriptionJSON + *sessionDescriptionJSONLen,
-                                 inputSize - *sessionDescriptionJSONLen, SESSION_DESCRIPTION_INIT_TEMPLATE_TAIL);
+        amountWritten = SNPRINTF(sessionDescriptionJSON + *sessionDescriptionJSONLen, inputSize - *sessionDescriptionJSONLen,
+                                 SESSION_DESCRIPTION_INIT_TEMPLATE_TAIL);
     }
     CHK(sessionDescriptionJSON == NULL || ((inputSize - *sessionDescriptionJSONLen) >= amountWritten), STATUS_BUFFER_TOO_SMALL);
     *sessionDescriptionJSONLen += (amountWritten + 1); // NULL terminator

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -9,6 +9,8 @@ STATUS serializeSessionDescriptionInit(PRtcSessionDescriptionInit pSessionDescri
     PCHAR curr, tail, next;
     UINT32 lineLen, inputSize = 0, amountWritten;
 
+    // NOTE: sessionDescriptionJSON can be NULL. In this case, no writing is actually done,
+    // but the size that it would have written is returned.
     CHK(pSessionDescriptionInit != NULL && sessionDescriptionJSONLen != NULL, STATUS_NULL_ARG);
 
     inputSize = *sessionDescriptionJSONLen;
@@ -30,21 +32,30 @@ STATUS serializeSessionDescriptionInit(PRtcSessionDescriptionInit pSessionDescri
             lineLen--;
         }
 
-        amountWritten =
-            SNPRINTF(sessionDescriptionJSON + *sessionDescriptionJSONLen, sessionDescriptionJSON == NULL ? 0 : inputSize - *sessionDescriptionJSONLen,
-                     "%*.*s%s", lineLen, lineLen, curr, SESSION_DESCRIPTION_INIT_LINE_ENDING);
+        if (sessionDescriptionJSON == NULL) {
+            amountWritten = SNPRINTF(NULL, 0, "%*.*s%s", lineLen, lineLen, curr, SESSION_DESCRIPTION_INIT_LINE_ENDING);
+        } else {
+            amountWritten = SNPRINTF(sessionDescriptionJSON + *sessionDescriptionJSONLen,
+                                     inputSize - *sessionDescriptionJSONLen, "%*.*s%s", lineLen, lineLen, curr,
+                                     SESSION_DESCRIPTION_INIT_LINE_ENDING);
+        }
         CHK(sessionDescriptionJSON == NULL || ((inputSize - *sessionDescriptionJSONLen) >= amountWritten), STATUS_BUFFER_TOO_SMALL);
 
         *sessionDescriptionJSONLen += amountWritten;
         curr = next + 1;
     }
 
-    amountWritten = SNPRINTF(sessionDescriptionJSON + *sessionDescriptionJSONLen,
-                             sessionDescriptionJSON == NULL ? 0 : inputSize - *sessionDescriptionJSONLen, SESSION_DESCRIPTION_INIT_TEMPLATE_TAIL);
+    if (sessionDescriptionJSON == NULL) {
+        amountWritten = SNPRINTF(NULL, 0, SESSION_DESCRIPTION_INIT_TEMPLATE_TAIL);
+    } else {
+        amountWritten = SNPRINTF(sessionDescriptionJSON + *sessionDescriptionJSONLen,
+                                 inputSize - *sessionDescriptionJSONLen, SESSION_DESCRIPTION_INIT_TEMPLATE_TAIL);
+    }
     CHK(sessionDescriptionJSON == NULL || ((inputSize - *sessionDescriptionJSONLen) >= amountWritten), STATUS_BUFFER_TOO_SMALL);
     *sessionDescriptionJSONLen += (amountWritten + 1); // NULL terminator
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Refactored `serializeSessionDescriptionInit` to eliminate undefined behavior in buffer size calculation logic

*Why was it changed?*
- The function previously performed pointer arithmetic on NULL pointers during buffer size calculation phase
- While functionally working, this triggered UndefinedBehaviorSanitizer warnings:

```
2025-05-13 17:26:20.144 INFO    main(): [KVS Viewer] Completed setting local description
2025-05-13 17:26:20.144 INFO    main(): [KVS Viewer] Offer creation successful
2025-05-13 17:26:20.144 INFO    main(): [KVS Viewer] Generating JSON of session description....
/Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/PeerConnection/SessionDescription.c:34:13: runtime error: applying non-zero offset 26 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/PeerConnection/SessionDescription.c:34:13 in 
/Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/PeerConnection/SessionDescription.c:34:13: runtime error: applying non-zero offset 26 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/PeerConnection/SessionDescription.c:34:13 in 
/Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/PeerConnection/SessionDescription.c:42:21: runtime error: applying non-zero offset 3980 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/PeerConnection/SessionDescription.c:42:21 in 
/Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/PeerConnection/SessionDescription.c:42:21: runtime error: applying non-zero offset 3980 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/PeerConnection/SessionDescription.c:42:21
```

*How was it changed?*
- Adjusted the logic to pass in `NULL` as the destination to `SNPRINTF` instead of `NULL + something` when NULL is provided.
- Separated the buffer size calculation and buffer writing logic paths
- Added comment noting the dual-purpose nature of the function (size calculation vs actual writing)

*What testing was done for the changes?*
- Ran the C viewer with the JS master with H.264 and H.265 and confirmed no more warnings from undefined behavior sanitizer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
