### PR TITLE
Bugfix: unused label build error observed

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -2491,7 +2491,6 @@ STATUS configureLwsLogging(UINT32 kvsLogLevel)
 
     lws_set_log_level(lws_levels, NULL);
 
-CleanUp:
     CHK_LOG_ERR(retStatus);
 
     LEAVES();


### PR DESCRIPTION
Build issue was observed with strict compiler flags for unused label

- Fixed by removing unused `CleanUp` label in `LwsApiCalls.c`
