### PR TITLE
Add a forceTurn check to the CI

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -133,7 +133,7 @@ jobs:
           VIEWER_EXIT=$?
 
           if [ $MASTER_EXIT -ne 0 ] || [ $VIEWER_EXIT -ne 0 ]; then
-            echo "Sample execution failed"
+            echo "Sample execution failed. Master exit code: $MASTER_EXIT, Viewer exit code: $VIEWER_EXIT"
             cat master.log
             cat viewer.log
             exit 1


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- CI configuration. Added a new job to run the master+viewer samples with forceTurn setting

*Why was it changed?*
- Automated verififcation that TURN-TURN connection works

*How was it changed?*
- CI configuration starts the master and viewer samples, and checks the log for the selected ICE candidate pair line

*What testing was done for the changes?*
- Ran the commands locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
