### PR TITLE
Refactor Signaling sources to make `Include_i.h` independent of libwebsockets

### DIFF
--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -54,8 +54,6 @@ extern "C" {
 #define INET6 1
 #include <usrsctp.h>
 
-#include <libwebsockets.h>
-
 #if !defined __WINDOWS_BUILD__
 #include <signal.h>
 #include <sys/types.h>
@@ -67,6 +65,7 @@ extern "C" {
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #endif
 
 // Max uFrag and uPwd length as documented in https://tools.ietf.org/html/rfc5245#section-15.4

--- a/src/source/Signaling/LwsApiCalls.h
+++ b/src/source/Signaling/LwsApiCalls.h
@@ -167,11 +167,14 @@ extern "C" {
 // Encoded max ice server infos string len
 #define MAX_ENCODED_ICE_SERVER_INFOS_STR_LEN (MAX_ICE_SERVER_INFOS_STR_LEN + ICE_SERVER_INFO_TEMPLATE_BLOAT_SIZE)
 
+// Alignment bytes for libwebsockets (Internally, it might end up using lesser than 16)
+#define LWS_ALIGN_BYTES 16
+
 // Scratch buffer size
-#define LWS_SCRATCH_BUFFER_SIZE (MAX_JSON_PARAMETER_STRING_LEN + LWS_PRE)
+#define LWS_SCRATCH_BUFFER_SIZE (MAX_JSON_PARAMETER_STRING_LEN + LWS_ALIGN_BYTES)
 
 // Send and receive buffer size
-#define LWS_MESSAGE_BUFFER_SIZE (SIZEOF(CHAR) * (MAX_SIGNALING_MESSAGE_LEN + LWS_PRE))
+#define LWS_MESSAGE_BUFFER_SIZE (SIZEOF(CHAR) * (MAX_SIGNALING_MESSAGE_LEN + LWS_ALIGN_BYTES))
 
 #define AWS_SIG_V4_HEADER_HOST (PCHAR) "host"
 
@@ -251,8 +254,8 @@ PVOID lwsListenerHandler(PVOID);
 PVOID reconnectHandler(PVOID);
 
 // LWS callback routine
-INT32 lwsHttpCallbackRoutine(struct lws*, enum lws_callback_reasons, PVOID, PVOID, size_t);
-INT32 lwsWssCallbackRoutine(struct lws*, enum lws_callback_reasons, PVOID, PVOID, size_t);
+INT32 lwsHttpCallbackRoutine(PVOID, INT32, PVOID, PVOID, size_t);
+INT32 lwsWssCallbackRoutine(PVOID, INT32, PVOID, PVOID, size_t);
 
 BOOL isCallResultSignatureExpired(PCallInfo);
 BOOL isCallResultSignatureNotYetCurrent(PCallInfo);

--- a/src/source/Signaling/Signaling.h
+++ b/src/source/Signaling/Signaling.h
@@ -337,14 +337,15 @@ typedef struct {
     // Restarted thread handler
     ThreadTracker reconnecterTracker;
 
-    // LWS context to use for Restful API
-    struct lws_context* pLwsContext;
+    // Generic websocket context - can be used by any implementation
+    PVOID pWebsocketContext;
 
-    // Signaling protocols - one more for the NULL terminator protocol
-    struct lws_protocols signalingProtocols[LWS_PROTOCOL_COUNT + 1];
+    // Generic websocket protocols array - can be used by any implementation
+    // + 1 for the null terminator protocol
+    PVOID signalingProtocols[LWS_PROTOCOL_COUNT + 1];
 
-    // Stored wsi objects
-    struct lws* currentWsi[LWS_PROTOCOL_COUNT];
+    // Generic websocket connection objects - can be used by any implementation
+    PVOID currentWsi[LWS_PROTOCOL_COUNT];
 
     // List of the ongoing messages
     PStackQueue pMessageQueue;


### PR DESCRIPTION
 - This way, one could write a new CMakeLists.txt, with ApiCalls using different websocket implementation
 - One should simply remove existing Signaling.c and LwsApiCalls.c from compilation and add their own

*What was changed?*
-  Include_i.h and other SIgnaling files modified to contain libwebsockets dependency to C files

*Why was it changed?*
- To make it easier to swap the signaling implementation keeping headers re-usable
