### PR TITLE
Update libkvsCommonLws to version 1.6.1

### DIFF
--- a/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
+++ b/CMake/Dependencies/libkvsCommonLws-CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(libkvsCommonLws-download
     GIT_REPOSITORY    https://github.com/awslabs/amazon-kinesis-video-streams-producer-c.git
-    GIT_TAG           v1.6.0
+    GIT_TAG           v1.6.1
     GIT_PROGRESS      TRUE
     GIT_SHALLOW       TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- The KVS Common LWS dependency library version.

*Why was it changed?*
- To use the latest KVS Common LWS and PIC libraries.

*How was it changed?*
- Updated from 1.6.0 to 1.6.1.

*What testing was done for the changes?*
- Letting the CI to pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
