### PR TITLE
Create storage-samples.yml

### DIFF
--- a/.github/workflows/storage-samples.yml
+++ b/.github/workflows/storage-samples.yml
@@ -1,5 +1,4 @@
-name: WebRTC C Join Storage Master Samples
-# todo: add the provisioning and consumption check
+name: WebRTC C Join Storage Master Sample
 
 on:
   push:
@@ -13,16 +12,14 @@ on:
       - main
 
 jobs:
-   
-
- 
-
   valgrind-check-for-join-storage:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     env:
       AWS_KVS_LOG_LEVEL: 1
+      CHANNEL_NAME: demo-channel-storage
+      STREAM_NAME: demo-stream-storage
 
     permissions:
       id-token: write
@@ -36,6 +33,37 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Provision AWS KVS resources
+        run: |
+          # Create stream if it doesn't exist
+          if ! aws kinesisvideo describe-stream --stream-name "$STREAM_NAME"; then
+            echo "Creating stream: $STREAM_NAME"
+            aws kinesisvideo create-stream --stream-name "$STREAM_NAME" --data-retention-in-hours 1
+          else
+            echo "Stream already exists: $STREAM_NAME"
+          fi
+
+          # Create signaling channel if it doesn't exist
+          if ! aws kinesisvideo describe-signaling-channel --channel-name "$CHANNEL_NAME"; then
+            echo "Creating signaling channel: $CHANNEL_NAME"
+            aws kinesisvideo create-signaling-channel --channel-name "$CHANNEL_NAME"
+          else
+            echo "Signaling channel already exists: $CHANNEL_NAME"
+          fi
+
+          CHANNEL_ARN=$(aws kinesisvideo describe-signaling-channel --channel-name "$CHANNEL_NAME" --query 'ChannelInfo.ChannelARN' --output text)
+          STREAM_ARN=$(aws kinesisvideo describe-stream --stream-name "$STREAM_NAME" --query 'StreamInfo.StreamARN' --output text)
+
+          STATUS=$(aws kinesisvideo describe-media-storage-configuration --channel-arn "$CHANNEL_ARN" --query 'MediaStorageConfiguration.Status' --output text)
+          if [ "$STATUS" != "ENABLED" ]; then
+            echo "Linking channel to stream"
+            aws kinesisvideo update-media-storage-configuration \
+              --channel-arn "$CHANNEL_ARN" \
+              --media-storage-configuration Status=ENABLED,StreamARN="$STREAM_ARN"
+          else
+            echo "Channel already linked to stream"
+          fi
 
       - name: Install deps
         run: |
@@ -54,44 +82,71 @@ jobs:
           make -j
 
       - name: Run tests
+        working-directory: build
         run: |
-          cd build
-          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-master.txt ./samples/kvsWebrtcClientMaster demo-channel-storage 1 opus h264 &
+          valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-master.txt ./samples/kvsWebrtcClientMaster $CHANNEL_NAME 1 opus h264 &
           PID_MASTER=$!
-     
 
           # Wait for processes to run initially
-          sleep 30 # Wait 30s
+          sleep 60 # Wait 60s
 
-          
+          # Interrupt master application (CTRL+C)
           kill -2 $PID_MASTER
 
           # Start a background task to enforce a timeout for graceful shutdown
           (
             sleep 10
             kill -9 $PID_MASTER 2>/dev/null
-          
           ) &
 
           wait $PID_MASTER
           EXIT_STATUS_MASTER=$?
-        
 
           # Check exit statuses to determine if the interrupt was successful
           if [ $EXIT_STATUS_MASTER -ne 0 ] ; then
             echo "Process did not exit gracefully."
             echo "Master exit code: $EXIT_STATUS_MASTER"
-           
             exit 1
           else
-
             echo "Processes exited successfully."
           fi
 
-          # Check for memory leaks in Valgrind output files
+      - name: Check valgrind output
+        working-directory: build
+        run: |
           if grep "All heap blocks were freed -- no leaks are possible" valgrind-master.txt ; then
             echo "No memory leaks detected."
           else
             echo "Memory leaks detected."
+            cat valgrind-master.txt
+            # TODO: exit 1
           fi
 
+      - name: Setup Python for media validation
+        if: false # TODO: re-enable
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Download and verify media
+        if: false # TODO: re-enable
+        run: |
+          # Clone validation tools
+          git clone --depth 1 --branch develop https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java.git /tmp/kvs-tools
+          cd /tmp/kvs-tools/scripts/python/getmediavalidation
+          
+          # Install dependencies
+          python -m pip install --upgrade pip
+          pip install -e .
+
+          # Fetch fragment info and check if table is non-empty
+          OUTPUT=$(python ./bin/fetch_fragment_info.py --stream-name "$STREAM_NAME" --last 5m)
+          echo "$OUTPUT"
+          
+          # Check if table contains data rows (look for fragment numbers)
+          if echo "$OUTPUT" | grep -E "^\| [0-9]+" > /dev/null; then
+            echo "✓ Media fragments found in stream"
+          else
+            echo "✗ No media fragments found in stream"
+            exit 1
+          fi


### PR DESCRIPTION
Storage sample CI 

*Issue #, if available:*
- N/A

*What was changed?*
- Added new GitHub Actions workflow `storage-samples.yml` for testing WebRTC Join Storage Master sample

*Why was it changed?*
- To validate the Join Storage Session feature that ingests WebRTC media to Kinesis Video Streams
- Ensures the SDK continues to work with the storage session on every PR

*How was it changed?*
- Created CI job that provisions KVS resources (stream, signaling channel, and media storage configuration)
- Runs master sample with valgrind for 60 seconds to record media
  - Validates memory leak-free operation (currently disabled)
  - Includes infrastructure for end-to-end media validation (currently disabled)

*What testing was done for the changes?*
- Tested in a fork:
  - Checked workflow provisions AWS resources correctly via AWS console
  - Confirmed sample runs successfully and exits gracefully
  - Checked valgrind detects memory management issues
  - Checked the listFragments utility reports an error when there are no fragments ingested

Screenshots:

<details><summary>Valgrind</summary>

<img width="669" height="179" alt="image" src="https://github.com/user-attachments/assets/7fd1a8b4-31ff-4c62-803c-6d658920b050" />

</details>

<details><summary>listFragments</summary>

<img width="1062" height="229" alt="image" src="https://github.com/user-attachments/assets/130cf123-8958-4054-8763-0d9c294507f5" />

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
