### PR TITLE
Speed up AWS SDK CPP build

### DIFF
--- a/CMake/Dependencies/libawscpp-CMakeLists.txt
+++ b/CMake/Dependencies/libawscpp-CMakeLists.txt
@@ -4,10 +4,12 @@ include(ExternalProject)
 
 ExternalProject_Add(libawscpp-download
     GIT_REPOSITORY    https://github.com/aws/aws-sdk-cpp.git
-    GIT_TAG           1.11.217
+    GIT_TAG           1.11.741
     LIST_SEPARATOR    "|"
     CMAKE_ARGS       -DBUILD_SHARED_LIBS=OFF
                      -DBUILD_ONLY=kinesisvideo|kinesis-video-webrtc-storage
+                     -DENABLE_TESTING=OFF
+                     -DAUTORUN_UNIT_TESTS=OFF
                      -DCMAKE_INSTALL_PREFIX=${OPEN_SRC_INSTALL_PREFIX}
     BUILD_ALWAYS      TRUE
     GIT_PROGRESS      TRUE


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Speed up the test build

*Why was it changed?*
- When building the tests (`cmake .. -DBUILD_TEST=ON`), the AWS SDK C++ will be built and used. By [default](https://github.com/aws/aws-sdk-cpp/blob/main/docs/CMake_Parameters.md), their unit tests will be built and run, which slows down our CI/CD.

*How was it changed?*
- Disable building and running AWS SDK C++'s unit tests in our build
- Upgrade to the latest version to consume the latest bug fixes and security updates

*What testing was done for the changes?*
- CI/CD should be sufficient as this only impacts the test build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
