### PR TITLE
Upgrade from mac 13 to mac 15 due to deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
       matrix:
         os:
           - name: Mac Intel
-            runner: macos-13
+            runner: macos-15-intel
           - name: Mac Apple Silicon
-            runner: macos-14
+            runner: macos-15
         compiler: [ gcc, clang ]
         config:
           - name: Shared OpenSSL

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   clang-format-check:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- CI: Runner type used

*Why was it changed?*
- MacOS 13 (x86_64) is being deprecated and being replaced with `macos-15-intel`
- https://github.com/actions/runner-images/issues/13045

*How was it changed?*
- Updated the runner type in the ci configuration file

*What testing was done for the changes?*
- If the CI passes, the migration completed successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
