### PR TITLE
Bump the version to 1.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CheckIncludeFiles)
 include(CheckFunctionExists)
 
 # The version MUST be updated before every release
-project(KinesisVideoWebRTCClient VERSION 1.16.0 LANGUAGES C)
+project(KinesisVideoWebRTCClient VERSION 1.17.0 LANGUAGES C)
 
 # User Flags
 option(ADD_MUCLIBC "Add -muclibc c flag" OFF)


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Bump the project version to 1.17.0

*Why was it changed?*
- Release prep - video-only mode for webrtc ingest

*How was it changed?*
- Change the project version used for the user agent

*What testing was done for the changes?*
- Trivial change, CI/CD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
