### PR TITLE
Bugfix: wrong retry count print

### DIFF
--- a/src/source/Signaling/StateMachine.c
+++ b/src/source/Signaling/StateMachine.c
@@ -101,7 +101,7 @@ STATUS defaultSignalingStateTransitionHook(UINT64 customData /* customData shoul
                  pSignalingStateMachineRetryStrategy, &pSignalingClient->diagnostics.stateMachineRetryCount)) != STATUS_SUCCESS) {
             DLOGW("Failed to get retry count. Error code: %08x", countStatus);
         } else {
-            DLOGD("Retry count: %llu", pSignalingClient->diagnostics.stateMachineRetryCount);
+            DLOGD("Retry count: %" PRIu32, pSignalingClient->diagnostics.stateMachineRetryCount);
         }
     }
     DLOGV("Signaling Client base result is [%u]. Executing KVS retry handler of retry strategy type [%u]", pSignalingClient->result,


### PR DESCRIPTION
 - The variable is uint32_t, printing it using llu format specifier is wrong
 - Use PRIu32 format specifier for the same
