### PR TITLE
Print the signaling message when it failed to parse

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -2090,7 +2090,7 @@ STATUS parseSignalingMessage(PCHAR pMessage, UINT32 messageLen, PReceivedSignali
         }
     }
 
-    CHK_ERR(parsedMessageType, STATUS_SIGNALING_INVALID_MESSAGE_TYPE, "Could not parse: %s", pMessage);
+    CHK_ERR(parsedMessageType, STATUS_SIGNALING_INVALID_MESSAGE_TYPE, "Could not parse: %.*s", messageLen, pMessage);
 
 CleanUp:
     CHK_LOG_ERR(retStatus);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Print the signaling message when it fails to parse

*Why was it changed?*
- Observability: Currently it just prints the error code and no further information

*How was it changed?*
- Print the message

*What testing was done for the changes?*
- CI/CD as this is a trivial change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
