### PR TITLE
Added note that CMake 3.x is required and 4.x is not yet supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To download run the following command:
 git clone https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c.git --single-branch -b main kvs-webrtc-sdk
 ```
 
-You will also need to install `pkg-config` and `CMake` and a build environment
+You will also need to install `pkg-config` and `CMake` (requires 3.x, `CMake` 4.x is not yet supported) and a build environment
 
 ### Configuring on Ubuntu / Unix
 


### PR DESCRIPTION
*Issue #, if available:*
- #2227 

*What was changed?*
- README

*Why was it changed?*
- To make sure users know to use CMake version 3.x and not 4.x when building.

*How was it changed?*
- Added a clarification to the README to specify version of CMake required.

*What testing was done for the changes?*
- None, only README was changed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
