### PR TITLE
Bugfix: Only operate on `pSenderTranceiver` if it was found

### DIFF
--- a/src/source/PeerConnection/Retransmitter.c
+++ b/src/source/PeerConnection/Retransmitter.c
@@ -121,13 +121,17 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
             pRtpPacket = NULL;
         }
     }
-CleanUp:
 
-    MUTEX_LOCK(pSenderTranceiver->statsLock);
-    pSenderTranceiver->outboundStats.nackCount += nackCount;
-    pSenderTranceiver->outboundStats.retransmittedPacketsSent += retransmittedPacketsSent;
-    pSenderTranceiver->outboundStats.retransmittedBytesSent += retransmittedBytesSent;
-    MUTEX_UNLOCK(pSenderTranceiver->statsLock);
+CleanUp:
+    if (pSenderTranceiver != NULL) {
+        MUTEX_LOCK(pSenderTranceiver->statsLock);
+        pSenderTranceiver->outboundStats.nackCount += nackCount;
+        pSenderTranceiver->outboundStats.retransmittedPacketsSent += retransmittedPacketsSent;
+        pSenderTranceiver->outboundStats.retransmittedBytesSent += retransmittedBytesSent;
+        MUTEX_UNLOCK(pSenderTranceiver->statsLock);
+    } else {
+        DLOGD("Retransmit pSenderTranceiver is NULL");
+    }
 
     CHK_LOG_ERR(retStatus);
     if (pRtpPacket != NULL) {


### PR DESCRIPTION
 - The code path traces and tries to take lock on `pSenderTranceiver` even if it is NULL
 - This makes the code crash if pSenderTranceiver is NULL

FIX: Check if pSenderTranceiver is NULL before dereferencing 
