### PR TITLE
Fix getaddrinfo fallback value to get used when turn server parsing fails

### DIFF
--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -550,6 +550,9 @@ STATUS getIpWithHostName(PCHAR hostname, PDualKvsIpAddresses destIps)
             DLOGW("Parsing for TURN address failed for %s, fallback to getaddrinfo", hostname);
         }
 
+        // Reset status before attempting getaddrinfo
+        retStatus = STATUS_SUCCESS;
+
         // Skip the IPv6 resolution if dual stack env var is not set.
         if (!useDualStackMode) {
             ipv6Resolved = TRUE;


### PR DESCRIPTION
*Issue #, if available:*

How to reproduce the issue:

The PeerConnection won't establish when overriding the endpoint to the legacy endpoint, but using dual-stack mode.

1. Setup C master
```sh
export CONTROL_PLANE_URI="https://kinesisvideo.us-west-2.amazonaws.com"
export KVS_DUALSTACK_ENDPOINTS=ON
```

2. Use the JS as a viewer

<details><summary>Expand for relevant C logs:</summary>

```log
2026-01-27 19:55:22.305 DEBUG   lwsWssCallbackRoutine(): Client is writable
2026-01-27 19:55:22.308 VERBOSE lwsWssCallbackRoutine(): WSS callback with reason 8
2026-01-27 19:55:22.308 DEBUG   receiveLwsMessage(): Client received message of type: ICE_CANDIDATE
2026-01-27 19:55:22.308 VERBOSE lwsWssCallbackRoutine(): WSS callback with reason 10
2026-01-27 19:55:22.308 DEBUG   lwsWssCallbackRoutine(): Client is writable
2026-01-27 19:55:23.253 DEBUG   getIpWithHostName(): Found an IPv4 ICE server addresss: x.x.x.x
2026-01-27 19:55:23.253 DEBUG   parseIceServer(): Resolved ICE Server IPv4 address for stun.kinesisvideo.us-west-2.api.aws: x.x.x.x with port: 47873
2026-01-27 19:55:23.253 PROFILE createIceAgent(): [ICE server parsing] Time taken: 1065 ms
2026-01-27 19:55:23.253 INFO    getIpWithHostName(): ICE SERVER Hostname received: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.253 DEBUG   getIpWithHostName(): Attempting to parse dual-stack IP addresses from TURN server hostname: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.253 WARN    getDualStackIpAddrFromDnsHostname(): Parsing IPv4 address failed, received unexpected hostname format: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.253 WARN    getDualStackIpAddrFromDnsHostname(): Failed to parse dual-stack address with error 0x00000002 from hostname: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.253 WARN    getIpWithHostName(): Parsing for TURN address failed for x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com, fallback to getaddrinfo
2026-01-27 19:55:23.254 DEBUG   getIpWithHostName(): Found an IPv4 ICE server addresss: x.x.x.x
2026-01-27 19:55:23.254 ERROR   getIpWithHostName(): operation returned status code: 0x00000002
2026-01-27 19:55:23.254 PROFILE createIceAgent(): [ICE server parsing] Time taken: 1 ms
2026-01-27 19:55:23.254 ERROR   createIceAgent(): Failed to parse ICE servers
2026-01-27 19:55:23.254 INFO    getIpWithHostName(): ICE SERVER Hostname received: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.254 DEBUG   getIpWithHostName(): Attempting to parse dual-stack IP addresses from TURN server hostname: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.254 WARN    getDualStackIpAddrFromDnsHostname(): Parsing IPv4 address failed, received unexpected hostname format: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.254 WARN    getDualStackIpAddrFromDnsHostname(): Failed to parse dual-stack address with error 0x00000002 from hostname: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.254 WARN    getIpWithHostName(): Parsing for TURN address failed for x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com, fallback to getaddrinfo
2026-01-27 19:55:23.256 DEBUG   getIpWithHostName(): Found an IPv4 ICE server addresss: x.x.x.x
2026-01-27 19:55:23.256 ERROR   getIpWithHostName(): operation returned status code: 0x00000002
2026-01-27 19:55:23.256 PROFILE createIceAgent(): [ICE server parsing] Time taken: 1 ms
2026-01-27 19:55:23.256 ERROR   createIceAgent(): Failed to parse ICE servers
2026-01-27 19:55:23.256 INFO    getIpWithHostName(): ICE SERVER Hostname received: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.256 DEBUG   getIpWithHostName(): Attempting to parse dual-stack IP addresses from TURN server hostname: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.256 WARN    getDualStackIpAddrFromDnsHostname(): Parsing IPv4 address failed, received unexpected hostname format: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.256 WARN    getDualStackIpAddrFromDnsHostname(): Failed to parse dual-stack address with error 0x00000002 from hostname: x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com
2026-01-27 19:55:23.256 WARN    getIpWithHostName(): Parsing for TURN address failed for x-x-x-x.t-xxxxxxxx.kinesisvideo.us-west-2.amazonaws.com, fallback to getaddrinfo
2026-01-27 19:55:23.257 DEBUG   getIpWithHostName(): Found an IPv4 ICE server addresss: x.x.x.x
2026-01-27 19:55:23.257 ERROR   getIpWithHostName(): operation returned status code: 0x00000002
2026-01-27 19:55:23.257 PROFILE createIceAgent(): [ICE server parsing] Time taken: 1 ms
2026-01-27 19:55:23.257 ERROR   createIceAgent(): Failed to parse ICE servers
2026-01-27 19:55:23.257 ERROR   createPeerConnection(): operation returned status code: 0x00000002
2026-01-27 19:55:23.257 ERROR   iceAgentShutdown(): operation returned status code: 0x00000001
2026-01-27 19:55:23.257 ERROR   freePeerConnection(): operation returned status code: 0x00000001
2026-01-27 19:55:23.257 INFO    freeDtlsSession(): Freeing the DTLS session
2026-01-27 19:55:23.257 PROFILE freePeerConnection(): [Free peer connection] Time taken: 0 ms
2026-01-27 19:55:23.257 ERROR   initializePeerConnection(): operation returned status code: 0x00000002
2026-01-27 19:55:23.257 DEBUG   freeSampleStreamingSession(): Freeing streaming session with peer id: mkx0n52u-ev9mc1t4en 
2026-01-27 19:55:23.257 ERROR   closePeerConnection(): operation returned status code: 0x00000001
2026-01-27 19:55:23.257 ERROR   freeSampleStreamingSession(): operation returned status code: 0x00000001
2026-01-27 19:55:23.257 ERROR   signalingMessageReceived(): operation returned status code: 0x00000002
2026-01-27 19:55:23.257 ERROR   receiveLwsMessageWrapper(): operation returned status code: 0x00000002
2026-01-27 19:55:23.703 PROFILE createRtcCertificate(): [Certificate creation time] Time taken: 4 ms
2026-01-27 19:55:23.703 VERBOSE pregenerateCertTimerCallback(): New certificate has been pre-generated and added to the queue
2026-01-27 19:55:24.078 VERBOSE lwsWssCallbackRoutine(): WSS callback with reason 10
2026-01-27 19:55:24.078 DEBUG   lwsWssCallbackRoutine(): Client is writable
```

</details>

*What was changed?*
-  Fixed `getIpWithHostName()` to correctly return success status when getaddrinfo fallback succeeds

*Why was it changed?*
- When using the legacy control plane endpoint, the GetIceServerConfig API returns legacy turn server format. But the SDK is set to dual-stack mode so it's expecting to parse the dual-stack format, causing a mismatch. That's why the getaddrinfo fallback is implemented.
- **When dual-stack hostname parsing failed, the error status (`0x00000002`) persisted even after getaddrinfo successfully resolved the address.**
- This caused ICE agent creation to fail with "Failed to parse ICE servers" despite successful DNS resolution, preventing peer connections from being established.

*How was it changed?*
- Added `retStatus = STATUS_SUCCESS` reset before attempting getaddrinfo fallback in `src/source/Ice/Network.c`. This ensures the function returns success when the fallback path successfully resolves the hostname.

*What testing was done for the changes?*
- Tested the above scenario again and the fallback value is correctly used instead of being ignored. PeerConnection established with the JS page

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
