### PR TITLE
Remove extra region instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-region: us-west-2
+          aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: us-west-2
 
   cleanup-old-resources:
     needs: check-aws-credentials
@@ -41,14 +40,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          aws-region: us-west-2
           repository: 'aws-samples/amazon-kinesis-video-streams-demos'
           path: demos-repo
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          aws-region: us-west-2
           python-version: "3.12"
 
       - name: Install dependencies
@@ -60,9 +57,8 @@ jobs:
       - name: Setup credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-region: us-west-2
+          aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: us-west-2
 
       - name: Run cleanup script
         working-directory: ./demos-repo/python/cleanup
@@ -105,13 +101,11 @@ jobs:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          aws-region: us-west-2
           cmake-version: '3.x'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: aws-actions/stale-issue-cleanup@v3
         with:
-          aws-region: us-west-2
           ancient-issue-message: This is a very old issue. We encourage you to check if this is still an issue in the latest release and if you find that this is still a problem, please feel free to open a new one.
           stale-issue-message: It looks like this issue has not been active for 10 days. If the issue is not resolved, please add an update to the ticket, else it will be automatically resolved in a few days.
 

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -28,6 +28,5 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.2.5
         with:
-          aws-region: us-west-2
           folder: doc/html
           branch: gh-pages


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- CI configuration

*Why was it changed?*
- Fix the CI. Since the yaml file itself is not parse-able, that set of jobs doesn't get initialized. Since the jobs didn't "fail", there is no red X.

<img width="1485" height="648" alt="image" src="https://github.com/user-attachments/assets/cf14f997-55b5-48c1-8dcd-75a82fada83c" />

*How was it changed?*
- Remove duplicate region key
- Removed extra aws-region where isn't needed

*What testing was done for the changes?*
- CI/CD should pass for these changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
