### PR TITLE
Fix compile warning in the test

### DIFF
--- a/tst/CustomEndpointTest.cpp
+++ b/tst/CustomEndpointTest.cpp
@@ -25,7 +25,7 @@ TEST_F(CustomEndpointTest, customControlPlaneEndpointBasicCase)
     channelInfo.pControlPlaneUrl = (PCHAR) validatedCustomControlPlaneUrl;
 
     // pChannelName must be set to make the createValidateChannelInfo call.
-    channelInfo.pChannelName = "TestChannelName";
+    channelInfo.pChannelName = (PCHAR) "TestChannelName";
 
     EXPECT_EQ(STATUS_SUCCESS, createValidateChannelInfo(&channelInfo, &pChannelInfo));
     EXPECT_NE(nullptr, pChannelInfo);
@@ -57,7 +57,7 @@ TEST_F(CustomEndpointTest, customControlPlaneEndpointEdgeCases)
     channelInfo.pControlPlaneUrl = (PCHAR) validatedCustomControlPlaneUrl;
 
     // pChannelName must be set to make the createValidateChannelInfo call.
-    channelInfo.pChannelName = "TestChannelName";
+    channelInfo.pChannelName = (PCHAR) "TestChannelName";
 
 
     /* MAX URL ARRAY LENGTH (expect the custom URL be used) */
@@ -123,7 +123,7 @@ TEST_F(CustomEndpointTest, customControlPlaneEndpointTooLong)
     CHAR customControlPlaneUrl[MAX_URI_CHAR_LEN + 2] =  {0};
 
     // pChannelName must be set to make the createValidateChannelInfo call.
-    channelInfo.pChannelName = "TestChannelName";
+    channelInfo.pChannelName = (PCHAR) "TestChannelName";
 
     // Fill array full of non-null values, accounting for null terminator.
     MEMSET(customControlPlaneUrl, 'X', SIZEOF(customControlPlaneUrl));


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fix a compile warning in the test

```log
/__w/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/CustomEndpointTest.cpp: In member function 'virtual void com::amazonaws::kinesis::video::webrtcclient::CustomEndpointTest_customControlPlaneEndpointBasicCase_Test::TestBody()':
/__w/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/CustomEndpointTest.cpp:28:32: warning: ISO C++ forbids converting a string constant to 'PCHAR' {aka 'char*'} [-Wwrite-strings]
   28 |     channelInfo.pChannelName = "TestChannelName";
      |                                ^~~~~~~~~~~~~~~~~
/__w/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/CustomEndpointTest.cpp: In member function 'virtual void com::amazonaws::kinesis::video::webrtcclient::CustomEndpointTest_customControlPlaneEndpointEdgeCases_Test::TestBody()':
/__w/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/CustomEndpointTest.cpp:60:32: warning: ISO C++ forbids converting a string constant to 'PCHAR' {aka 'char*'} [-Wwrite-strings]
   60 |     channelInfo.pChannelName = "TestChannelName";
      |                                ^~~~~~~~~~~~~~~~~
/__w/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/CustomEndpointTest.cpp: In member function 'virtual void com::amazonaws::kinesis::video::webrtcclient::CustomEndpointTest_customControlPlaneEndpointTooLong_Test::TestBody()':
/__w/amazon-kinesis-video-streams-webrtc-sdk-c/amazon-kinesis-video-streams-webrtc-sdk-c/tst/CustomEndpointTest.cpp:126:32: warning: ISO C++ forbids converting a string constant to 'PCHAR' {aka 'char*'} [-Wwrite-strings]
  126 |     channelInfo.pChannelName = "TestChannelName";
      |                                ^~~~~~~~~~~~~~~~~
```

*Why was it changed?*
- Less compile warnings

*How was it changed?*
- Cast to PCHAR

*What testing was done for the changes?*
- Built locally and no more warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
