### PR TITLE
Ignore case for the Opus codec mime type

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1,6 +1,30 @@
 #define LOG_CLASS "SessionDescription"
 #include "../Include_i.h"
 
+// Case-insensitive string contains
+// Finds the first occurrence of the substring needle in the string haystack.
+// The terminating null bytes are not compared.
+PCHAR STRCASESTR(PCHAR haystack, PCHAR needle)
+{
+    if (haystack == NULL || needle == NULL) {
+        return NULL;
+    }
+
+    UINT32 needleLen = STRLEN(needle);
+    if (needleLen == 0) {
+        return haystack;
+    }
+
+    PCHAR p = haystack;
+    while (*p != '\0') {
+        if (STRNCMPI(p, needle, needleLen) == 0) {
+            return p;
+        }
+        p++;
+    }
+    return NULL;
+}
+
 STATUS serializeSessionDescriptionInit(PRtcSessionDescriptionInit pSessionDescriptionInit, PCHAR sessionDescriptionJSON,
                                        PUINT32 sessionDescriptionJSONLen)
 {
@@ -1311,7 +1335,7 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
                 if (STRSTR(attributeValue, H264_VALUE) != NULL) {
                     supportCodec = TRUE;
                     rtcCodec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
-                } else if (STRSTR(attributeValue, OPUS_VALUE) != NULL) {
+                } else if (STRCASESTR(attributeValue, OPUS_VALUE) != NULL) {
                     supportCodec = TRUE;
                     rtcCodec = RTC_CODEC_OPUS;
                 } else if (STRSTR(attributeValue, MULAW_VALUE) != NULL) {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fixed case-sensitive codec matching in SDP negotiation by replacing `STRSTR` (case-sensitive string contains) with a `STRCASESTR` (case-insensitive string contains) for OPUS codec detection.
- Added unit test `caseInsensitiveCodecMatching_OPUS` to validate the fix

*Why was it changed?*
- The SDK was failing to negotiate OPUS audio tracks when remote peers sent SDP offers with capitalized codec names (e.g., `a=rtpmap:111 OPUS/48000/2` instead of `a=rtpmap:111 opus/48000/2`)
- This case-sensitivity issue caused the codec table to miss OPUS payload type mappings, resulting in inactive audio tracks with fake streams instead of proper media negotiation

*How was it changed?*
- Modified `findTransceiversByRemoteDescription()` in `SessionDescription.c` to use case-insensitive string comparison  instead of case-sensitive `STRSTR` for OPUS codec matching
- The change leverages existing PIC macros (`GLOBAL_STRCMPI` maps to `strcasecmp`) ensuring cross-platform compatibility
- Only the OPUS codec matching was updated in this PR to minimize risk; other codecs can be addressed in follow-up PRs

*What testing was done for the changes?*
- Added new unit test `SdpApiTest.caseInsensitiveCodecMatching_OPUS` that reproduces the exact failure scenario with capitalized OPUS in SDP offers
- Verified peer connection establishment with the peer that sends a capitalized `OPUS`
- Test validates that the fix produces correct SDP answers with:
  - Active audio tracks (`a=sendrecv` instead of `a=inactive`)
  - Proper payload type mapping (`a=rtpmap:111 opus/48000/2`)
  - Real media streams (no fake streams/tracks)
- All existing SDP tests continue to pass, confirming no regressions
- Build verification successful across the test suite

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
