### PR TITLE
Prefer dynamic allocations over large STATIC arrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,42 @@ jobs:
 
   # ----------------------------------------------------
 
+  dynamic-allocs-check:
+    needs: cleanup-old-resources
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.x'
+
+      - name: Build repository
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DBUILD_TEST=ON -DPREFER_DYNAMIC_ALLOCS=ON -DENABLE_AWS_SDK_IN_TESTS=OFF
+          make -j
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Run tests
+        working-directory: ./build
+        run: |
+          ./tst/webrtc_client_test
+
   stats-calc-control-check:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -182,7 +182,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DPARALLEL_BUILD=ON
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DPARALLEL_BUILD=ON -DPREFER_DYNAMIC_ALLOCS=ON
           make -j
 
       - name: Run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(ENABLE_STATS_CALCULATION_CONTROL "Enable support for runtime control of i
 option(BUILD_OLD_MBEDTLS_VERSION "Use MbedTLS version 2.28.8." OFF)
 option(INCREASE_PRECISION_TIMING_LOGS "PROFILE-level timing logs have 2 decimals of milliseconds (otherwise truncated to whole millisecond)" ON)
 option(PARALLEL_BUILD "Build dependencies with parallel flag" OFF)
+option(PREFER_DYNAMIC_ALLOCS "Prefer dynamic allocations for signalingpayloads and URLs" OFF)
 
 # Developer Flags
 option(BUILD_TEST "Build the testing tree." OFF)
@@ -166,6 +167,10 @@ endif()
 
 if (USE_LIBSRTP3)
   add_definitions(-DUSE_LIBSRTP3)
+endif()
+
+if (PREFER_DYNAMIC_ALLOCS)
+  add_definitions(-DPREFER_DYNAMIC_ALLOCS=1)
 endif()
 
 if(USE_OPENSSL)

--- a/README.md
+++ b/README.md
@@ -477,6 +477,27 @@ CHK_STATUS(configureTransceiverRollingBuffer(pVideoRtcRtpTransceiver, &videoTrac
 By setting these up, applications can have better control over the amount of memory that the application consumes. However, note, if the allocation is too small and the network bad leading to multiple nacks, it can lead to choppy media / dropped frames. Hence, care must be taken while deciding on the values to ensure the parameters satisfy necessary performance requirements.
 For more information, check the sample to see how these values are set up.
 
+### Preferring dynamic allocations over large static arrays
+
+Build with `-DPREFER_DYNAMIC_ALLOCS=ON` to replace the signaling path's
+large stack buffers with heap allocations — useful on constrained
+platforms (e.g. ESP32). This enables `USE_DYNAMIC_URL` (transparent;
+URL / paramsJson sized via `SNPRINTF(NULL, 0, ...)`) and
+`DYNAMIC_SIGNALING_PAYLOAD` (`SignalingMessage.payload` becomes a
+`PCHAR` instead of `CHAR[MAX_SIGNALING_MESSAGE_LEN + 1]`). The SDK and
+the application must agree on the flag.
+
+Release the payload via the SDK-side helper (declared unconditionally,
+no-op in the static build, so callers don't need an `#ifdef`):
+
+```c
+ReceivedSignalingMessage receivedMessage;
+parseSignalingMessage(json, jsonLen, &receivedMessage);
+freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+```
+
+See `samples/common/Common.c` for usage.
+
 ## Setup IoT
 * To use IoT certificate to authenticate with KVS signaling, please refer to [Controlling Access to Kinesis Video Streams Resources Using AWS IoT](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/how-iot.html) for provisioning details.
 * A sample IAM policy for the IoT role looks like below, policy can be modified based on your permission requirement.

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -287,6 +287,12 @@ STATUS respondWithAnswer(PSampleStreamingSession pSampleStreamingSession)
     SignalingMessage message = {0};
     UINT32 buffLen = MAX_SIGNALING_MESSAGE_LEN;
 
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    /* MEMCALLOC so the +1 NULL-terminator byte is zeroed even if
+     * serializeSessionDescriptionInit doesn't write that last byte. */
+    message.payload = (PCHAR) MEMCALLOC(1, MAX_SIGNALING_MESSAGE_LEN + 1);
+    CHK(message.payload != NULL, STATUS_NOT_ENOUGH_MEMORY);
+#endif
     CHK_STATUS(serializeSessionDescriptionInit(&pSampleStreamingSession->answerSessionDescriptionInit, message.payload, &buffLen));
 
     message.version = SIGNALING_MESSAGE_CURRENT_VERSION;
@@ -300,6 +306,10 @@ STATUS respondWithAnswer(PSampleStreamingSession pSampleStreamingSession)
     CHK_STATUS(sendSignalingMessage(pSampleStreamingSession, &message));
 
 CleanUp:
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(message.payload);
+#endif
 
     CHK_LOG_ERR(retStatus);
     return retStatus;
@@ -343,12 +353,23 @@ VOID onIceCandidateHandler(UINT64 customData, PCHAR candidateJson)
         message.messageType = SIGNALING_MESSAGE_TYPE_ICE_CANDIDATE;
         STRNCPY(message.peerClientId, pSampleStreamingSession->peerId, MAX_SIGNALING_CLIENT_ID_LEN);
         message.payloadLen = (UINT32) STRNLEN(candidateJson, MAX_SIGNALING_MESSAGE_LEN);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+        /* MEMCALLOC so payload[payloadLen] is guaranteed '\0' — STRNCPY
+         * below copies exactly payloadLen bytes and does not write the
+         * terminator. */
+        message.payload = (PCHAR) MEMCALLOC(1, message.payloadLen + 1);
+        CHK(message.payload != NULL, STATUS_NOT_ENOUGH_MEMORY);
+#endif
         STRNCPY(message.payload, candidateJson, message.payloadLen);
         message.correlationId[0] = '\0';
         CHK_STATUS(sendSignalingMessage(pSampleStreamingSession, &message));
     }
 
 CleanUp:
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(message.payload);
+#endif
 
     CHK_LOG_ERR(retStatus);
 }
@@ -1531,6 +1552,7 @@ STATUS submitPendingIceCandidate(PPendingMessageQueue pPendingMessageQueue, PSam
             if (pReceivedSignalingMessage->signalingMessage.messageType == SIGNALING_MESSAGE_TYPE_ICE_CANDIDATE) {
                 CHK_STATUS(handleRemoteCandidate(pSampleStreamingSession, &pReceivedSignalingMessage->signalingMessage));
             }
+            freeSignalingMessagePayload(&pReceivedSignalingMessage->signalingMessage);
             SAFE_MEMFREE(pReceivedSignalingMessage);
         }
     } while (!noPendingSignalingMessageForClient);
@@ -1539,6 +1561,9 @@ STATUS submitPendingIceCandidate(PPendingMessageQueue pPendingMessageQueue, PSam
 
 CleanUp:
 
+    if (pReceivedSignalingMessage != NULL) {
+        freeSignalingMessagePayload(&pReceivedSignalingMessage->signalingMessage);
+    }
     SAFE_MEMFREE(pReceivedSignalingMessage);
     CHK_LOG_ERR(retStatus);
     return retStatus;
@@ -1659,6 +1684,13 @@ STATUS signalingMessageReceived(UINT64 customData, PReceivedSignalingMessage pRe
                 pReceivedSignalingMessageCopy = (PReceivedSignalingMessage) MEMCALLOC(1, SIZEOF(ReceivedSignalingMessage));
 
                 *pReceivedSignalingMessageCopy = *pReceivedSignalingMessage;
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+                pReceivedSignalingMessageCopy->signalingMessage.payload =
+                    (PCHAR) MEMALLOC(pReceivedSignalingMessage->signalingMessage.payloadLen + 1);
+                CHK(pReceivedSignalingMessageCopy->signalingMessage.payload != NULL, STATUS_NOT_ENOUGH_MEMORY);
+                STRNCPY(pReceivedSignalingMessageCopy->signalingMessage.payload, pReceivedSignalingMessage->signalingMessage.payload,
+                        pReceivedSignalingMessage->signalingMessage.payloadLen + 1);
+#endif
 
                 CHK_STATUS(stackQueueEnqueue(pPendingMessageQueue->messageQueue, (UINT64) pReceivedSignalingMessageCopy));
 
@@ -1692,7 +1724,15 @@ STATUS signalingMessageReceived(UINT64 customData, PReceivedSignalingMessage pRe
 
 CleanUp:
 
-    SAFE_MEMFREE(pReceivedSignalingMessageCopy);
+    if (pReceivedSignalingMessage != NULL) {
+        freeSignalingMessagePayload(&pReceivedSignalingMessage->signalingMessage);
+    }
+    if (pReceivedSignalingMessageCopy != NULL) {
+        /* Release the copy's own payload before the struct — under
+         * DYNAMIC_SIGNALING_PAYLOAD the copy owns a distinct heap buffer. */
+        freeSignalingMessagePayload(&pReceivedSignalingMessageCopy->signalingMessage);
+        SAFE_MEMFREE(pReceivedSignalingMessageCopy);
+    }
     if (pPendingMessageQueue != NULL) {
         freeMessageQueue(pPendingMessageQueue);
     }
@@ -1738,12 +1778,27 @@ CleanUp:
 STATUS freeMessageQueue(PPendingMessageQueue pPendingMessageQueue)
 {
     STATUS retStatus = STATUS_SUCCESS;
+    BOOL isEmpty = FALSE;
+    UINT64 item = 0;
+    PReceivedSignalingMessage pReceivedSignalingMessage = NULL;
 
     // free is idempotent
     CHK(pPendingMessageQueue != NULL, retStatus);
 
     if (pPendingMessageQueue->messageQueue != NULL) {
-        stackQueueClear(pPendingMessageQueue->messageQueue, TRUE);
+        // Drain any still-queued messages, releasing each one's dynamically-allocated
+        // payload (DYNAMIC_SIGNALING_PAYLOAD) before freeing the struct. A plain
+        // stackQueueClear(TRUE) would free the struct but leak the inner payload.
+        while (stackQueueIsEmpty(pPendingMessageQueue->messageQueue, &isEmpty) == STATUS_SUCCESS && !isEmpty) {
+            item = 0;
+            CHK_STATUS(stackQueueDequeue(pPendingMessageQueue->messageQueue, &item));
+            pReceivedSignalingMessage = (PReceivedSignalingMessage) item;
+            if (pReceivedSignalingMessage != NULL) {
+                freeSignalingMessagePayload(&pReceivedSignalingMessage->signalingMessage);
+                MEMFREE(pReceivedSignalingMessage);
+            }
+        }
+        stackQueueClear(pPendingMessageQueue->messageQueue, FALSE);
         stackQueueFree(pPendingMessageQueue->messageQueue);
     }
 

--- a/samples/p2p/kvsWebRTCClientViewer.c
+++ b/samples/p2p/kvsWebRTCClientViewer.c
@@ -140,11 +140,19 @@ INT32 main(INT32 argc, CHAR* argv[])
     DLOGI("[KVS Viewer] Generating JSON of session description....");
     CHK_STATUS(serializeSessionDescriptionInit(&offerSessionDescriptionInit, NULL, &buffLen));
 
-    if (buffLen >= SIZEOF(message.payload)) {
+    /* Under DYNAMIC_SIGNALING_PAYLOAD, message.payload is a PCHAR (pointer),
+     * so SIZEOF would only give the pointer width. Compare against the actual
+     * SDK-side cap, MAX_SIGNALING_MESSAGE_LEN, instead. */
+    if (buffLen > MAX_SIGNALING_MESSAGE_LEN + 1) {
         DLOGE("[KVS Viewer] serializeSessionDescriptionInit(): operation returned status code: 0x%08x ", STATUS_INVALID_OPERATION);
         retStatus = STATUS_INVALID_OPERATION;
         goto CleanUp;
     }
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    message.payload = (PCHAR) MEMCALLOC(1, buffLen);
+    CHK(message.payload != NULL, STATUS_NOT_ENOUGH_MEMORY);
+#endif
 
     CHK_STATUS(serializeSessionDescriptionInit(&offerSessionDescriptionInit, message.payload, &buffLen));
 
@@ -181,6 +189,10 @@ CleanUp:
     }
 
     DLOGI("[KVS Viewer] Cleaning up....");
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(message.payload);
+#endif
 
     if (locked) {
         MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);

--- a/samples/p2p/kvsWebRTCClientViewerGstSample.c
+++ b/samples/p2p/kvsWebRTCClientViewerGstSample.c
@@ -146,11 +146,19 @@ INT32 main(INT32 argc, CHAR* argv[])
     DLOGI("[KVS Gstreamer Viewer] Generating JSON of session description....");
     CHK_STATUS(serializeSessionDescriptionInit(&offerSessionDescriptionInit, NULL, &buffLen));
 
-    if (buffLen >= SIZEOF(message.payload)) {
+    /* Under DYNAMIC_SIGNALING_PAYLOAD, message.payload is a PCHAR (pointer),
+     * so SIZEOF would only give the pointer width. Compare against the actual
+     * SDK-side cap, MAX_SIGNALING_MESSAGE_LEN, instead. */
+    if (buffLen > MAX_SIGNALING_MESSAGE_LEN + 1) {
         DLOGE("[KVS Gstreamer Viewer] serializeSessionDescriptionInit(): operation returned status code: 0x%08x ", STATUS_INVALID_OPERATION);
         retStatus = STATUS_INVALID_OPERATION;
         goto CleanUp;
     }
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    message.payload = (PCHAR) MEMCALLOC(1, buffLen);
+    CHK(message.payload != NULL, STATUS_NOT_ENOUGH_MEMORY);
+#endif
 
     CHK_STATUS(serializeSessionDescriptionInit(&offerSessionDescriptionInit, message.payload, &buffLen));
 
@@ -187,6 +195,10 @@ CleanUp:
     }
 
     DLOGI("[KVS Gstreamer Viewer] Cleaning up....");
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(message.payload);
+#endif
 
     if (locked) {
         MUTEX_UNLOCK(pSampleConfiguration->sampleConfigurationObjLock);

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -2400,6 +2400,13 @@ PUBLIC_API STATUS signalingClientSendMessageSync(SIGNALING_CLIENT_HANDLE, PSigna
  *    no-op. Safe to invoke unconditionally so callers don't need their own
  *    `#ifdef`.
  *
+ * Call this on every SignalingMessage the SDK populates — including on
+ * failure paths. The SDK zeros the message struct before parsing, so the
+ * call is safe even when nothing was allocated; but if parsing fails after
+ * the payload has been allocated, skipping this call leaks that buffer.
+ * Treat it like a destructor that pairs with any SDK call which fills in
+ * a SignalingMessage / ReceivedSignalingMessage out-param.
+ *
  * Safe to call with a NULL pMessage.
  *
  * @param[in,out] pMessage SignalingMessage whose payload should be released.

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1511,6 +1511,15 @@ typedef struct {
 } RtcIceCandidateInit, *PRtcIceCandidateInit;
 
 /**
+ * @brief When PREFER_DYNAMIC_ALLOCS is enabled, use dynamic allocation for the
+ * signaling payload buffer. Reduces peak memory usage on constrained platforms.
+ * (Signaling API URL / paramsJson buffers are always dynamic now.)
+ */
+#if PREFER_DYNAMIC_ALLOCS
+#define DYNAMIC_SIGNALING_PAYLOAD 1
+#endif
+
+/**
  * @brief Structure defining the basic signaling message
  */
 typedef struct {
@@ -1524,7 +1533,11 @@ typedef struct {
 
     UINT32 payloadLen; //!< Optional payload length. If 0, the length will be calculated
 
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    PCHAR payload; //!< Actual signaling message payload - dynamically allocated
+#else
     CHAR payload[MAX_SIGNALING_MESSAGE_LEN + 1]; //!< Actual signaling message payload
+#endif
 } SignalingMessage, *PSignalingMessage;
 
 /**
@@ -2370,6 +2383,28 @@ PUBLIC_API STATUS freeSignalingClient(PSIGNALING_CLIENT_HANDLE);
  * @return STATUS code of the execution. STATUS_SUCCESS on success
  */
 PUBLIC_API STATUS signalingClientSendMessageSync(SIGNALING_CLIENT_HANDLE, PSignalingMessage);
+
+/**
+ * @brief Free the SignalingMessage payload.
+ *
+ * Symmetric helper for releasing whatever resources the payload uses.
+ * Behaviour depends on the build mode:
+ *  - `PREFER_DYNAMIC_ALLOCS=ON` (DYNAMIC_SIGNALING_PAYLOAD): the SDK
+ *    allocated the receive-side payload inside the parser via its own
+ *    allocator. This helper frees it through the same allocator. Calling
+ *    free() / application-side MEMFREE() is unsafe in shared-library builds
+ *    (mismatched allocator) and in test builds (instrumented-allocator
+ *    header mismatch).
+ *  - `PREFER_DYNAMIC_ALLOCS=OFF` (default): the payload is an inline array
+ *    inside SignalingMessage and there's nothing to free; the call is a
+ *    no-op. Safe to invoke unconditionally so callers don't need their own
+ *    `#ifdef`.
+ *
+ * Safe to call with a NULL pMessage.
+ *
+ * @param[in,out] pMessage SignalingMessage whose payload should be released.
+ */
+PUBLIC_API VOID freeSignalingMessagePayload(PSignalingMessage pMessage);
 
 /**
  * @brief Gets the retrieved ICE configuration information object count

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2676,11 +2676,18 @@ STATUS incomingRelayedDataHandler(UINT64 customData, PSocketConnection pSocketCo
 {
     STATUS retStatus = STATUS_SUCCESS;
     PIceCandidate pRelayedCandidate = (PIceCandidate) customData;
-    // this should be more than enough. Usually the number of channel data in each tcp message is around 4
-    TurnChannelData turnChannelData[DEFAULT_TURN_CHANNEL_DATA_BUFFER_SIZE] = {0};
-    UINT32 turnChannelDataCount = ARRAY_SIZE(turnChannelData), i = 0;
+    // Usually the number of channel data items per TCP message is ~4, but the
+    // buffer is sized for the worst case (DEFAULT_TURN_CHANNEL_DATA_BUFFER_SIZE).
+    // At 512 entries that is ~16 KB — far too large for the stack, and it
+    // overflows constrained worker-thread stacks (e.g. the ICE timer-queue
+    // executor) when this handler runs on them. Allocate it on the heap.
+    PTurnChannelData turnChannelData = NULL;
+    UINT32 turnChannelDataCount = DEFAULT_TURN_CHANNEL_DATA_BUFFER_SIZE, i = 0;
 
     CHK(pRelayedCandidate != NULL && pSocketConnection != NULL, STATUS_NULL_ARG);
+
+    CHK(NULL != (turnChannelData = (PTurnChannelData) MEMCALLOC(DEFAULT_TURN_CHANNEL_DATA_BUFFER_SIZE, SIZEOF(TurnChannelData))),
+        STATUS_NOT_ENOUGH_MEMORY);
 
     CHK_STATUS(turnConnectionIncomingDataHandler(pRelayedCandidate->pTurnConnection, pBuffer, bufferLen, pSrc, pDest, turnChannelData,
                                                  &turnChannelDataCount));
@@ -2690,6 +2697,7 @@ STATUS incomingRelayedDataHandler(UINT64 customData, PSocketConnection pSocketCo
     }
 
 CleanUp:
+    SAFE_MEMFREE(turnChannelData);
     CHK_LOG_ERR(retStatus);
 
     return retStatus;

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1091,8 +1091,8 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
     }
 
     // Allocate memory for paramsJson sized to the actual protocol string we'll write.
-    paramsJsonLen = SNPRINTF(NULL, 0, GET_CHANNEL_ENDPOINT_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
-                             protocols, getStringFromChannelRoleType(pSignalingClient->pChannelInfo->channelRoleType));
+    paramsJsonLen = SNPRINTF(NULL, 0, GET_CHANNEL_ENDPOINT_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn, protocols,
+                             getStringFromChannelRoleType(pSignalingClient->pChannelInfo->channelRoleType));
     paramsJsonLen += 1; // +1 for the NULL terminator
     paramsJson = (PCHAR) MEMALLOC(paramsJsonLen);
     CHK(paramsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
@@ -1102,8 +1102,8 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
     STRCAT(url, GET_SIGNALING_CHANNEL_ENDPOINT_API_POSTFIX);
 
     // Prepare the json params for the call
-    SNPRINTF(paramsJson, paramsJsonLen, GET_CHANNEL_ENDPOINT_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
-             protocols, getStringFromChannelRoleType(pSignalingClient->pChannelInfo->channelRoleType));
+    SNPRINTF(paramsJson, paramsJsonLen, GET_CHANNEL_ENDPOINT_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn, protocols,
+             getStringFromChannelRoleType(pSignalingClient->pChannelInfo->channelRoleType));
     DLOGD("Request params: %s", paramsJson);
 
     // Create the request info with the body

--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -750,8 +750,9 @@ STATUS describeChannelLws(PSignalingClient pSignalingClient, UINT64 time)
     UNUSED_PARAM(time);
 
     PRequestInfo pRequestInfo = NULL;
-    CHAR url[MAX_URI_CHAR_LEN + 1];
-    CHAR paramsJson[MAX_JSON_PARAMETER_STRING_LEN];
+    UINT32 paramsJsonLen = 0;
+    PCHAR url = NULL;
+    PCHAR paramsJson = NULL;
     PLwsCallInfo pLwsCallInfo = NULL;
     PCHAR pResponseStr;
     jsmn_parser parser;
@@ -763,12 +764,24 @@ STATUS describeChannelLws(PSignalingClient pSignalingClient, UINT64 time)
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
 
+    // Allocate memory for url
+    UINT32 urlLen = STRNLEN(pSignalingClient->pChannelInfo->pControlPlaneUrl, MAX_ARN_LEN) + STRLEN(DESCRIBE_SIGNALING_CHANNEL_API_POSTFIX);
+    urlLen += 1; // +1 for the NULL terminator
+    url = (PCHAR) MEMALLOC(urlLen);
+    CHK(url != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    // Allocate memory for paramsJson
+    paramsJsonLen = SNPRINTF(NULL, 0, DESCRIBE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->pChannelInfo->pChannelName);
+    paramsJsonLen += 1; // +1 for the NULL terminator
+    paramsJson = (PCHAR) MEMALLOC(paramsJsonLen);
+    CHK(paramsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
     // Create the API url
     STRCPY(url, pSignalingClient->pChannelInfo->pControlPlaneUrl);
     STRCAT(url, DESCRIBE_SIGNALING_CHANNEL_API_POSTFIX);
 
     // Prepare the json params for the call
-    SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), DESCRIBE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->pChannelInfo->pChannelName);
+    SNPRINTF(paramsJson, paramsJsonLen, DESCRIBE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->pChannelInfo->pChannelName);
     // Create the request info with the body
     CHK_STATUS(createRequestInfo(url, paramsJson, pSignalingClient->pChannelInfo->pRegion, pSignalingClient->pChannelInfo->pCertPath, NULL, NULL,
                                  SSL_CERTIFICATE_TYPE_NOT_SPECIFIED, pSignalingClient->pChannelInfo->pUserAgent,
@@ -881,6 +894,9 @@ CleanUp:
         DLOGE("Call Failed with Status:  0x%08x", retStatus);
     }
 
+    SAFE_MEMFREE(url);
+    SAFE_MEMFREE(paramsJson);
+
     freeLwsCallInfo(&pLwsCallInfo);
 
     LEAVES();
@@ -894,11 +910,13 @@ STATUS createChannelLws(PSignalingClient pSignalingClient, UINT64 time)
     UNUSED_PARAM(time);
 
     PRequestInfo pRequestInfo = NULL;
-    CHAR url[MAX_URI_CHAR_LEN + 1];
-    CHAR paramsJson[MAX_JSON_PARAMETER_STRING_LEN];
-    CHAR tagsJson[2 * MAX_JSON_PARAMETER_STRING_LEN];
-    PCHAR pCurPtr, pTagsStart, pResponseStr;
-    UINT32 i, strLen, resultLen;
+    UINT32 paramsJsonLen = 0;
+    PCHAR url = NULL;
+    PCHAR paramsJson = NULL;
+    PCHAR tagsJson = NULL;
+    PCHAR tagsScratch = NULL;
+    PCHAR pCurPtr, pResponseStr;
+    UINT32 i, strLen, resultLen, tagsJsonLen, scratchLen, remaining;
     INT32 charsCopied;
     PLwsCallInfo pLwsCallInfo = NULL;
     jsmn_parser parser;
@@ -907,31 +925,61 @@ STATUS createChannelLws(PSignalingClient pSignalingClient, UINT64 time)
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
 
+    // Allocate memory for url
+    UINT32 urlLen = STRNLEN(pSignalingClient->pChannelInfo->pControlPlaneUrl, MAX_ARN_LEN) + STRLEN(CREATE_SIGNALING_CHANNEL_API_POSTFIX);
+    urlLen += 1; // +1 for the NULL terminator
+    url = (PCHAR) MEMALLOC(urlLen);
+    CHK(url != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
     // Create the API url
     STRCPY(url, pSignalingClient->pChannelInfo->pControlPlaneUrl);
     STRCAT(url, CREATE_SIGNALING_CHANNEL_API_POSTFIX);
 
-    tagsJson[0] = '\0';
     if (pSignalingClient->pChannelInfo->tagCount != 0) {
-        // Prepare the tags elements. Format the list at the end
-        pCurPtr = tagsJson + MAX_JSON_PARAMETER_STRING_LEN;
-        pTagsStart = pCurPtr;
+        // Size the scratch holding each tag's JSON object
+        scratchLen = 1; // NULL terminator
         for (i = 0; i < pSignalingClient->pChannelInfo->tagCount; i++) {
-            charsCopied = SNPRINTF(pCurPtr, MAX_JSON_PARAMETER_STRING_LEN - (pCurPtr - pTagsStart), TAG_PARAM_JSON_OBJ_TEMPLATE,
-                                   pSignalingClient->pChannelInfo->pTags[i].name, pSignalingClient->pChannelInfo->pTags[i].value);
-            CHK(charsCopied > 0 && charsCopied < MAX_JSON_PARAMETER_STRING_LEN - (pCurPtr - pTagsStart), STATUS_INTERNAL_ERROR);
-            pCurPtr += charsCopied;
+            charsCopied = SNPRINTF(NULL, 0, TAG_PARAM_JSON_OBJ_TEMPLATE, pSignalingClient->pChannelInfo->pTags[i].name,
+                                   pSignalingClient->pChannelInfo->pTags[i].value);
+            CHK(charsCopied > 0, STATUS_INTERNAL_ERROR);
+            scratchLen += (UINT32) charsCopied;
         }
+        tagsScratch = (PCHAR) MEMALLOC(scratchLen);
+        CHK(tagsScratch != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
-        // Remove the tailing comma
-        *(pCurPtr - 1) = '\0';
+        // Concatenate the tag objects
+        pCurPtr = tagsScratch;
+        remaining = scratchLen;
+        for (i = 0; i < pSignalingClient->pChannelInfo->tagCount; i++) {
+            charsCopied = SNPRINTF(pCurPtr, remaining, TAG_PARAM_JSON_OBJ_TEMPLATE, pSignalingClient->pChannelInfo->pTags[i].name,
+                                   pSignalingClient->pChannelInfo->pTags[i].value);
+            CHK(charsCopied > 0 && (UINT32) charsCopied < remaining, STATUS_INTERNAL_ERROR);
+            pCurPtr += charsCopied;
+            remaining -= (UINT32) charsCopied;
+        }
+        *(pCurPtr - 1) = '\0'; // strip trailing comma
 
-        // Prepare the json params for the call
-        SNPRINTF(tagsJson, MAX_JSON_PARAMETER_STRING_LEN, TAGS_PARAM_JSON_TEMPLATE, tagsJson + MAX_JSON_PARAMETER_STRING_LEN);
+        // Wrap into "Tags":[ ... ]
+        tagsJsonLen = SNPRINTF(NULL, 0, TAGS_PARAM_JSON_TEMPLATE, tagsScratch) + 1;
+        tagsJson = (PCHAR) MEMALLOC(tagsJsonLen);
+        CHK(tagsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
+        SNPRINTF(tagsJson, tagsJsonLen, TAGS_PARAM_JSON_TEMPLATE, tagsScratch);
+    } else {
+        tagsJson = (PCHAR) MEMALLOC(1);
+        CHK(tagsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
+        tagsJson[0] = '\0';
     }
 
+    // Allocate memory for paramsJson
+    paramsJsonLen = SNPRINTF(NULL, 0, CREATE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->pChannelInfo->pChannelName,
+                             getStringFromChannelType(pSignalingClient->pChannelInfo->channelType),
+                             pSignalingClient->pChannelInfo->messageTtl / HUNDREDS_OF_NANOS_IN_A_SECOND, tagsJson);
+    paramsJsonLen += 1; // +1 for the NULL terminator
+    paramsJson = (PCHAR) MEMALLOC(paramsJsonLen);
+    CHK(paramsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
     // Prepare the json params for the call
-    SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), CREATE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->pChannelInfo->pChannelName,
+    SNPRINTF(paramsJson, paramsJsonLen, CREATE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->pChannelInfo->pChannelName,
              getStringFromChannelType(pSignalingClient->pChannelInfo->channelType),
              pSignalingClient->pChannelInfo->messageTtl / HUNDREDS_OF_NANOS_IN_A_SECOND, tagsJson);
 
@@ -988,6 +1036,11 @@ CleanUp:
         DLOGE("Call Failed with Status:  0x%08x", retStatus);
     }
 
+    SAFE_MEMFREE(url);
+    SAFE_MEMFREE(paramsJson);
+    SAFE_MEMFREE(tagsJson);
+    SAFE_MEMFREE(tagsScratch);
+
     freeLwsCallInfo(&pLwsCallInfo);
 
     LEAVES();
@@ -1001,8 +1054,9 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
     UNUSED_PARAM(time);
 
     PRequestInfo pRequestInfo = NULL;
-    CHAR url[MAX_URI_CHAR_LEN + 1];
-    CHAR paramsJson[MAX_JSON_PARAMETER_STRING_LEN];
+    UINT32 paramsJsonLen = 0;
+    PCHAR url = NULL;
+    PCHAR paramsJson = NULL;
     UINT32 i, resultLen, strLen, protocolLen = 0, endpointLen = 0;
     PCHAR pResponseStr, pProtocol = NULL, pEndpoint = NULL;
     PLwsCallInfo pLwsCallInfo = NULL;
@@ -1017,20 +1071,39 @@ STATUS getChannelEndpointLws(PSignalingClient pSignalingClient, UINT64 time)
     DLOGD("Storage status: %s (%d)", pSignalingClient->mediaStorageConfig.storageStatus ? "ENABLED" : "DISABLED",
           pSignalingClient->mediaStorageConfig.storageStatus);
 
+    // Allocate memory for url
+    UINT32 urlLen = STRNLEN(pSignalingClient->pChannelInfo->pControlPlaneUrl, MAX_ARN_LEN) + STRLEN(GET_SIGNALING_CHANNEL_ENDPOINT_API_POSTFIX);
+    urlLen += 1; // +1 for the NULL terminator
+    url = (PCHAR) MEMALLOC(urlLen);
+    CHK(url != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    // Pick the protocol list once so the pre-size and the write use the
+    // same string. SIGNALING_CHANNEL_PROTOCOL_W_MEDIA_STORAGE is longer than
+    // SIGNALING_CHANNEL_PROTOCOL; using a single value avoids a 10-byte
+    // heap overflow on the storage-enabled path.
+    PCHAR protocols;
+    if (pSignalingClient->mediaStorageConfig.storageStatus == FALSE) {
+        DLOGD("Requesting protocols: WSS, HTTPS (storage disabled - no WEBRTC)");
+        protocols = (PCHAR) SIGNALING_CHANNEL_PROTOCOL;
+    } else {
+        DLOGD("Requesting protocols: WSS, HTTPS, WEBRTC (storage enabled)");
+        protocols = (PCHAR) SIGNALING_CHANNEL_PROTOCOL_W_MEDIA_STORAGE;
+    }
+
+    // Allocate memory for paramsJson sized to the actual protocol string we'll write.
+    paramsJsonLen = SNPRINTF(NULL, 0, GET_CHANNEL_ENDPOINT_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
+                             protocols, getStringFromChannelRoleType(pSignalingClient->pChannelInfo->channelRoleType));
+    paramsJsonLen += 1; // +1 for the NULL terminator
+    paramsJson = (PCHAR) MEMALLOC(paramsJsonLen);
+    CHK(paramsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
     // Create the API url
     STRCPY(url, pSignalingClient->pChannelInfo->pControlPlaneUrl);
     STRCAT(url, GET_SIGNALING_CHANNEL_ENDPOINT_API_POSTFIX);
 
     // Prepare the json params for the call
-    if (pSignalingClient->mediaStorageConfig.storageStatus == FALSE) {
-        DLOGD("Requesting protocols: WSS, HTTPS (storage disabled - no WEBRTC)");
-        SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), GET_CHANNEL_ENDPOINT_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
-                 SIGNALING_CHANNEL_PROTOCOL, getStringFromChannelRoleType(pSignalingClient->pChannelInfo->channelRoleType));
-    } else {
-        DLOGD("Requesting protocols: WSS, HTTPS, WEBRTC (storage enabled)");
-        SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), GET_CHANNEL_ENDPOINT_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
-                 SIGNALING_CHANNEL_PROTOCOL_W_MEDIA_STORAGE, getStringFromChannelRoleType(pSignalingClient->pChannelInfo->channelRoleType));
-    }
+    SNPRINTF(paramsJson, paramsJsonLen, GET_CHANNEL_ENDPOINT_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
+             protocols, getStringFromChannelRoleType(pSignalingClient->pChannelInfo->channelRoleType));
     DLOGD("Request params: %s", paramsJson);
 
     // Create the request info with the body
@@ -1150,6 +1223,9 @@ CleanUp:
         DLOGE("Call Failed with Status:  0x%08x", retStatus);
     }
 
+    SAFE_MEMFREE(url);
+    SAFE_MEMFREE(paramsJson);
+
     freeLwsCallInfo(&pLwsCallInfo);
 
     LEAVES();
@@ -1163,13 +1239,28 @@ STATUS getIceConfigLws(PSignalingClient pSignalingClient, UINT64 time)
     UNUSED_PARAM(time);
 
     PRequestInfo pRequestInfo = NULL;
-    CHAR url[MAX_URI_CHAR_LEN + 1], paramsJson[MAX_JSON_PARAMETER_STRING_LEN];
+    UINT32 paramsJsonLen = 0;
+    PCHAR url = NULL;
+    PCHAR paramsJson = NULL;
     PLwsCallInfo pLwsCallInfo = NULL;
     PCHAR pResponseStr;
     UINT32 resultLen;
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     CHK(pSignalingClient->channelEndpointHttps[0] != '\0', STATUS_INTERNAL_ERROR);
+
+    // Allocate memory for url
+    UINT32 urlLen = STRNLEN(pSignalingClient->channelEndpointHttps, MAX_SIGNALING_ENDPOINT_URI_LEN) + STRLEN(GET_ICE_CONFIG_API_POSTFIX);
+    urlLen += 1; // +1 for the NULL terminator
+    url = (PCHAR) MEMALLOC(urlLen);
+    CHK(url != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    // Allocate memory for paramsJson
+    paramsJsonLen = SNPRINTF(NULL, 0, GET_ICE_CONFIG_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
+                             pSignalingClient->clientInfo.signalingClientInfo.clientId);
+    paramsJsonLen += 1; // +1 for the NULL terminator
+    paramsJson = (PCHAR) MEMALLOC(paramsJsonLen);
+    CHK(paramsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
     // Update the diagnostics info on the number of ICE refresh calls
     ATOMIC_INCREMENT(&pSignalingClient->diagnostics.iceRefreshCount);
@@ -1179,7 +1270,7 @@ STATUS getIceConfigLws(PSignalingClient pSignalingClient, UINT64 time)
     STRCAT(url, GET_ICE_CONFIG_API_POSTFIX);
 
     // Prepare the json params for the call
-    SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), GET_ICE_CONFIG_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
+    SNPRINTF(paramsJson, paramsJsonLen, GET_ICE_CONFIG_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
              pSignalingClient->clientInfo.signalingClientInfo.clientId);
 
     // Create the request info with the body
@@ -1220,6 +1311,9 @@ CleanUp:
     if (STATUS_FAILED(retStatus)) {
         DLOGE("Call Failed with Status:  0x%08x", retStatus);
     }
+
+    SAFE_MEMFREE(url);
+    SAFE_MEMFREE(paramsJson);
 
     freeLwsCallInfo(&pLwsCallInfo);
 
@@ -1328,8 +1422,10 @@ STATUS deleteChannelLws(PSignalingClient pSignalingClient, UINT64 time)
     UNUSED_PARAM(time);
 
     PRequestInfo pRequestInfo = NULL;
-    CHAR url[MAX_URI_CHAR_LEN + 1];
-    CHAR paramsJson[MAX_JSON_PARAMETER_STRING_LEN];
+    PCHAR url = NULL;
+    UINT32 urlLen = 0;
+    PCHAR paramsJson = NULL;
+    UINT32 paramsJsonLen = 0;
     PLwsCallInfo pLwsCallInfo = NULL;
     SIZE_T result;
 
@@ -1342,12 +1438,25 @@ STATUS deleteChannelLws(PSignalingClient pSignalingClient, UINT64 time)
         terminateConnectionWithStatus(pSignalingClient, SERVICE_CALL_RESULT_OK);
     }
 
+    // Allocate memory for url
+    urlLen = STRNLEN(pSignalingClient->pChannelInfo->pControlPlaneUrl, MAX_ARN_LEN) + STRLEN(DELETE_SIGNALING_CHANNEL_API_POSTFIX);
+    urlLen += 1; // +1 for the NULL terminator
+    url = (PCHAR) MEMALLOC(urlLen);
+    CHK(url != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    // Allocate memory for paramsJson
+    paramsJsonLen = SNPRINTF(NULL, 0, DELETE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
+                             pSignalingClient->channelDescription.updateVersion);
+    paramsJsonLen += 1; // +1 for the NULL terminator
+    paramsJson = (PCHAR) MEMALLOC(paramsJsonLen);
+    CHK(paramsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
     // Create the API url
     STRCPY(url, pSignalingClient->pChannelInfo->pControlPlaneUrl);
     STRCAT(url, DELETE_SIGNALING_CHANNEL_API_POSTFIX);
 
     // Prepare the json params for the call
-    SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), DELETE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
+    SNPRINTF(paramsJson, paramsJsonLen, DELETE_CHANNEL_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
              pSignalingClient->channelDescription.updateVersion);
 
     // Create the request info with the body
@@ -1384,6 +1493,9 @@ CleanUp:
     if (STATUS_FAILED(retStatus)) {
         DLOGE("Call Failed with Status:  0x%08x", retStatus);
     }
+
+    SAFE_MEMFREE(url);
+    SAFE_MEMFREE(paramsJson);
 
     freeLwsCallInfo(&pLwsCallInfo);
 
@@ -1452,7 +1564,7 @@ STATUS connectSignalingChannelLws(PSignalingClient pSignalingClient, UINT64 time
     UNUSED_PARAM(time);
 
     PRequestInfo pRequestInfo = NULL;
-    CHAR url[MAX_URI_CHAR_LEN + 1];
+    PCHAR url = NULL;
     PLwsCallInfo pLwsCallInfo = NULL;
     BOOL locked = FALSE;
     SERVICE_CALL_RESULT callResult = SERVICE_CALL_RESULT_NOT_SET;
@@ -1461,14 +1573,29 @@ STATUS connectSignalingChannelLws(PSignalingClient pSignalingClient, UINT64 time
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     CHK(pSignalingClient->channelEndpointWss[0] != '\0', STATUS_INTERNAL_ERROR);
 
+    UINT32 urlLen = 0;
+    if (pSignalingClient->pChannelInfo->channelRoleType == SIGNALING_CHANNEL_ROLE_TYPE_VIEWER) {
+        // Allocate memory for url
+        urlLen = SNPRINTF(NULL, 0, SIGNALING_ENDPOINT_VIEWER_URL_WSS_TEMPLATE, pSignalingClient->channelEndpointWss, SIGNALING_CHANNEL_ARN_PARAM_NAME,
+                          pSignalingClient->channelDescription.channelArn, SIGNALING_CLIENT_ID_PARAM_NAME,
+                          pSignalingClient->clientInfo.signalingClientInfo.clientId);
+    } else {
+        // Allocate memory for url
+        urlLen = SNPRINTF(NULL, 0, SIGNALING_ENDPOINT_MASTER_URL_WSS_TEMPLATE, pSignalingClient->channelEndpointWss, SIGNALING_CHANNEL_ARN_PARAM_NAME,
+                          pSignalingClient->channelDescription.channelArn);
+    }
+    urlLen += 1; // +1 for the NULL terminator
+    url = (PCHAR) MEMALLOC(urlLen);
+    CHK(url != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
     // Prepare the json params for the call
     if (pSignalingClient->pChannelInfo->channelRoleType == SIGNALING_CHANNEL_ROLE_TYPE_VIEWER) {
-        SNPRINTF(url, ARRAY_SIZE(url), SIGNALING_ENDPOINT_VIEWER_URL_WSS_TEMPLATE, pSignalingClient->channelEndpointWss,
-                 SIGNALING_CHANNEL_ARN_PARAM_NAME, pSignalingClient->channelDescription.channelArn, SIGNALING_CLIENT_ID_PARAM_NAME,
+        SNPRINTF(url, urlLen, SIGNALING_ENDPOINT_VIEWER_URL_WSS_TEMPLATE, pSignalingClient->channelEndpointWss, SIGNALING_CHANNEL_ARN_PARAM_NAME,
+                 pSignalingClient->channelDescription.channelArn, SIGNALING_CLIENT_ID_PARAM_NAME,
                  pSignalingClient->clientInfo.signalingClientInfo.clientId);
     } else {
-        SNPRINTF(url, ARRAY_SIZE(url), SIGNALING_ENDPOINT_MASTER_URL_WSS_TEMPLATE, pSignalingClient->channelEndpointWss,
-                 SIGNALING_CHANNEL_ARN_PARAM_NAME, pSignalingClient->channelDescription.channelArn);
+        SNPRINTF(url, urlLen, SIGNALING_ENDPOINT_MASTER_URL_WSS_TEMPLATE, pSignalingClient->channelEndpointWss, SIGNALING_CHANNEL_ARN_PARAM_NAME,
+                 pSignalingClient->channelDescription.channelArn);
     }
 
     // Create the request info with the body
@@ -1518,6 +1645,8 @@ CleanUp:
 
     CHK_LOG_ERR(retStatus);
 
+    SAFE_MEMFREE(url);
+
     if (STATUS_FAILED(retStatus) && pSignalingClient != NULL) {
         // Fix-up the timeout case
         SERVICE_CALL_RESULT serviceCallResult =
@@ -1546,13 +1675,31 @@ STATUS joinStorageSessionLws(PSignalingClient pSignalingClient, UINT64 time)
     UNUSED_PARAM(time);
 
     PRequestInfo pRequestInfo = NULL;
-    CHAR url[MAX_URI_CHAR_LEN + 1];
-    CHAR paramsJson[MAX_JSON_PARAMETER_STRING_LEN];
+    UINT32 paramsJsonLen = 0;
+    PCHAR url = NULL;
+    PCHAR paramsJson = NULL;
     PLwsCallInfo pLwsCallInfo = NULL;
 
     UNUSED_PARAM(pLwsCallInfo);
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     CHK(pSignalingClient->channelEndpointWebrtc[0] != '\0', STATUS_INTERNAL_ERROR);
+
+    // Allocate memory for url
+    UINT32 urlLen = STRNLEN(pSignalingClient->channelEndpointWebrtc, MAX_SIGNALING_ENDPOINT_URI_LEN) + STRLEN(JOIN_STORAGE_SESSION_API_POSTFIX);
+    urlLen += 1; // +1 for the NULL terminator
+    url = (PCHAR) MEMALLOC(urlLen);
+    CHK(url != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    // Allocate memory for paramsJson
+    if (pSignalingClient->pChannelInfo->channelRoleType == SIGNALING_CHANNEL_ROLE_TYPE_VIEWER) {
+        paramsJsonLen = SNPRINTF(NULL, 0, SIGNALING_JOIN_STORAGE_SESSION_VIEWER_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn,
+                                 pSignalingClient->clientInfo.signalingClientInfo.clientId);
+    } else {
+        paramsJsonLen = SNPRINTF(NULL, 0, SIGNALING_JOIN_STORAGE_SESSION_MASTER_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn);
+    }
+    paramsJsonLen += 1; // +1 for the NULL terminator
+    paramsJson = (PCHAR) MEMALLOC(paramsJsonLen);
+    CHK(paramsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
     // Create the API url
     STRCPY(url, pSignalingClient->channelEndpointWebrtc);
@@ -1560,10 +1707,10 @@ STATUS joinStorageSessionLws(PSignalingClient pSignalingClient, UINT64 time)
 
     // Prepare the json params for the call
     if (pSignalingClient->pChannelInfo->channelRoleType == SIGNALING_CHANNEL_ROLE_TYPE_VIEWER) {
-        SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), SIGNALING_JOIN_STORAGE_SESSION_VIEWER_PARAM_JSON_TEMPLATE,
+        SNPRINTF(paramsJson, paramsJsonLen, SIGNALING_JOIN_STORAGE_SESSION_VIEWER_PARAM_JSON_TEMPLATE,
                  pSignalingClient->channelDescription.channelArn, pSignalingClient->clientInfo.signalingClientInfo.clientId);
     } else {
-        SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), SIGNALING_JOIN_STORAGE_SESSION_MASTER_PARAM_JSON_TEMPLATE,
+        SNPRINTF(paramsJson, paramsJsonLen, SIGNALING_JOIN_STORAGE_SESSION_MASTER_PARAM_JSON_TEMPLATE,
                  pSignalingClient->channelDescription.channelArn);
     }
 
@@ -1605,6 +1752,9 @@ CleanUp:
         DLOGE("Call Failed with Status:  0x%08x", retStatus);
     }
 
+    SAFE_MEMFREE(url);
+    SAFE_MEMFREE(paramsJson);
+
     freeLwsCallInfo(&pLwsCallInfo);
 
     LEAVES();
@@ -1618,8 +1768,9 @@ STATUS describeMediaStorageConfLws(PSignalingClient pSignalingClient, UINT64 tim
     UNUSED_PARAM(time);
 
     PRequestInfo pRequestInfo = NULL;
-    CHAR url[MAX_URI_CHAR_LEN + 1];
-    CHAR paramsJson[MAX_JSON_PARAMETER_STRING_LEN];
+    UINT32 paramsJsonLen = 0;
+    PCHAR url = NULL;
+    PCHAR paramsJson = NULL;
     PLwsCallInfo pLwsCallInfo = NULL;
     PCHAR pResponseStr;
     jsmn_parser parser;
@@ -1641,13 +1792,25 @@ STATUS describeMediaStorageConfLws(PSignalingClient pSignalingClient, UINT64 tim
     DLOGD("Previous storage status: %s (%d)", previousStorageStatus ? "ENABLED" : "DISABLED", previousStorageStatus);
     DLOGD("Previous storage stream ARN: %s", pSignalingClient->mediaStorageConfig.storageStreamArn);
 
+    // Allocate memory for url
+    UINT32 urlLen = STRNLEN(pSignalingClient->pChannelInfo->pControlPlaneUrl, MAX_ARN_LEN) + STRLEN(DESCRIBE_MEDIA_STORAGE_CONF_API_POSTFIX);
+    urlLen += 1; // +1 for the NULL terminator
+    url = (PCHAR) MEMALLOC(urlLen);
+    CHK(url != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    // Allocate memory for paramsJson
+    paramsJsonLen = SNPRINTF(NULL, 0, DESCRIBE_MEDIA_STORAGE_CONF_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn);
+    paramsJsonLen += 1; // +1 for the NULL terminator
+    paramsJson = (PCHAR) MEMALLOC(paramsJsonLen);
+    CHK(paramsJson != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
     // Create the API url
     STRCPY(url, pSignalingClient->pChannelInfo->pControlPlaneUrl);
     STRCAT(url, DESCRIBE_MEDIA_STORAGE_CONF_API_POSTFIX);
 
     // Prepare the json params for the call
     CHK(pSignalingClient->channelDescription.channelArn[0] != '\0', STATUS_NULL_ARG);
-    SNPRINTF(paramsJson, ARRAY_SIZE(paramsJson), DESCRIBE_MEDIA_STORAGE_CONF_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn);
+    SNPRINTF(paramsJson, paramsJsonLen, DESCRIBE_MEDIA_STORAGE_CONF_PARAM_JSON_TEMPLATE, pSignalingClient->channelDescription.channelArn);
     // Create the request info with the body
     CHK_STATUS(createRequestInfo(url, paramsJson, pSignalingClient->pChannelInfo->pRegion, pSignalingClient->pChannelInfo->pCertPath, NULL, NULL,
                                  SSL_CERTIFICATE_TYPE_NOT_SPECIFIED, pSignalingClient->pChannelInfo->pUserAgent,
@@ -1742,6 +1905,9 @@ CleanUp:
     if (STATUS_FAILED(retStatus)) {
         DLOGE("Call Failed with Status:  0x%08x", retStatus);
     }
+
+    SAFE_MEMFREE(url);
+    SAFE_MEMFREE(paramsJson);
 
     freeLwsCallInfo(&pLwsCallInfo);
 
@@ -1859,7 +2025,8 @@ STATUS sendLwsMessage(PSignalingClient pSignalingClient, SIGNALING_MESSAGE_TYPE 
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    CHAR encodedMessage[MAX_SESSION_DESCRIPTION_INIT_SDP_LEN + 1];
+    UINT32 encodedMessageLen = 0;
+    PCHAR encodedMessage = NULL;
     CHAR encodedIceConfig[MAX_ENCODED_ICE_SERVER_INFOS_STR_LEN + 1];
     CHAR encodedUris[MAX_ICE_SERVER_URI_STR_LEN + 1];
     UINT32 size, writtenSize, correlationLen, iceCount, uriCount, urisLen, iceConfigLen;
@@ -1901,8 +2068,14 @@ STATUS sendLwsMessage(PSignalingClient pSignalingClient, SIGNALING_MESSAGE_TYPE 
         correlationLen = correlationIdLen;
     }
 
+    // Allocate memory for encodedMessage
+    encodedMessageLen = ((size + 2) / 3) * 4 + 1; // +1 for null terminator
+    CHK(encodedMessageLen <= MAX_SESSION_DESCRIPTION_INIT_SDP_LEN + 1, STATUS_INVALID_ARG);
+    encodedMessage = (PCHAR) MEMALLOC(encodedMessageLen);
+    CHK(encodedMessage != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
     // Base64 encode the message
-    writtenSize = ARRAY_SIZE(encodedMessage);
+    writtenSize = encodedMessageLen;
     CHK_STATUS(base64Encode(pMessage, size, encodedMessage, &writtenSize));
 
     // Account for the template expansion + Action string + max recipient id
@@ -1984,6 +2157,8 @@ STATUS sendLwsMessage(PSignalingClient pSignalingClient, SIGNALING_MESSAGE_TYPE 
 CleanUp:
     CHK_LOG_ERR(retStatus);
 
+    SAFE_MEMFREE(encodedMessage);
+
     LEAVES();
     return retStatus;
 }
@@ -2063,6 +2238,25 @@ CleanUp:
     return retStatus;
 }
 
+VOID freeSignalingMessagePayload(PSignalingMessage pMessage)
+{
+    if (pMessage == NULL) {
+        return;
+    }
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    if (pMessage->payload != NULL) {
+        /* MEMFREE here matches the SDK-side MEMCALLOC used in
+         * parseSignalingMessage; both go through this translation unit's
+         * allocator so static / shared / instrumented builds all work. */
+        MEMFREE(pMessage->payload);
+        pMessage->payload = NULL;
+    }
+#else
+    /* Static-array payload — nothing to release. */
+    (VOID) pMessage;
+#endif
+}
+
 STATUS parseSignalingMessage(PCHAR pMessage, UINT32 messageLen, PReceivedSignalingMessage pReceivedSignalingMessage)
 {
     ENTERS();
@@ -2075,10 +2269,13 @@ STATUS parseSignalingMessage(PCHAR pMessage, UINT32 messageLen, PReceivedSignali
     BOOL parsedMessageType = FALSE, parsedStatusResponse = FALSE;
 
     CHK(pMessage != NULL && pReceivedSignalingMessage != NULL, STATUS_NULL_ARG);
-    CHK(messageLen <= MAX_SIGNALING_MESSAGE_LEN, STATUS_INVALID_API_CALL_RETURN_JSON);
 
+    /* Zero the output struct up front so the caller can safely invoke
+     * freeSignalingMessagePayload() after any return from this function. */
     MEMSET(pReceivedSignalingMessage, 0x00, SIZEOF(ReceivedSignalingMessage));
     pReceivedSignalingMessage->signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_UNKNOWN;
+
+    CHK(messageLen <= MAX_SIGNALING_MESSAGE_LEN, STATUS_INVALID_API_CALL_RETURN_JSON);
 
     jsmn_init(&parser);
     tokenCount = jsmn_parse(&parser, pMessage, messageLen, tokens, SIZEOF(tokens) / SIZEOF(jsmntok_t));
@@ -2102,7 +2299,12 @@ STATUS parseSignalingMessage(PCHAR pMessage, UINT32 messageLen, PReceivedSignali
         } else if (compareJsonString(pMessage, &tokens[i], JSMN_STRING, (PCHAR) "messagePayload")) {
             strLen = (UINT32) (tokens[i + 1].end - tokens[i + 1].start);
             CHK(strLen <= MAX_SIGNALING_MESSAGE_LEN, STATUS_INVALID_API_CALL_RETURN_JSON);
-            outLen = SIZEOF(pReceivedSignalingMessage->signalingMessage.payload);
+            outLen = (strLen + 3) / 4 * 3 + 1;
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+            pReceivedSignalingMessage->signalingMessage.payload = (PCHAR) MEMCALLOC(1, outLen);
+            CHK(pReceivedSignalingMessage->signalingMessage.payload != NULL, STATUS_NOT_ENOUGH_MEMORY);
+#endif
+
             // Base64 method will set outLen <= original input outLen
             CHK_STATUS(base64Decode(pMessage + tokens[i + 1].start, strLen, (PBYTE) (pReceivedSignalingMessage->signalingMessage.payload), &outLen));
 
@@ -2205,6 +2407,7 @@ STATUS receiveLwsMessage(PSignalingClient pSignalingClient, PCHAR pMessage, UINT
             // Notify the awaiting send
             CVAR_BROADCAST(pSignalingClient->receiveCvar);
             // Delete the message wrapper and exit
+            freeSignalingMessagePayload(&pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage);
             SAFE_MEMFREE(pSignalingMessageWrapper);
             CHK(FALSE, retStatus);
             break;
@@ -2214,6 +2417,7 @@ STATUS receiveLwsMessage(PSignalingClient pSignalingClient, PCHAR pMessage, UINT
             CHK_STATUS(terminateConnectionWithStatus(pSignalingClient, SERVICE_CALL_RESULT_SIGNALING_GO_AWAY));
 
             // Delete the message wrapper and exit
+            freeSignalingMessagePayload(&pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage);
             SAFE_MEMFREE(pSignalingMessageWrapper);
 
             // Iterate the state machinery
@@ -2229,6 +2433,7 @@ STATUS receiveLwsMessage(PSignalingClient pSignalingClient, PCHAR pMessage, UINT
             CHK_STATUS(terminateConnectionWithStatus(pSignalingClient, SERVICE_CALL_RESULT_SIGNALING_RECONNECT_ICE));
 
             // Delete the message wrapper and exit
+            freeSignalingMessagePayload(&pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage);
             SAFE_MEMFREE(pSignalingMessageWrapper);
 
             // Iterate the state machinery
@@ -2284,7 +2489,7 @@ CleanUp:
         if (IS_VALID_TID_VALUE(receivedTid)) {
             THREAD_CANCEL(receivedTid);
         }
-
+        freeSignalingMessagePayload(&pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage);
         SAFE_MEMFREE(pSignalingMessageWrapper);
     }
 
@@ -2451,6 +2656,7 @@ PVOID receiveLwsMessageWrapper(PVOID args)
 CleanUp:
     CHK_LOG_ERR(retStatus);
 
+    freeSignalingMessagePayload(&pSignalingMessageWrapper->receivedSignalingMessage.signalingMessage);
     SAFE_MEMFREE(pSignalingMessageWrapper);
 
     return (PVOID) (ULONG_PTR) retStatus;

--- a/tst/SignalingApiFunctionalityTest.cpp
+++ b/tst/SignalingApiFunctionalityTest.cpp
@@ -59,6 +59,10 @@ STATUS masterMessageReceived(UINT64 customData, PReceivedSignalingMessage pRecei
     message.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     message.messageType = SIGNALING_MESSAGE_TYPE_ANSWER;
     STRCPY(message.peerClientId, TEST_SIGNALING_VIEWER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    message.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(message.payload != NULL);
+#endif
     MEMSET(message.payload, 'B', 200);
     message.payload[200] = '\0';
     message.payloadLen = 0;
@@ -66,6 +70,9 @@ STATUS masterMessageReceived(UINT64 customData, PReceivedSignalingMessage pRecei
     status = signalingSendMessageSync(pTest->pActiveClient, &message);
     CHK_LOG_ERR(status);
 
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(message.payload);
+#endif
     // Return success to continue
     return STATUS_SUCCESS;
 }
@@ -383,6 +390,10 @@ TEST_F(SignalingApiFunctionalityTest, mockMaster)
     message.payloadLen = 0;
     message.correlationId[0] = '\0';
     message.messageType = SIGNALING_MESSAGE_TYPE_ANSWER;
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    message.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(message.payload != NULL);
+#endif
     MEMSET(message.payload, 'B', MAX_SIGNALING_MESSAGE_LEN);
     message.payload[MAX_SIGNALING_MESSAGE_LEN] = '\0';
 
@@ -432,6 +443,9 @@ TEST_F(SignalingApiFunctionalityTest, mockMaster)
     // Free again
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(message.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, mockViewer)
@@ -519,6 +533,10 @@ TEST_F(SignalingApiFunctionalityTest, mockViewer)
     message.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     message.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(message.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    message.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(message.payload != NULL);
+#endif
     MEMSET(message.payload, 'A', 100);
     message.payload[100] = '\0';
     message.payloadLen = 0;
@@ -546,6 +564,9 @@ TEST_F(SignalingApiFunctionalityTest, mockViewer)
     // Free again
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
     EXPECT_FALSE(IS_VALID_SIGNALING_CLIENT_HANDLE(signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(message.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, invalidChannelInfoInput)
@@ -888,6 +909,10 @@ TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -898,6 +923,9 @@ TEST_F(SignalingApiFunctionalityTest, iceReconnectEmulation)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedVariations)
@@ -1151,6 +1179,10 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedVariatio
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -1161,6 +1193,9 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedVariatio
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedVariations)
@@ -1416,6 +1451,10 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedVariations)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -1426,6 +1465,9 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedVariations)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedAuthExpiration)
@@ -1777,6 +1819,10 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -1787,6 +1833,9 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultInjectionRecovered)
@@ -1893,6 +1942,10 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -1903,6 +1956,9 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaultInjectionNotRecovered)
@@ -2006,6 +2062,10 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2016,6 +2076,9 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithFaul
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultInjectionNot1669)
@@ -2122,6 +2185,10 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2132,6 +2199,9 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithFaultIn
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithBadAuth)
@@ -2242,6 +2312,10 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithBadA
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2252,6 +2326,9 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshNotConnectedWithBadA
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithBadAuth)
@@ -2365,6 +2442,10 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithBadAuth
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2375,6 +2456,9 @@ TEST_F(SignalingApiFunctionalityTest, iceServerConfigRefreshConnectedWithBadAuth
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
@@ -2449,6 +2533,10 @@ TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2459,6 +2547,9 @@ TEST_F(SignalingApiFunctionalityTest, goAwayEmulation)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
@@ -2537,6 +2628,10 @@ TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2547,6 +2642,9 @@ TEST_F(SignalingApiFunctionalityTest, unknownMessageTypeEmulation)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, connectTimeoutEmulation)
@@ -2658,6 +2756,10 @@ TEST_F(SignalingApiFunctionalityTest, connectTimeoutEmulation)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2668,6 +2770,9 @@ TEST_F(SignalingApiFunctionalityTest, connectTimeoutEmulation)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, channelInfoArnSkipDescribe)
@@ -2741,6 +2846,10 @@ TEST_F(SignalingApiFunctionalityTest, channelInfoArnSkipDescribe)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2800,6 +2909,9 @@ TEST_F(SignalingApiFunctionalityTest, channelInfoArnSkipDescribe)
     deleteChannelLws(FROM_SIGNALING_CLIENT_HANDLE(signalingHandle), 0);
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedWithArn)
@@ -2873,6 +2985,10 @@ TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedWithArn)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -2932,6 +3048,9 @@ TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedWithArn)
     EXPECT_EQ(STATUS_SUCCESS, signalingClientDeleteSync(signalingHandle));
 
     EXPECT_EQ(STATUS_SUCCESS, freeSignalingClient(&signalingHandle));
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, deleteChannelCreatedAuthExpiration)
@@ -3066,6 +3185,10 @@ TEST_F(SignalingApiFunctionalityTest, signalingClientDisconnectSyncVariations)
     message.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     message.messageType = SIGNALING_MESSAGE_TYPE_ANSWER;
     STRCPY(message.peerClientId, TEST_SIGNALING_VIEWER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    message.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(message.payload != NULL);
+#endif
     MEMSET(message.payload, 'A', 200);
     message.payload[200] = '\0';
     message.payloadLen = 0;
@@ -3085,6 +3208,10 @@ TEST_F(SignalingApiFunctionalityTest, signalingClientDisconnectSyncVariations)
     // Reconnect and send a message successfully
     EXPECT_EQ(STATUS_SUCCESS, signalingClientConnectSync(mSignalingClientHandle));
     EXPECT_EQ(STATUS_SUCCESS, signalingClientSendMessageSync(mSignalingClientHandle, &message));
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(message.payload);
+#endif
 
     deinitializeSignalingClient();
 }
@@ -3662,6 +3789,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_ParseOfferSuccess)
     EXPECT_STREQ("Hello", receivedMessage.signalingMessage.payload);
     EXPECT_EQ(5, receivedMessage.signalingMessage.payloadLen);
     EXPECT_EQ(SIGNALING_MESSAGE_TYPE_OFFER, receivedMessage.signalingMessage.messageType);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_ParseStatusResponseSuccess) {
@@ -3687,7 +3817,12 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_ParseStatusRespons
     // Check not-present fields are correctly zeroed
     EXPECT_STREQ("", receivedMessage.description);
     EXPECT_STREQ("", receivedMessage.signalingMessage.peerClientId);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    // With dynamic payload, unparsed payload is NULL (not allocated)
+    EXPECT_EQ(NULL, receivedMessage.signalingMessage.payload);
+#else
     EXPECT_STREQ("", receivedMessage.signalingMessage.payload);
+#endif
     EXPECT_EQ(0, receivedMessage.signalingMessage.payloadLen);
 }
 
@@ -3704,6 +3839,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_InvalidArgs) {
     // Validate that the jsonMessage is OK
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
     EXPECT_EQ(STATUS_SUCCESS, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 
     // NULL parameter
     EXPECT_EQ(STATUS_NULL_ARG, parseSignalingMessage(NULL, jsonMessage.length(), &receivedMessage));
@@ -3718,6 +3856,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_messageTooLong) {
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_senderClientIdIsTooLong) {
@@ -3735,6 +3876,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_senderClientIdIsTo
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_messageTypeIsTooLong) {
@@ -3752,6 +3896,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_messageTypeIsTooLo
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_messagePayloadIsTooLong) {
@@ -3769,6 +3916,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_messagePayloadIsTo
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_correlationIdIsTooLong) {
@@ -3790,6 +3940,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_correlationIdIsToo
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_errorTypeIsTooLong) {
@@ -3811,6 +3964,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_errorTypeIsTooLong
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_statusCodeIsTooLong) {
@@ -3832,6 +3988,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_statusCodeIsTooLon
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_descriptionIsTooLong) {
@@ -3853,6 +4012,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_descriptionIsTooLo
     STATUS status = parseSignalingMessage((PCHAR) jsonMessage.c_str(), jsonMessage.length(), &receivedMessage);
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 
@@ -3862,6 +4024,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_emptyJson) {
 
     STATUS status = parseSignalingMessage((PCHAR) emptyJsonMessage.c_str(), emptyJsonMessage.length(), &receivedMessage);
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_ignoreExtraFields) {
@@ -3885,6 +4050,9 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_ignoreExtraFields)
     EXPECT_STREQ("Hello", receivedMessage.signalingMessage.payload);
     EXPECT_EQ(5, receivedMessage.signalingMessage.payloadLen);
     EXPECT_EQ(SIGNALING_MESSAGE_TYPE_OFFER, receivedMessage.signalingMessage.messageType);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
+#endif
 }
 
 TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_InvalidJson) {
@@ -3901,9 +4069,15 @@ TEST_F(SignalingApiFunctionalityTest, SignalingMessageParsing_InvalidJson) {
 
     EXPECT_EQ(STATUS_INVALID_API_CALL_RETURN_JSON, status);
     EXPECT_STREQ("", receivedMessage.signalingMessage.peerClientId);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    /* Parser bailed without allocating; payload stays NULL. */
+    EXPECT_EQ(NULL, receivedMessage.signalingMessage.payload);
+#else
     EXPECT_STREQ("", receivedMessage.signalingMessage.payload);
+#endif
     EXPECT_EQ(0, receivedMessage.signalingMessage.payloadLen);
     EXPECT_EQ(SIGNALING_MESSAGE_TYPE_UNKNOWN, receivedMessage.signalingMessage.messageType);
+    freeSignalingMessagePayload(&receivedMessage.signalingMessage);
 }
 
 } // namespace webrtcclient

--- a/tst/SignalingApiTest.cpp
+++ b/tst/SignalingApiTest.cpp
@@ -208,6 +208,10 @@ TEST_F(SignalingApiTest, signalingSendMessageSync)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -237,6 +241,10 @@ TEST_F(SignalingApiTest, signalingSendMessageSync)
     // No peer id no correlation id
     signalingMessage.correlationId[0] = '\0';
     EXPECT_EQ(expectedStatus, signalingClientSendMessageSync(mSignalingClientHandle, &signalingMessage));
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 
     deinitializeSignalingClient();
     //wait for threads of threadpool to close
@@ -273,6 +281,10 @@ TEST_F(SignalingApiTest, signalingSendMessageSyncFileCredsProvider)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -292,6 +304,10 @@ TEST_F(SignalingApiTest, signalingSendMessageSyncFileCredsProvider)
     // No peer id no correlation id
     signalingMessage.correlationId[0] = '\0';
     EXPECT_EQ(STATUS_SUCCESS, signalingClientSendMessageSync(mSignalingClientHandle, &signalingMessage));
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 
     deinitializeSignalingClient();
 
@@ -339,11 +355,19 @@ TEST_F(SignalingApiTest, signalingClientDeleteSync)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
     signalingMessage.correlationId[0] = '\0';
     EXPECT_EQ(expectedStatus, signalingClientSendMessageSync(mSignalingClientHandle, &signalingMessage));
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 
     deinitializeSignalingClient();
     //wait for threads of threadpool to close
@@ -501,6 +525,10 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     signalingMessage.version = SIGNALING_MESSAGE_CURRENT_VERSION;
     signalingMessage.messageType = SIGNALING_MESSAGE_TYPE_OFFER;
     STRCPY(signalingMessage.peerClientId, TEST_SIGNALING_MASTER_CLIENT_ID);
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    signalingMessage.payload = (PCHAR) MEMALLOC(MAX_SIGNALING_MESSAGE_LEN + 1);
+    EXPECT_TRUE(signalingMessage.payload != NULL);
+#endif
     MEMSET(signalingMessage.payload, 'A', 100);
     signalingMessage.payload[100] = '\0';
     signalingMessage.payloadLen = 0;
@@ -537,6 +565,10 @@ TEST_F(SignalingApiTest, signalingClientGetMetrics)
     EXPECT_NE(0, metrics.signalingClientStats.connectionDuration);
     EXPECT_NE(0, metrics.signalingClientStats.cpApiCallLatency);
     EXPECT_NE(0, metrics.signalingClientStats.dpApiCallLatency);
+
+#ifdef DYNAMIC_SIGNALING_PAYLOAD
+    SAFE_MEMFREE(signalingMessage.payload);
+#endif
 
     deinitializeSignalingClient();
 }


### PR DESCRIPTION
## What changed
Replace large static arrays with dynamic allocations in signaling API call functions, gated behind the `-DPREFER_DYNAMIC_ALLOCS=ON` CMake option (default OFF).

## Why
Functions like `describeChannelLws`, `createChannelLws`, `getChannelEndpointLws`, `getIceConfigLws`, `deleteChannelLws`, `connectSignalingChannel`, `joinStorageSessionLws`, and `describeMediaStorageConfLws` each allocate large stack arrays (`CHAR url[MAX_URI_CHAR_LEN + 1]` and `CHAR paramsJson[MAX_JSON_PARAMETER_STRING_LEN]`) that consume significant stack space. On memory-constrained platforms (ESP32), this is a major issue.

## How
- **LwsApiCalls.c**: In each signaling API function, replaced `CHAR url[...]` and `CHAR paramsJson[...]` stack arrays with dynamically allocated buffers sized to exact need using `SNPRINTF(NULL, 0, ...)`. All buffers are freed in `CleanUp` paths.
- **Include.h**: Added `USE_DYNAMIC_URL` macro (enabled when `PREFER_DYNAMIC_ALLOCS` is set). Also includes `DYNAMIC_SIGNALING_PAYLOAD` for dynamic signaling message payload (also in PR #2140).
- **samples/common/Common.c**: Added payload alloc/free guards in `respondWithAnswer`, `onIceCandidateHandler`, `submitPendingIceCandidate`, and `signalingMessageReceived`.
- **CMakeLists.txt**: Wired up `PREFER_DYNAMIC_ALLOCS` CMake option.

## Testing done
- Builds with both `-DPREFER_DYNAMIC_ALLOCS=ON` and default (OFF)
- Clang-format compliance check passes
- Rebased onto latest `develop` branch

## Related PRs
- PR #2140 — subset of this PR, covers only `DYNAMIC_SIGNALING_PAYLOAD`