### PR TITLE
Removed duplicate putSctpPacket call

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -188,12 +188,6 @@ VOID onInboundPacket(UINT64 customData, PBYTE buff, UINT32 buffLen)
     if (buff[0] > 19 && buff[0] < 64) {
         dtlsSessionProcessPacket(pKvsPeerConnection->pDtlsSession, buff, &signedBuffLen);
 
-#ifdef ENABLE_DATA_CHANNEL
-        if (ATOMIC_LOAD_BOOL(&pKvsPeerConnection->sctpIsEnabled) && signedBuffLen > 0) {
-            CHK_STATUS(putSctpPacket(pKvsPeerConnection->pSctpSession, buff, signedBuffLen));
-        }
-#endif
-
         CHK_STATUS(dtlsSessionIsInitFinished(pKvsPeerConnection->pDtlsSession, &isDtlsConnected));
         if (isDtlsConnected) {
             if (pKvsPeerConnection->pSrtpSession == NULL) {


### PR DESCRIPTION
*Issue #, if available:*
- #2180, putSctpPacket is called twice resulting in duplicate packets being reported.

*What was changed?*
- Removed duplicate `putSctpPacket` call in `PeerConnection.c`

*Why was it changed?*
- This was originally changed in #1749, but it seems the merge in #1783 duplicated `putSctpPacket` calls.

*How was it changed?*
- Removed `putSctpPacket` call from `PeerConnection.c`

*What testing was done for the changes?*
- CI/CD should pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
