### PR TITLE
Fix H265 FMTP issue with kvsWebrtcClientViewer

### DIFF
--- a/src/source/PeerConnection/SessionDescription.h
+++ b/src/source/PeerConnection/SessionDescription.h
@@ -51,10 +51,8 @@ extern "C" {
 #define DEFAULT_PAYLOAD_MULAW_STR (PCHAR) "0"
 #define DEFAULT_PAYLOAD_ALAW_STR  (PCHAR) "8"
 
-#define DEFAULT_H264_FMTP (PCHAR) "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f"
-#define DEFAULT_H265_FMTP                                                                                                                            \
-    (PCHAR) "profile-space=0;profile-id=0;tier-flag=0;level-id=0;interop-constraints=000000000000;sprop-vps=QAEMAf//"                                \
-            "AIAAAAMAAAMAAAMAAAMAALUCQA==;sprop-sps=QgEBAIAAAAMAAAMAAAMAAAMAAKACgIAtH+W1kkbQzkkktySqSfKSyA==;sprop-pps=RAHBpVgeSA=="
+#define DEFAULT_H264_FMTP   (PCHAR) "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f"
+#define DEFAULT_H265_FMTP   (PCHAR) "level-id=93;profile-id=1"
 #define DEFAULT_OPUS_FMTP   (PCHAR) "minptime=10;useinbandfec=1"
 #define H264_PROFILE_42E01F 0x42e01f
 // profile-level-id:


### PR DESCRIPTION
Add new default H265 fmtp
    · level-id to be 93 (Level 3.1, 720p)
    · profile-id to be 1 (Main profile)

Fixed the issue of connection failure caused by incorrect h265 fmtp format.

It has already been tested on  ubuntu、 Amba S5l 、Ingenic T31 、Asrmicro and Rockchip rv1126.
