### PR TITLE
env to set the transport setting

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -354,6 +354,7 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
     PIceConfigInfo pIceConfigInfo;
     UINT64 data;
     PRtcCertificate pRtcCertificate = NULL;
+    PCHAR pIceTransportPolicy;
 
     CHK(pSampleConfiguration != NULL && ppRtcPeerConnection != NULL, STATUS_NULL_ARG);
 
@@ -362,8 +363,15 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
     // Set this to custom callback to enable filtering of interfaces
     configuration.kvsRtcConfiguration.iceSetInterfaceFilterFunc = NULL;
 
-    // Set the ICE mode explicitly
-    configuration.iceTransportPolicy = ICE_TRANSPORT_POLICY_ALL;
+    // Set the ICE transport policy from environment variable or default to ALL
+    pIceTransportPolicy = GETENV(ICE_TRANSPORT_POLICY_ENV_VAR);
+    if (!IS_NULL_OR_EMPTY_STRING(pIceTransportPolicy) && STRCMPI(pIceTransportPolicy, "relay") == 0) {
+        configuration.iceTransportPolicy = ICE_TRANSPORT_POLICY_RELAY;
+        DLOGI("ICE transport policy: relay");
+    } else {
+        configuration.iceTransportPolicy = ICE_TRANSPORT_POLICY_ALL;
+        DLOGI("ICE transport policy: all");
+    }
 
 #ifdef ENABLE_STATS_CALCULATION_CONTROL
     configuration.kvsRtcConfiguration.enableIceStats = pSampleConfiguration->enableIceStats;

--- a/samples/Samples.h
+++ b/samples/Samples.h
@@ -81,6 +81,8 @@ extern "C" {
     "\"connectStartTime\": %llu, \"connectEndTime\": %llu }"
 #define ICE_AGENT_METRICS_JSON_TEMPLATE "{\"candidateGatheringStartTime\": %llu, \"candidateGatheringEndTime\": %llu }"
 
+#define ICE_TRANSPORT_POLICY_ENV_VAR ((PCHAR) "KVS_ICE_TRANSPORT_POLICY")
+
 #define MAX_DATA_CHANNEL_METRICS_MESSAGE_SIZE     260 // strlen(DATA_CHANNEL_MESSAGE_TEMPLATE) + 20 * 5
 #define MAX_PEER_CONNECTION_METRICS_MESSAGE_SIZE  105 // strlen(PEER_CONNECTION_METRICS_JSON_TEMPLATE) + 20 * 2
 #define MAX_SIGNALING_CLIENT_METRICS_MESSAGE_SIZE 736 // strlen(SIGNALING_CLIENT_METRICS_JSON_TEMPLATE) + 20 * 10


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add an environment variable setting for the transport policy (https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#icetransportpolicy)

*Why was it changed?*
- Make it easier to tweak the sample parameters

*How was it changed?*
- Parse the environment variable, if it's set to "relay" ignoring case. Default remains the same as ALL.

*What testing was done for the changes?*
- Ran it locally with the env set and not set

| ALL | Relay |
| ----------- | -------- |
| <img width="1048" height="375" alt="image" src="https://github.com/user-attachments/assets/9ab5d69e-9eac-42ad-9c2a-be46ab5b6e8e" /> | <img width="1030" height="306" alt="image" src="https://github.com/user-attachments/assets/6a8e3a89-f788-4c33-9772-193fdd3cf4c1" /> | 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
