### PR TITLE
Validate input for transceiver direction and default to sendrecv if not valid

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -889,10 +889,12 @@ typedef enum {
  * Reference: https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverdirection
  */
 typedef enum {
-    RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV = 1, //!< This indicates that peer can send and receive data
-    RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY = 2, //!< This indicates that the peer can only send information
-    RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY = 3, //!< This indicates that the peer can only receive information
-    RTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE = 4, //!< This indicates that the peer can not send or receive data
+    RTC_RTP_TRANSCEIVER_DIRECTION_UNINITIALIZED = 0, //!< Will use the default "sendrecv" after initialization
+    RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV = 1,      //!< This indicates that peer can send and receive data
+    RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY = 2,      //!< This indicates that the peer can only send information
+    RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY = 3,      //!< This indicates that the peer can only receive information
+    RTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE = 4,      //!< This indicates that the peer can not send or receive data
+    RTC_RTP_TRANSCEIVER_DIRECTION_MAX,               //!< Sentinel for validation, keep last
 } RTC_RTP_TRANSCEIVER_DIRECTION;
 
 /**

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1613,7 +1613,12 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
 
     if (pRtcRtpTransceiverInit != NULL) {
-        direction = pRtcRtpTransceiverInit->direction;
+        if (RTC_RTP_TRANSCEIVER_DIRECTION_UNINITIALIZED < pRtcRtpTransceiverInit->direction &&
+            pRtcRtpTransceiverInit->direction < RTC_RTP_TRANSCEIVER_DIRECTION_MAX) {
+            direction = pRtcRtpTransceiverInit->direction;
+        } else {
+            DLOGW("Unknown direction: %u, defaulting to sendrecv", (UINT32) pRtcRtpTransceiverInit->direction);
+        }
     }
 
     if (direction == RTC_RTP_TRANSCEIVER_DIRECTION_RECVONLY && pRtcMediaStreamTrack == NULL) {

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -1052,6 +1052,95 @@ a=group:BUNDLE 0
     });
 }
 
+// scenario: zero-initialize the struct and don't set the direction property
+TEST_F(SdpApiTest, addTransceiverNoDirection_thenDefaultToSendRecv)
+{
+    auto offer = std::string(R"(v=0
+o=- 481034601 1588366671 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5
+a=group:BUNDLE 0 1
+m=video 9 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 0.0.0.0
+a=setup:actpass
+a=mid:0
+a=ice-ufrag:WWlXtoHfeAVCwqHc
+a=ice-pwd:GvmyTnsfVtQuxuoareyqyAapQRoAeMdp
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 H264/90000
+a=sendrecv
+m=audio 9 UDP/TLS/RTP/SAVPF 111
+c=IN IP4 0.0.0.0
+a=setup:actpass
+a=mid:1
+a=ice-ufrag:WWlXtoHfeAVCwqHc
+a=ice-pwd:GvmyTnsfVtQuxuoareyqyAapQRoAeMdp
+a=rtcp-mux
+a=rtpmap:111 opus/48000/2
+a=sendrecv
+)");
+
+    assertLFAndCRLF((PCHAR) offer.c_str(), offer.size(), [](PCHAR sdp) {
+        RtcConfiguration configuration{};
+        PRtcPeerConnection pRtcPeerConnection = nullptr;
+        RtcMediaStreamTrack videoTrack{}, audioTrack{};
+        PRtcRtpTransceiver videoTransceiver = nullptr, audioTransceiver = nullptr;
+        RtcSessionDescriptionInit offerSdp{}, answerSdp{};
+        RtcRtpTransceiverInit videoInit{}, audioInit{};
+
+        MEMSET(&videoInit, 0x00, SIZEOF(videoInit));
+        MEMSET(&audioInit, 0x00, SIZEOF(videoInit));
+
+        videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        videoTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+        STRCPY(videoTrack.streamId, "videoStream");
+        STRCPY(videoTrack.trackId, "videoTrack");
+        // no direction (leave as 0)
+
+        audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
+        audioTrack.codec = RTC_CODEC_OPUS;
+        STRCPY(audioTrack.streamId, "audioStream");
+        STRCPY(audioTrack.trackId, "audioTrack");
+        audioInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_MAX;
+
+        offerSdp.type = SDP_TYPE_OFFER;
+        STRCPY(offerSdp.sdp, sdp);
+
+        EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+        EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+        EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_OPUS));
+        EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &videoTrack, &videoInit, &videoTransceiver));
+        EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &audioTrack, &audioInit, &audioTransceiver));
+        EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(pRtcPeerConnection, &offerSdp));
+        EXPECT_EQ(STATUS_SUCCESS, createAnswer(pRtcPeerConnection, &answerSdp));
+
+        std::string answer(answerSdp.sdp);
+        EXPECT_PRED_FORMAT2(testing::IsSubstring, "m=video", answer);
+        EXPECT_PRED_FORMAT2(testing::IsSubstring, "m=audio", answer);
+
+        // Find positions of media sections
+        size_t videoPos = answer.find("m=video");
+        size_t audioPos = answer.find("m=audio");
+
+        // Find direction attributes, searching from each media section start
+        size_t videoSendonly = answer.find("a=sendrecv", videoPos);
+        size_t audioSendrecv = answer.find("a=sendrecv", audioPos);
+
+        // Verify video has sendrecv (offer sendrecv + answer sendrecv = sendrecv)
+        EXPECT_NE(videoSendonly, std::string::npos);
+        EXPECT_LT(videoSendonly, audioPos); // sendrecv must be before audio section (i.e., in video section)
+
+        // Verify audio has sendrecv (offer sendrecv + answer sendrecv = sendrecv)
+        EXPECT_NE(audioSendrecv, std::string::npos);
+        EXPECT_GT(audioSendrecv, audioPos); // sendrecv must be after audio section start (i.e., in audio section)
+
+        closePeerConnection(pRtcPeerConnection);
+        freePeerConnection(&pRtcPeerConnection);
+    });
+}
+
 // if offer (remote) contains video m-line only then answer (local) should contain video m-line only
 // even if local side has other transceivers, i.e. audio
 TEST_F(SdpApiTest, videoOnlyOffer_validateNoAudioInAnswer)


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add input validation for the direction. The target scenario is zero-initializing the struct but not updating this field
- According to spec (https://www.w3.org/TR/webrtc/#webidl-1417283722), the default should be sendrecv

*Why was it changed?*
- In #2222 the direction will be considered when creating the answer

*How was it changed?*
- Added max and zero transceiver direction sentinel values and validate the enum value is valid
- If not, print a warning and default to sendrecv

*What testing was done for the changes?*
- Ran the new unit test locally:

```log
2026-02-20 17:53:07.453 WARN    addTransceiver(): Unknown direction: 0, defaulting to sendrecv
2026-02-20 17:53:07.453 WARN    addTransceiver(): Unknown direction: 5, defaulting to sendrecv
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
