### PR TITLE
Adding inttypes.h for the print specifier

### DIFF
--- a/src/source/Signaling/StateMachine.h
+++ b/src/source/Signaling/StateMachine.h
@@ -10,6 +10,8 @@ Signaling State Machine internal include file
 extern "C" {
 #endif
 
+#include <inttypes.h>
+
 /**
  * Signaling states definitions
  */


### PR DESCRIPTION
*Issue #, if available:*
- Slight adjustment to PR #2160

*What was changed?*
- Add missing header for windows-msvc-openssl and mbedtls-ubuntu-gcc-4-4 CI jobs
  - https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/17658125973/job/50263892168
  - https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/17658125973/job/50263892050

```
/__w/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Signaling/StateMachine.c: In function 'defaultSignalingStateTransitionHook':
/__w/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Signaling/StateMachine.c:104: error: expected ')' before 'PRIu32'
```
```
[ 54%] Building C object CMakeFiles/kvsWebrtcSignalingClient.dir/src/source/Signaling/StateMachine.c.obj
StateMachine.c
C:\webrtc\src\source\Signaling\StateMachine.c(104): error C2146: syntax error: missing ')' before identifier 'PRIu32'
C:\webrtc\src\source\Signaling\StateMachine.c(104): error C2059: syntax error: ')'
```

*Why was it changed?*
- CI was failing for these 2 jobs after PRIu32 was added in #2160. Due to CMake v3.x not being available at the time, we thought all the jobs passed successfully. These 2 did not and need addressing.

*How was it changed?*
- Add missing `include.h`

*What testing was done for the changes?*
- CI should now pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
