### PR TITLE
Fix Stats.h typo in documentation

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -215,7 +215,7 @@ typedef struct {
     UINT64 bytesReceived;                      //!< Total number of bytes (minus header and padding) received on this candidate pair
     UINT64 lastPacketSentTimestamp;            //!< Represents the timestamp at which the last packet was sent on this particular
                                                //!< candidate pair, excluding STUN packets.
-    UINT64 lastPacketReceivedTimestamp;        //!< Represents the timestamp at which the last packet was sent on this particular
+    UINT64 lastPacketReceivedTimestamp;        //!< Represents the timestamp at which the last packet was received on this particular
                                                //!< candidate pair, excluding STUN packets.
     UINT64 firstRequestTimestamp;    //!< Represents the timestamp at which the first STUN request was sent on this particular candidate pair.
     UINT64 lastRequestTimestamp;     //!< Represents the timestamp at which the last STUN request was sent on this particular candidate pair.


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- This fixes a typo in the documentation

*Why was it changed?*
- Notice the docs for `lastPacketSentTimestamp` and `lastPacketReceivedTimestamp` is currently identical, both saying this value represents the sent packets.

*How was it changed?*
- Purely textual fix.

*What testing was done for the changes?*
- Docs-only change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
