### PR TITLE
Sctp.c: Fix `multi-line comment` compiler error

### DIFF
--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -210,11 +210,11 @@ CleanUp:
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //     \                                                               /
 //     |                             Label                             |
-//     /                                                               \
+//     /                                                               /
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //     \                                                               /
 //     |                            Protocol                           |
-//     /                                                               \
+//     /                                                               /
 //     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 STATUS sctpSessionWriteDcep(PSctpSession pSctpSession, UINT32 streamId, PCHAR pChannelName, UINT32 pChannelNameLen,
                             PRtcDataChannelInit pRtcDataChannelInit)


### PR DESCRIPTION
The change fixes following compiler complain:

```
/Users/vikramdattu/work/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sctp/Sctp.c: At top level:
/Users/vikramdattu/work/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sctp/Sctp.c:213:1: error: multi-line comment [-Werror=comment]
  213 | //     /                                                               \
      | ^
/Users/vikramdattu/work/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Sctp/Sctp.c:217:1: error: multi-line comment [-Werror=comment]
  217 | //     /                                                               \
      | ^
```

`\` Appends next line to current line, leading the above error with multiline-comment.

Fix: Change it to `/`