### PR TITLE
Support dynamically allocated signaling payload

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1263,6 +1263,15 @@ typedef struct {
 } RtcIceCandidateInit, *PRtcIceCandidateInit;
 
 /**
+ * @brief Define this macro to use dynamically allocated payload in SignalingMessage
+ * This can be useful for platforms with limited memory as it avoids allocating
+ * MAX_SIGNALING_MESSAGE_LEN for each message when only a small payload is needed
+ */
+#ifndef DYNAMIC_SIGNALING_PAYLOAD
+#define DYNAMIC_SIGNALING_PAYLOAD   1
+#endif
+
+/**
  * @brief Structure defining the basic signaling message
  */
 typedef struct {
@@ -1276,7 +1285,11 @@ typedef struct {
 
     UINT32 payloadLen; //!< Optional payload length. If 0, the length will be calculated
 
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    PCHAR payload; //!< Actual signaling message payload - dynamically allocated
+#else
     CHAR payload[MAX_SIGNALING_MESSAGE_LEN + 1]; //!< Actual signaling message payload
+#endif
 } SignalingMessage, *PSignalingMessage;
 
 /**

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -2017,6 +2017,10 @@ STATUS receiveLwsMessage(PSignalingClient pSignalingClient, PCHAR pMessage, UINT
 
     CHK(NULL != (pSignalingMessageWrapper = (PSignalingMessageWrapper) MEMCALLOC(1, SIZEOF(SignalingMessageWrapper))), STATUS_NOT_ENOUGH_MEMORY);
 
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    CHK(NULL != (pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage.payload = (PBYTE) MEMCALLOC(1, MAX_SIGNALING_MESSAGE_LEN + 1)), STATUS_NOT_ENOUGH_MEMORY);
+#endif
+
     pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
 
     // Loop through the tokens and extract the stream description
@@ -2235,7 +2239,11 @@ CleanUp:
         if (IS_VALID_TID_VALUE(receivedTid)) {
             THREAD_CANCEL(receivedTid);
         }
-
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+        if (pSignalingMessageWrapper) {
+            SAFE_MEMFREE(pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage.payload);
+        }
+#endif
         SAFE_MEMFREE(pSignalingMessageWrapper);
     }
 
@@ -2402,6 +2410,9 @@ PVOID receiveLwsMessageWrapper(PVOID args)
 CleanUp:
     CHK_LOG_ERR(retStatus);
 
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage.payload);
+#endif
     SAFE_MEMFREE(pSignalingMessageWrapper);
 
     return (PVOID) (ULONG_PTR) retStatus;


### PR DESCRIPTION
*Issue #, if available:*
- We end up allocating `MAX_SIGNALING_MESSAGE_LEN` per signaling message received.

*What was changed?*
- Configuration to choose to do this allocation dynamically.

*Why was it changed?*
-  For memory constrained devices, this is a huge deal. and would reduce(~couple of 100KBs of) peak memory usage.

*How was it changed?*
- 

*What testing was done for the changes?*
- 
