### PR TITLE
control plane uri env override

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -909,6 +909,11 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
     pSampleConfiguration->channelInfo.pCertPath = pSampleConfiguration->pCaCertPath;
     pSampleConfiguration->channelInfo.messageTtl = 0; // Default is 60 seconds
 
+    pSampleConfiguration->channelInfo.pControlPlaneUrl = GETENV(CONTROL_PLANE_URI_ENV_VAR);
+    if (!IS_NULL_OR_EMPTY_STRING(pSampleConfiguration->channelInfo.pControlPlaneUrl)) {
+        DLOGI("Override URL: %s", pSampleConfiguration->channelInfo.pControlPlaneUrl);
+    }
+
     pSampleConfiguration->signalingClientCallbacks.version = SIGNALING_CLIENT_CALLBACKS_CURRENT_VERSION;
     pSampleConfiguration->signalingClientCallbacks.errorReportFn = signalingClientError;
     pSampleConfiguration->signalingClientCallbacks.stateChangeFn = signalingClientStateChanged;

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -69,6 +69,8 @@ extern "C" {
 #define MASTER_DATA_CHANNEL_MESSAGE "This message is from the KVS Master"
 #define VIEWER_DATA_CHANNEL_MESSAGE "This message is from the KVS Viewer"
 
+#define CONTROL_PLANE_URI_ENV_VAR ((PCHAR) "CONTROL_PLANE_URI")
+
 #define DATA_CHANNEL_MESSAGE_TEMPLATE                                                                                                                \
     "{\"content\":\"%s\",\"firstMessageFromViewerTs\":\"%s\",\"firstMessageFromMasterTs\":\"%s\",\"secondMessageFromViewerTs\":\"%s\","              \
     "\"secondMessageFromMasterTs\":\"%s\",\"lastMessageFromViewerTs\":\"%s\" }"


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add control plane uri override, similar to our other samples

*Why was it changed?*
- Can control this at runtime without requiring rebuild

*How was it changed?*
- Set the channelInfo.pControlPlaneUrl var based on the environment variable

*What testing was done for the changes?*
- Tested locally with the JS page

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
