### PR TITLE
Add readonly permission for the stack size check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    permissions:
+      contents: read
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Specify readonly permission for the stack size check job

*Why was it changed?*
- Minimal permission best practice

*How was it changed?*
- Set the readonly permission

*What testing was done for the changes?*
- CI/CD should verify

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
