### PR TITLE
Zero-initialize Signaling message struct

### DIFF
--- a/samples/Common.c
+++ b/samples/Common.c
@@ -277,7 +277,7 @@ CleanUp:
 STATUS respondWithAnswer(PSampleStreamingSession pSampleStreamingSession)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    SignalingMessage message;
+    SignalingMessage message = {0};
     UINT32 buffLen = MAX_SIGNALING_MESSAGE_LEN;
 
     CHK_STATUS(serializeSessionDescriptionInit(&pSampleStreamingSession->answerSessionDescriptionInit, message.payload, &buffLen));
@@ -312,7 +312,7 @@ VOID onIceCandidateHandler(UINT64 customData, PCHAR candidateJson)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PSampleStreamingSession pSampleStreamingSession = (PSampleStreamingSession) customData;
-    SignalingMessage message;
+    SignalingMessage message = {0};
 
     CHK(pSampleStreamingSession != NULL, STATUS_NULL_ARG);
 

--- a/samples/kvsWebRTCClientViewer.c
+++ b/samples/kvsWebRTCClientViewer.c
@@ -36,7 +36,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     STATUS retStatus = STATUS_SUCCESS;
     RtcSessionDescriptionInit offerSessionDescriptionInit;
     UINT32 buffLen = 0;
-    SignalingMessage message;
+    SignalingMessage message = {0};
     PSampleConfiguration pSampleConfiguration = NULL;
     PSampleStreamingSession pSampleStreamingSession = NULL;
     RTC_CODEC audioCodec = RTC_CODEC_OPUS;

--- a/samples/kvsWebRTCClientViewerGstSample.c
+++ b/samples/kvsWebRTCClientViewerGstSample.c
@@ -36,7 +36,7 @@ INT32 main(INT32 argc, CHAR* argv[])
     STATUS retStatus = STATUS_SUCCESS;
     RtcSessionDescriptionInit offerSessionDescriptionInit;
     UINT32 buffLen = 0;
-    SignalingMessage message;
+    SignalingMessage message = {0};
     PSampleConfiguration pSampleConfiguration = NULL;
     PSampleStreamingSession pSampleStreamingSession = NULL;
     RTC_CODEC audioCodec = RTC_CODEC_OPUS;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Initialized SignalingMessage structures with {0} in all sample applications to zero out struct padding bytes and unused array elements.

*Why was it changed?*
- **This is a sample bug, not an SDK bug.** Valgrind detected use of uninitialized memory when SignalingMessage structures were passed from sample code to SDK functions. The observed error was:

```
==12464== Memcheck, a memory error detector
==12464== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==12464== Using Valgrind-3.22.0-bd4db67b1d-20231031 and LibVEX; rerun with -h for copyright info
==12464== Command: ./samples/kvsWebrtcClientMaster demo-channel-storage 1 opus h264
==12464== Parent PID: 12463
==12464== 
--12464-- 
--12464-- Valgrind options:
--12464--    --leak-check=full
--12464--    --show-leak-kinds=all
--12464--    --track-origins=yes
--12464--    --verbose
--12464--    --log-file=valgrind-master.txt
==12464==    at 0x4846828: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12464==    by 0x4A3B1B4: _IO_file_doallocate (filedoalloc.c:101)
==12464==    by 0x4A4B523: _IO_doallocbuf (genops.c:347)
==12464==    by 0x4A48F8F: _IO_file_overflow@@GLIBC_2.2.5 (fileops.c:745)
==12464==    by 0x4A49AAE: _IO_new_file_xsputn (fileops.c:1244)
==12464==    by 0x4A49AAE: _IO_file_xsputn@@GLIBC_2.2.5 (fileops.c:1197)
==12464==    by 0x4A16B48: __printf_buffer_flush_to_file (printf_buffer_to_file.c:59)
==12464==    by 0x4A167E4: __printf_buffer_do_flush (printf_buffer_flush.c:53)
==12464==    by 0x4A167E4: __printf_buffer_flush (Xprintf_buffer_flush.c:65)
==12464==    by 0x4A16DA8: __printf_buffer_write (Xprintf_buffer_write.c:33)
==12464==    by 0x4A1F483: __printf_buffer (vfprintf-internal.c:1028)
==12464==    by 0x4A215A1: __vfprintf_internal (vfprintf-internal.c:1559)
==12464==    by 0x112FD5: fileLoggerLogPrintFn (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/samples/kvsWebrtcClientMaster)
==12464==    by 0x10BF7F: main (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/samples/kvsWebrtcClientMaster)
==12464==  Uninitialised value was created by a stack allocation
==12464==    at 0x10EA23: onIceCandidateHandler (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/samples/kvsWebrtcClientMaster)
==12464== 
==12464== 
==12464== 8 errors in context 2 of 2:
==12464== Conditional jump or move depends on uninitialised value(s)
==12464==    at 0x484F238: strlen (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==12464==    by 0x4A20DA7: __printf_buffer (vfprintf-process-arg.c:435)
==12464==    by 0x4A215A1: __vfprintf_internal (vfprintf-internal.c:1559)
==12464==    by 0x112FD5: fileLoggerLogPrintFn (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/samples/kvsWebrtcClientMaster)
==12464==    by 0x4982F87: sendLwsMessage (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/libkvsWebrtcSignalingClient.so)
==12464==    by 0x498649B: signalingSendMessageSync (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/libkvsWebrtcSignalingClient.so)
==12464==    by 0x497E000: signalingClientSendMessageSync (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/libkvsWebrtcSignalingClient.so)
==12464==    by 0x10E4D6: sendSignalingMessage (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/samples/kvsWebrtcClientMaster)
==12464==    by 0x10EBCD: onIceCandidateHandler (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/samples/kvsWebrtcClientMaster)
==12464==    by 0x489DA59: onNewIceLocalCandidate (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/libkvsWebrtcClient.so)
==12464==    by 0x488E0FC: iceAgentReportNewLocalCandidate (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/libkvsWebrtcClient.so)
==12464==    by 0x488E4BB: iceAgentGatherCandidateTimerCallback (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/libkvsWebrtcClient.so)
==12464==  Uninitialised value was created by a stack allocation
==12464==    at 0x10EA23: onIceCandidateHandler (in /home/runner/work/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/build/samples/kvsWebrtcClientMaster)
==12464== 
==12464== ERROR SUMMARY: 10 errors from 2 contexts (suppressed: 0 from 0)
```

- **Why this is a sample bug:** The SDK code does not instantiate SignalingMessage structures, it only receives pointers to them from application code.

- **Why the SDK cannot/should not validate this:** 
  - The SDK correctly validates logical constraints (NULL pointers, string lengths, struct version) but cannot detect uninitialized memory in caller-provided structures.

*How was it changed?*
- Use `{0}` to zero-initialize the struct in the samples.
- The `{0}` initialization is C89 standard-compliant and already used elsewhere in the codebase

*What testing was done for the changes?*
- Checked the valgrind output and it's not giving this warning anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
