### PR TITLE
Ci: Windows path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,11 +350,13 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-      - name: Move cloned repo
+      - name: Move cloned repo to shorter path
         shell: powershell
         run: |
-          mkdir C:\webrtc
-          Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c\*" -Destination "C:\webrtc"
+          $src = "${env:GITHUB_WORKSPACE}\*"
+          $dest = "C:\webrtc"
+          mkdir "$dest"
+          Move-Item -Path $src -Destination $dest
       - name: Install dependencies
         shell: powershell
         run: |


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Windows CI path

*Why was it changed?*
- Recent github actions runner update (2 days ago) https://github.com/actions/runner-images/commit/71ed87ce949ec4d05207c3f84a1dca48a29695c3 changed the `PATH` of the cloned repository to `C:\` instead of `D:\`, which broke the CI run for Windows.

From the logs of https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/15503951014/job/43669419744:

```log
Move-Item : Cannot find path 
'D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c' because it does not exist.
At C:\a\_temp\c209d814-9072-4e4e-9c81-4ae8a42d0dd9.ps1:3 char:1
+ Move-Item -Path "D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazo ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (D:\a\amazon-kin...ms-webrtc-sdk-c:String) [Move-Item], ItemNotFoundExce 
   ption
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.MoveItemCommand
```

The log that indicated that the PATH got changed:

Before:
```
Run actions/checkout@v4
Syncing repository: awslabs/amazon-kinesis-video-streams-webrtc-sdk-c
Getting Git version info
Temporarily overriding HOME='D:\a\_temp\c829ea2e-5b42-46b8-b416-1ea67136f1c5' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c
Deleting the contents of 'D:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
Determining the checkout info
"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
Checking out the ref
"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
568313[26](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/15493159798/job/43623368501#step:2:28)3bf9cb277c5ef971750605ac1b9cddfd
```

After:
```
Syncing repository: awslabs/amazon-kinesis-video-streams-webrtc-sdk-c
Getting Git version info
Temporarily overriding HOME='C:\a\_temp\d0fd92a4-f056-4f8d-bb5d-d495843dc566' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory C:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c
Deleting the contents of 'C:\a\amazon-kinesis-video-streams-webrtc-sdk-c\amazon-kinesis-video-streams-webrtc-sdk-c'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
Determining the checkout info
"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
Checking out the ref
"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
9e07f0c333888cf99665362e7cc3b94389876a5d
```


*How was it changed?*
- Instead of hard-coding this path, use `GITHUB_WORKSPACE` environment variable instead.

*What testing was done for the changes?*
- Ran it on a fork to verify the windows CI passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
