### PR TITLE
connectionListener: Yield till timeout if no fds set

### DIFF
--- a/src/source/Ice/ConnectionListener.c
+++ b/src/source/Ice/ConnectionListener.c
@@ -315,6 +315,9 @@ PVOID connectionListenerReceiveDataRoutine(PVOID arg)
 #endif
             // blocking call until resolves as a timeout, an error, a signal or data received
             retval = POLL(rfds, nfds, CONNECTION_LISTENER_SOCKET_WAIT_FOR_DATA_TIMEOUT / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        } else {
+            // No sockets to poll (no active sessions). Yield to other tasks.
+            THREAD_SLEEP(CONNECTION_LISTENER_SOCKET_WAIT_FOR_DATA_TIMEOUT);
         }
 
         // In case of 0 we have a timeout and should re-lock to allow for other


### PR DESCRIPTION
Till the time session is active, we keep polling on active sockets. For this time period, if there is no data on any sockets, we may keep spinning

Solution: Sleep for timeout milliseconds in no-data case