### PR TITLE
feat: Add USE_KVS_FIPS_ENDPOINT environment variable for FIPS-compliant endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,30 @@ To disable dual-stack mode, unset the environment variable:
 unset KVS_DUALSTACK_ENDPOINTS
 ```
 
+### Enabling FIPS mode
+To use FIPS-compliant AWS KVS endpoints, set the following environment variable:
+```
+export USE_KVS_FIPS_ENDPOINT=ON
+```
+
+When enabled, the SDK will automatically use the appropriate FIPS endpoint based on the configured region. FIPS endpoints are available for the following regions:
+- `us-iso-east-1`, `us-iso-west-1` (C2S)
+- `us-isob-east-1` (SC2S)
+- `us-gov-west-1`, `us-gov-east-1` (GovCloud)
+
+Note: FIPS STUN endpoints use the `stuns:` scheme (TLS) instead of `stun:` for secure communication.
+
+FIPS mode can be combined with dual-stack mode by setting both environment variables:
+```
+export USE_KVS_FIPS_ENDPOINT=ON
+export KVS_DUALSTACK_ENDPOINTS=ON
+```
+
+To disable FIPS mode, unset the environment variable:
+```
+unset USE_KVS_FIPS_ENDPOINT
+```
+
 ### Disabling IP-Family-Specific TURN Candidates
 The following environment variables can be used to disable certain TURN relay candidates from being generated for the local peer:
 ```

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -856,6 +856,27 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
         pSampleConfiguration->channelInfo.pRegion = DEFAULT_AWS_REGION;
     }
 
+    // Early validation: Check if FIPS endpoint is enabled with an unsupported region
+    if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR)) {
+        BOOL fipsRegionSupported = FALSE;
+        PCHAR supportedFipsRegions[] = {"us-iso-east-1", "us-iso-west-1", "us-isob-east-1", "us-gov-west-1", "us-gov-east-1"};
+        UINT32 numSupportedRegions = ARRAY_SIZE(supportedFipsRegions);
+        UINT32 regionIdx;
+        
+        for (regionIdx = 0; regionIdx < numSupportedRegions; regionIdx++) {
+            if (STRCMP(pSampleConfiguration->channelInfo.pRegion, supportedFipsRegions[regionIdx]) == 0) {
+                fipsRegionSupported = TRUE;
+                break;
+            }
+        }
+        
+        if (!fipsRegionSupported) {
+            DLOGE("FIPS endpoint is not supported for region '%s'. Supported FIPS regions: us-iso-east-1, us-iso-west-1, us-isob-east-1, us-gov-west-1, us-gov-east-1. Exiting.", 
+                  pSampleConfiguration->channelInfo.pRegion);
+            CHK(FALSE, STATUS_SIGNALING_INVALID_REGION_LENGTH);
+        }
+    }
+
     CHK_STATUS(lookForSslCert(&pSampleConfiguration));
 
 #ifdef IOT_CORE_ENABLE_CREDENTIALS

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -385,26 +385,8 @@ STATUS initializePeerConnection(PSampleConfiguration pSampleConfiguration, PRtcP
     configuration.kvsRtcConfiguration.enableIceStats = pSampleConfiguration->enableIceStats;
 #endif
 
-    // Set the  STUN server
-    PCHAR pKinesisVideoStunUrlPostFix = NULL;
-    if (isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
-        DLOGD("Using dual-stack STUN endpoint");
-        if (STRSTR(pSampleConfiguration->channelInfo.pRegion, "cn-")) {
-            pKinesisVideoStunUrlPostFix = KINESIS_VIDEO_DUALSTACK_STUN_URL_POSTFIX_CN;
-        } else {
-            pKinesisVideoStunUrlPostFix = KINESIS_VIDEO_DUALSTACK_STUN_URL_POSTFIX;
-        }
-    } else {
-        DLOGD("Using legacy STUN endpoint");
-        if (STRSTR(pSampleConfiguration->channelInfo.pRegion, "cn-")) {
-            pKinesisVideoStunUrlPostFix = KINESIS_VIDEO_STUN_URL_POSTFIX_CN;
-        } else {
-            pKinesisVideoStunUrlPostFix = KINESIS_VIDEO_STUN_URL_POSTFIX;
-        }
-    }
-
-    SNPRINTF(configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, pSampleConfiguration->channelInfo.pRegion,
-             pKinesisVideoStunUrlPostFix);
+    // Set the STUN server URL using SDK function (handles standard, dual-stack, China, and FIPS endpoints)
+    CHK_STATUS(getStunUrl(pSampleConfiguration->channelInfo.pRegion, configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN));
 
     if (pSampleConfiguration->useTurn) {
         // Set the URIs from the configuration
@@ -856,26 +838,6 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
         pSampleConfiguration->channelInfo.pRegion = DEFAULT_AWS_REGION;
     }
 
-    // Early validation: Check if FIPS endpoint is enabled with an unsupported region
-    if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR)) {
-        BOOL fipsRegionSupported = FALSE;
-        PCHAR supportedFipsRegions[] = {"us-iso-east-1", "us-iso-west-1", "us-isob-east-1", "us-gov-west-1", "us-gov-east-1"};
-        UINT32 numSupportedRegions = ARRAY_SIZE(supportedFipsRegions);
-        UINT32 regionIdx;
-        
-        for (regionIdx = 0; regionIdx < numSupportedRegions; regionIdx++) {
-            if (STRCMP(pSampleConfiguration->channelInfo.pRegion, supportedFipsRegions[regionIdx]) == 0) {
-                fipsRegionSupported = TRUE;
-                break;
-            }
-        }
-        
-        if (!fipsRegionSupported) {
-            DLOGE("FIPS endpoint is not supported for region '%s'. Supported FIPS regions: us-iso-east-1, us-iso-west-1, us-isob-east-1, us-gov-west-1, us-gov-east-1. Exiting.", 
-                  pSampleConfiguration->channelInfo.pRegion);
-            CHK(FALSE, STATUS_SIGNALING_INVALID_REGION_LENGTH);
-        }
-    }
 
     CHK_STATUS(lookForSslCert(&pSampleConfiguration));
 

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -361,6 +361,7 @@ extern "C" {
 #define STATUS_SIGNALING_JOIN_SESSION_CALL_FAILED                  STATUS_SIGNALING_BASE + 0x0000004a
 #define STATUS_SIGNALING_JOIN_SESSION_CONNECTED_FAILED             STATUS_SIGNALING_BASE + 0x0000004b
 #define STATUS_SIGNALING_DESCRIBE_MEDIA_CALL_FAILED                STATUS_SIGNALING_BASE + 0x0000004c
+#define STATUS_SIGNALING_FIPS_UNSUPPORTED_REGION                   STATUS_SIGNALING_BASE + 0x0000004d
 
 /*!@} */
 
@@ -2269,6 +2270,20 @@ PUBLIC_API STATUS createRtcCertificate(PRtcCertificate*);
  * @return STATUS code of the execution. STATUS_SUCCESS on success
  */
 PUBLIC_API STATUS freeRtcCertificate(PRtcCertificate);
+
+/**
+ * @brief Constructs the STUN server URL based on region and environment settings.
+ * Handles standard, dual-stack, China, and FIPS endpoints.
+ *
+ * Note: FIPS STUN requires "stuns:" scheme (TLS), not "stun:"
+ *
+ * @param[in] PCHAR The AWS region string
+ * @param[out] PCHAR Buffer to store the constructed STUN URL
+ * @param[in] UINT32 Size of the buffer
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS getStunUrl(PCHAR, PCHAR, UINT32);
 
 /*!@} */
 #ifdef __cplusplus

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -702,6 +702,16 @@ extern "C" {
 #define USE_DUAL_STACK_ENDPOINTS_ENV_VAR ((PCHAR) "KVS_DUALSTACK_ENDPOINTS")
 
 /**
+ * Env to control whether to use FIPS endpoints, unset means false
+ * When enabled, the SDK will automatically use the appropriate FIPS endpoint
+ * based on the configured region. Supported regions:
+ * - us-iso-east-1, us-iso-west-1 (C2S)
+ * - us-isob-east-1 (SC2S)
+ * - us-gov-west-1, us-gov-east-1 (GovCloud)
+ */
+#define USE_FIPS_ENDPOINT_ENV_VAR ((PCHAR) "USE_KVS_FIPS_ENDPOINT")
+
+/**
  * Envs to disable IPv4 or IPv6 TURN relay candidates
  */
 #define DISABLE_IPV4_TURN_ENV_VAR ((PCHAR) "KVS_DISABLE_IPV4_TURN")

--- a/src/source/Signaling/ChannelInfo.c
+++ b/src/source/Signaling/ChannelInfo.c
@@ -1,6 +1,54 @@
 #define LOG_CLASS "ChannelInfo"
 #include "../Include_i.h"
 
+// FIPS endpoint mappings - region to endpoint URL (legacy/non-dual-stack)
+// These endpoints are used when only USE_FIPS_ENDPOINT_ENV_VAR is enabled
+static const FipsEndpointMapping FIPS_ENDPOINT_MAPPINGS[FIPS_ENDPOINT_MAPPING_COUNT] = {
+    {"us-iso-east-1", "https://kinesisvideo-fips.us-iso-east-1.c2s.ic.gov"},
+    {"us-iso-west-1", "https://kinesisvideo-fips.us-iso-west-1.c2s.ic.gov"},
+    {"us-isob-east-1", "https://kinesisvideo-fips.us-isob-east-1.sc2s.sgov.gov"},
+    {"us-gov-west-1", "https://kinesisvideo-fips.us-gov-west-1.amazonaws.com"},
+    {"us-gov-east-1", "https://kinesisvideo-fips.us-gov-east-1.amazonaws.com"},
+};
+
+// FIPS dual-stack endpoint mappings - region to endpoint URL
+// These endpoints are used when BOTH USE_FIPS_ENDPOINT_ENV_VAR and USE_DUAL_STACK_ENDPOINTS_ENV_VAR are enabled
+static const FipsEndpointMapping FIPS_DUAL_STACK_ENDPOINT_MAPPINGS[FIPS_ENDPOINT_MAPPING_COUNT] = {
+    {"us-iso-east-1", "https://kinesisvideo-fips.us-iso-east-1.api.aws.ic.gov"},
+    {"us-iso-west-1", "https://kinesisvideo-fips.us-iso-west-1.api.aws.ic.gov"},
+    {"us-isob-east-1", "https://kinesisvideo-fips.us-isob-east-1.api.aws.scloud"},
+    {"us-gov-west-1", "https://kinesisvideo-fips.us-gov-west-1.api.aws"},
+    {"us-gov-east-1", "https://kinesisvideo-fips.us-gov-east-1.api.aws"},
+};
+
+/**
+ * Gets the FIPS endpoint URL for a given region.
+ *
+ * @param pRegion - The AWS region string
+ * @param useDualStack - Whether to use dual-stack FIPS endpoints
+ *
+ * @return - The FIPS endpoint URL if found, NULL otherwise
+ */
+static PCHAR getFipsEndpointForRegion(PCHAR pRegion, BOOL useDualStack)
+{
+    UINT32 i;
+    const FipsEndpointMapping* pMappings;
+
+    if (pRegion == NULL) {
+        return NULL;
+    }
+
+    pMappings = useDualStack ? FIPS_DUAL_STACK_ENDPOINT_MAPPINGS : FIPS_ENDPOINT_MAPPINGS;
+
+    for (i = 0; i < FIPS_ENDPOINT_MAPPING_COUNT; i++) {
+        if (STRCMP(pRegion, pMappings[i].pRegion) == 0) {
+            return pMappings[i].pEndpoint;
+        }
+    }
+
+    return NULL;
+}
+
 #define ARN_DELIMETER_CHAR                  ':'
 #define ARN_CHANNEL_NAME_CODE_SEP           '/'
 #define ARN_BEGIN                           "arn:aws"
@@ -175,28 +223,37 @@ STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* pp
 
     if (!IS_NULL_OR_EMPTY_STRING(pOrigChannelInfo->pControlPlaneUrl)) {
         STRCPY(pCurPtr, pOrigChannelInfo->pControlPlaneUrl);
-    } else {
-        if (isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
-            // Create dual-stack fully qualified URI for appropriate region.
-            DLOGI("Using dual-stack KVS endpoints.");
-            if (STRSTR(pChannelInfo->pRegion, AWS_CN_REGION_PREFIX)) {
-                SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
-                         pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_CN_DUAL_STACK);
-            } else {
-                SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
-                         pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_DUAL_STACK);
-            }
-
+    } else if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR) && isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
+        // Case 1: BOTH FIPS and dual-stack enabled - use FIPS dual-stack endpoint
+        PCHAR pFipsEndpoint = getFipsEndpointForRegion(pChannelInfo->pRegion, TRUE);
+        DLOGI("Using FIPS dual-stack KVS endpoint for region %s.", pChannelInfo->pRegion);
+        STRNCPY(pCurPtr, pFipsEndpoint, MAX_CONTROL_PLANE_URI_CHAR_LEN - 1);
+        pCurPtr[MAX_CONTROL_PLANE_URI_CHAR_LEN - 1] = '\0';
+    } else if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR)) {
+        // Case 2: Only FIPS enabled - use FIPS endpoint (legacy/non-dual-stack)
+        PCHAR pFipsEndpoint = getFipsEndpointForRegion(pChannelInfo->pRegion, FALSE);
+        DLOGI("Using FIPS KVS endpoint for region %s.", pChannelInfo->pRegion);
+        STRNCPY(pCurPtr, pFipsEndpoint, MAX_CONTROL_PLANE_URI_CHAR_LEN - 1);
+        pCurPtr[MAX_CONTROL_PLANE_URI_CHAR_LEN - 1] = '\0';
+    } else if (isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
+        // Case 3: Only dual-stack enabled - use dual-stack endpoint
+        DLOGI("Using dual-stack KVS endpoints.");
+        if (STRSTR(pChannelInfo->pRegion, AWS_CN_REGION_PREFIX)) {
+            SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
+                     pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_CN_DUAL_STACK);
         } else {
-            // Create legacy fully qualified URI for appropriate region.
-            DLOGI("Using legacy KVS endpoints.");
-            if (STRSTR(pChannelInfo->pRegion, AWS_CN_REGION_PREFIX)) {
-                SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
-                         pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_CN);
-            } else {
-                SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
-                         pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX);
-            }
+            SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
+                     pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_DUAL_STACK);
+        }
+    } else {
+        // Case 4: Neither enabled - use standard/legacy endpoint
+        DLOGI("Using legacy KVS endpoints.");
+        if (STRSTR(pChannelInfo->pRegion, AWS_CN_REGION_PREFIX)) {
+            SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
+                     pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_CN);
+        } else {
+            SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
+                     pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX);
         }
     }
 

--- a/src/source/Signaling/ChannelInfo.c
+++ b/src/source/Signaling/ChannelInfo.c
@@ -1,52 +1,97 @@
 #define LOG_CLASS "ChannelInfo"
 #include "../Include_i.h"
 
-// FIPS endpoint mappings - region to endpoint URL (legacy/non-dual-stack)
-// These endpoints are used when only USE_FIPS_ENDPOINT_ENV_VAR is enabled
-static const FipsEndpointMapping FIPS_ENDPOINT_MAPPINGS[FIPS_ENDPOINT_MAPPING_COUNT] = {
-    {"us-iso-east-1", "https://kinesisvideo-fips.us-iso-east-1.c2s.ic.gov"},
-    {"us-iso-west-1", "https://kinesisvideo-fips.us-iso-west-1.c2s.ic.gov"},
-    {"us-isob-east-1", "https://kinesisvideo-fips.us-isob-east-1.sc2s.sgov.gov"},
-    {"us-gov-west-1", "https://kinesisvideo-fips.us-gov-west-1.amazonaws.com"},
-    {"us-gov-east-1", "https://kinesisvideo-fips.us-gov-east-1.amazonaws.com"},
-};
-
-// FIPS dual-stack endpoint mappings - region to endpoint URL
-// These endpoints are used when BOTH USE_FIPS_ENDPOINT_ENV_VAR and USE_DUAL_STACK_ENDPOINTS_ENV_VAR are enabled
-static const FipsEndpointMapping FIPS_DUAL_STACK_ENDPOINT_MAPPINGS[FIPS_ENDPOINT_MAPPING_COUNT] = {
-    {"us-iso-east-1", "https://kinesisvideo-fips.us-iso-east-1.api.aws.ic.gov"},
-    {"us-iso-west-1", "https://kinesisvideo-fips.us-iso-west-1.api.aws.ic.gov"},
-    {"us-isob-east-1", "https://kinesisvideo-fips.us-isob-east-1.api.aws.scloud"},
-    {"us-gov-west-1", "https://kinesisvideo-fips.us-gov-west-1.api.aws"},
-    {"us-gov-east-1", "https://kinesisvideo-fips.us-gov-east-1.api.aws"},
-};
-
 /**
  * Gets the FIPS endpoint URL for a given region.
  *
  * @param pRegion - The AWS region string
  * @param useDualStack - Whether to use dual-stack FIPS endpoints
+ * @param pOutBuffer - Output buffer to store the endpoint URL
+ * @param outBufferLen - Length of the output buffer
  *
- * @return - The FIPS endpoint URL if found, NULL otherwise
+ * @return - STATUS_SUCCESS on success, error status otherwise
  */
-static PCHAR getFipsEndpointForRegion(PCHAR pRegion, BOOL useDualStack)
+static STATUS getFipsEndpointForRegion(PCHAR pRegion, BOOL useDualStack, PCHAR pOutBuffer, UINT32 outBufferLen)
 {
+    STATUS retStatus = STATUS_SUCCESS;
     UINT32 i;
     const FipsEndpointMapping* pMappings;
 
-    if (pRegion == NULL) {
-        return NULL;
-    }
+    CHK(pRegion != NULL, STATUS_NULL_ARG);
+    CHK(pOutBuffer != NULL, STATUS_NULL_ARG);
+    CHK(outBufferLen > 0, STATUS_INVALID_ARG);
 
     pMappings = useDualStack ? FIPS_DUAL_STACK_ENDPOINT_MAPPINGS : FIPS_ENDPOINT_MAPPINGS;
 
     for (i = 0; i < FIPS_ENDPOINT_MAPPING_COUNT; i++) {
         if (STRCMP(pRegion, pMappings[i].pRegion) == 0) {
-            return pMappings[i].pEndpoint;
+            STRNCPY(pOutBuffer, pMappings[i].pEndpoint, outBufferLen - 1);
+            pOutBuffer[outBufferLen - 1] = '\0';
+            CHK(FALSE, retStatus);  // Jump to CleanUp with STATUS_SUCCESS
         }
     }
 
-    return NULL;
+    DLOGW("FIPS endpoint is not supported for region: %s", pRegion);
+    CHK(FALSE, STATUS_SIGNALING_FIPS_UNSUPPORTED_REGION);
+
+CleanUp:
+    return retStatus;
+}
+
+/**
+ * Constructs the control plane endpoint URL based on region and environment settings.
+ * 
+ * Priority:
+ * 1. FIPS + dual-stack enabled -> FIPS dual-stack endpoint
+ * 2. FIPS only enabled -> FIPS legacy endpoint
+ * 3. Dual-stack only enabled -> standard dual-stack endpoint
+ * 4. Neither enabled -> standard legacy endpoint
+ *
+ * @param pRegion - The AWS region string
+ * @param pEndpointBuffer - Buffer to store the constructed endpoint URL
+ * @param bufferSize - Size of the endpoint buffer
+ *
+ * @return - STATUS_SUCCESS on success, error status otherwise
+ */
+STATUS constructControlPlaneEndpoint(PCHAR pRegion, PCHAR pEndpointBuffer, UINT32 bufferSize)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pRegion != NULL && pEndpointBuffer != NULL, STATUS_NULL_ARG);
+    CHK(bufferSize > 0, STATUS_INVALID_ARG);
+
+    if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR) && isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
+        // Case 1: BOTH FIPS and dual-stack enabled - use FIPS dual-stack endpoint
+        CHK_STATUS(getFipsEndpointForRegion(pRegion, TRUE, pEndpointBuffer, bufferSize));
+        DLOGI("Using FIPS dual-stack KVS endpoint for region %s.", pRegion);
+    } else if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR)) {
+        // Case 2: Only FIPS enabled - use FIPS endpoint (legacy/non-dual-stack)
+        CHK_STATUS(getFipsEndpointForRegion(pRegion, FALSE, pEndpointBuffer, bufferSize));
+        DLOGI("Using FIPS KVS endpoint for region %s.", pRegion);
+    } else if (isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
+        // Case 3: Only dual-stack enabled - use dual-stack endpoint
+        DLOGI("Using dual-stack KVS endpoints.");
+        if (STRSTR(pRegion, AWS_CN_REGION_PREFIX)) {
+            SNPRINTF(pEndpointBuffer, bufferSize, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
+                     pRegion, CONTROL_PLANE_URI_POSTFIX_CN_DUAL_STACK);
+        } else {
+            SNPRINTF(pEndpointBuffer, bufferSize, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
+                     pRegion, CONTROL_PLANE_URI_POSTFIX_DUAL_STACK);
+        }
+    } else {
+        // Case 4: Neither enabled - use standard/legacy endpoint
+        DLOGI("Using legacy KVS endpoints.");
+        if (STRSTR(pRegion, AWS_CN_REGION_PREFIX)) {
+            SNPRINTF(pEndpointBuffer, bufferSize, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
+                     pRegion, CONTROL_PLANE_URI_POSTFIX_CN);
+        } else {
+            SNPRINTF(pEndpointBuffer, bufferSize, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
+                     pRegion, CONTROL_PLANE_URI_POSTFIX);
+        }
+    }
+
+CleanUp:
+    return retStatus;
 }
 
 #define ARN_DELIMETER_CHAR                  ':'
@@ -223,38 +268,8 @@ STATUS createValidateChannelInfo(PChannelInfo pOrigChannelInfo, PChannelInfo* pp
 
     if (!IS_NULL_OR_EMPTY_STRING(pOrigChannelInfo->pControlPlaneUrl)) {
         STRCPY(pCurPtr, pOrigChannelInfo->pControlPlaneUrl);
-    } else if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR) && isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
-        // Case 1: BOTH FIPS and dual-stack enabled - use FIPS dual-stack endpoint
-        PCHAR pFipsEndpoint = getFipsEndpointForRegion(pChannelInfo->pRegion, TRUE);
-        DLOGI("Using FIPS dual-stack KVS endpoint for region %s.", pChannelInfo->pRegion);
-        STRNCPY(pCurPtr, pFipsEndpoint, MAX_CONTROL_PLANE_URI_CHAR_LEN - 1);
-        pCurPtr[MAX_CONTROL_PLANE_URI_CHAR_LEN - 1] = '\0';
-    } else if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR)) {
-        // Case 2: Only FIPS enabled - use FIPS endpoint (legacy/non-dual-stack)
-        PCHAR pFipsEndpoint = getFipsEndpointForRegion(pChannelInfo->pRegion, FALSE);
-        DLOGI("Using FIPS KVS endpoint for region %s.", pChannelInfo->pRegion);
-        STRNCPY(pCurPtr, pFipsEndpoint, MAX_CONTROL_PLANE_URI_CHAR_LEN - 1);
-        pCurPtr[MAX_CONTROL_PLANE_URI_CHAR_LEN - 1] = '\0';
-    } else if (isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
-        // Case 3: Only dual-stack enabled - use dual-stack endpoint
-        DLOGI("Using dual-stack KVS endpoints.");
-        if (STRSTR(pChannelInfo->pRegion, AWS_CN_REGION_PREFIX)) {
-            SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
-                     pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_CN_DUAL_STACK);
-        } else {
-            SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
-                     pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_DUAL_STACK);
-        }
     } else {
-        // Case 4: Neither enabled - use standard/legacy endpoint
-        DLOGI("Using legacy KVS endpoints.");
-        if (STRSTR(pChannelInfo->pRegion, AWS_CN_REGION_PREFIX)) {
-            SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
-                     pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX_CN);
-        } else {
-            SNPRINTF(pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN, "%s%s.%s%s", CONTROL_PLANE_URI_PREFIX, KINESIS_VIDEO_SERVICE_NAME,
-                     pChannelInfo->pRegion, CONTROL_PLANE_URI_POSTFIX);
-        }
+        CHK_STATUS(constructControlPlaneEndpoint(pChannelInfo->pRegion, pCurPtr, MAX_CONTROL_PLANE_URI_CHAR_LEN));
     }
 
     pChannelInfo->pControlPlaneUrl = pCurPtr;
@@ -512,4 +527,68 @@ STATUS validateKvsSignalingChannelArnAndExtractChannelName(PChannelInfo pChannel
     }
 
     return STATUS_SIGNALING_INVALID_CHANNEL_ARN;
+}
+
+/**
+ * Constructs the STUN server URL based on region and environment settings.
+ *
+ * @param pRegion - The AWS region string
+ * @param pStunUrlBuffer - Buffer to store the constructed STUN URL
+ * @param bufferSize - Size of the buffer
+ *
+ * @return - STATUS_SUCCESS on success, error status otherwise
+ */
+STATUS getStunUrl(PCHAR pRegion, PCHAR pStunUrlBuffer, UINT32 bufferSize)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PCHAR pUrlPostfix = NULL;
+    PCHAR pScheme = NULL;
+    PCHAR pServiceName = NULL;
+
+    CHK(pRegion != NULL && pStunUrlBuffer != NULL, STATUS_NULL_ARG);
+    CHK(bufferSize > 0, STATUS_INVALID_ARG);
+
+    if (isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR)) {
+        // FIPS STUN requires "stuns:" scheme (TLS)
+        pScheme = "stuns";
+        pServiceName = "kinesisvideo-fips";
+
+        if (isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
+            // FIPS + dual-stack
+            pUrlPostfix = KINESIS_VIDEO_DUALSTACK_STUN_URL_POSTFIX;
+            DLOGI("Using FIPS dual-stack STUN endpoint for region %s.", pRegion);
+        } else {
+            // FIPS only (legacy)
+            pUrlPostfix = KINESIS_VIDEO_STUN_URL_POSTFIX;
+            DLOGI("Using FIPS STUN endpoint for region %s.", pRegion);
+        }
+    } else {
+        // Standard STUN uses "stun:" scheme
+        pScheme = "stun";
+        pServiceName = "kinesisvideo";
+
+        if (isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR)) {
+            // Dual-stack only
+            DLOGD("Using dual-stack STUN endpoint.");
+            if (STRSTR(pRegion, AWS_CN_REGION_PREFIX)) {
+                pUrlPostfix = KINESIS_VIDEO_DUALSTACK_STUN_URL_POSTFIX_CN;
+            } else {
+                pUrlPostfix = KINESIS_VIDEO_DUALSTACK_STUN_URL_POSTFIX;
+            }
+        } else {
+            // Standard/legacy
+            DLOGD("Using legacy STUN endpoint.");
+            if (STRSTR(pRegion, AWS_CN_REGION_PREFIX)) {
+                pUrlPostfix = KINESIS_VIDEO_STUN_URL_POSTFIX_CN;
+            } else {
+                pUrlPostfix = KINESIS_VIDEO_STUN_URL_POSTFIX;
+            }
+        }
+    }
+
+    // Construct the STUN URL: <scheme>:stun.<service>.<region>.<postfix>:443
+    SNPRINTF(pStunUrlBuffer, bufferSize, "%s:stun.%s.%s.%s:443", pScheme, pServiceName, pRegion, pUrlPostfix);
+
+CleanUp:
+    return retStatus;
 }

--- a/src/source/Signaling/ChannelInfo.h
+++ b/src/source/Signaling/ChannelInfo.h
@@ -37,19 +37,51 @@ extern "C" {
 #define SIGNALING_USER_AGENT_POSTFIX_VERSION (PCHAR) "UNKNOWN"
 #endif
 
-// FIPS endpoint region prefixes
-#define AWS_ISO_REGION_PREFIX     "us-iso-"
-#define AWS_ISOB_REGION_PREFIX    "us-isob-"
-#define AWS_GOV_REGION_PREFIX     "us-gov-"
-
-// Number of FIPS endpoint mappings
-#define FIPS_ENDPOINT_MAPPING_COUNT 5
-
 // Structure to hold FIPS endpoint mapping
 typedef struct {
     PCHAR pRegion;
     PCHAR pEndpoint;
 } FipsEndpointMapping;
+
+// Number of FIPS endpoint mappings
+#define FIPS_ENDPOINT_MAPPING_COUNT 5
+
+// FIPS endpoint mappings - region to endpoint URL (legacy/non-dual-stack)
+// These endpoints are used when only USE_FIPS_ENDPOINT_ENV_VAR is enabled
+static const FipsEndpointMapping FIPS_ENDPOINT_MAPPINGS[FIPS_ENDPOINT_MAPPING_COUNT] = {
+    {"us-iso-east-1", "https://kinesisvideo-fips.us-iso-east-1.c2s.ic.gov"},
+    {"us-iso-west-1", "https://kinesisvideo-fips.us-iso-west-1.c2s.ic.gov"},
+    {"us-isob-east-1", "https://kinesisvideo-fips.us-isob-east-1.sc2s.sgov.gov"},
+    {"us-gov-west-1", "https://kinesisvideo-fips.us-gov-west-1.amazonaws.com"},
+    {"us-gov-east-1", "https://kinesisvideo-fips.us-gov-east-1.amazonaws.com"},
+};
+
+// FIPS dual-stack endpoint mappings - region to endpoint URL
+// These endpoints are used when BOTH USE_FIPS_ENDPOINT_ENV_VAR and USE_DUAL_STACK_ENDPOINTS_ENV_VAR are enabled
+static const FipsEndpointMapping FIPS_DUAL_STACK_ENDPOINT_MAPPINGS[FIPS_ENDPOINT_MAPPING_COUNT] = {
+    {"us-iso-east-1", "https://kinesisvideo-fips.us-iso-east-1.api.aws.ic.gov"},
+    {"us-iso-west-1", "https://kinesisvideo-fips.us-iso-west-1.api.aws.ic.gov"},
+    {"us-isob-east-1", "https://kinesisvideo-fips.us-isob-east-1.api.aws.scloud"},
+    {"us-gov-west-1", "https://kinesisvideo-fips.us-gov-west-1.api.aws"},
+    {"us-gov-east-1", "https://kinesisvideo-fips.us-gov-east-1.api.aws"},
+};
+
+/**
+ * Constructs the control plane endpoint URL based on region and environment settings.
+ * 
+ * Priority:
+ * 1. FIPS + dual-stack enabled -> FIPS dual-stack endpoint
+ * 2. FIPS only enabled -> FIPS legacy endpoint
+ * 3. Dual-stack only enabled -> standard dual-stack endpoint
+ * 4. Neither enabled -> standard legacy endpoint
+ *
+ * @param - PCHAR - IN - The AWS region string
+ * @param - PCHAR - OUT - Buffer to store the constructed endpoint URL
+ * @param - UINT32 - IN - Size of the endpoint buffer
+ *
+ * @return - STATUS_SUCCESS on success, error status otherwise
+ */
+STATUS constructControlPlaneEndpoint(PCHAR, PCHAR, UINT32);
 
 /**
  * Takes in a pointer to a public version of ChannelInfo object.
@@ -128,6 +160,20 @@ PCHAR getStringFromChannelRoleType(SIGNALING_CHANNEL_ROLE_TYPE);
  *@return - success if arn was valid otherwise failure
  */
 STATUS validateKvsSignalingChannelArnAndExtractChannelName(PChannelInfo, PUINT16, PUINT16);
+
+/**
+ * Constructs the STUN server URL based on region and environment settings.
+ * Handles standard, dual-stack, China, and FIPS endpoints.
+ *
+ * Note: FIPS STUN requires "stuns:" scheme (TLS), not "stun:"
+ *
+ * @param - PCHAR - IN - The AWS region string
+ * @param - PCHAR - OUT - Buffer to store the constructed STUN URL
+ * @param - UINT32 - IN - Size of the buffer
+ *
+ * @return - STATUS_SUCCESS on success, error status otherwise
+ */
+STATUS getStunUrl(PCHAR, PCHAR, UINT32);
 
 #ifdef __cplusplus
 }

--- a/src/source/Signaling/ChannelInfo.h
+++ b/src/source/Signaling/ChannelInfo.h
@@ -37,6 +37,20 @@ extern "C" {
 #define SIGNALING_USER_AGENT_POSTFIX_VERSION (PCHAR) "UNKNOWN"
 #endif
 
+// FIPS endpoint region prefixes
+#define AWS_ISO_REGION_PREFIX     "us-iso-"
+#define AWS_ISOB_REGION_PREFIX    "us-isob-"
+#define AWS_GOV_REGION_PREFIX     "us-gov-"
+
+// Number of FIPS endpoint mappings
+#define FIPS_ENDPOINT_MAPPING_COUNT 5
+
+// Structure to hold FIPS endpoint mapping
+typedef struct {
+    PCHAR pRegion;
+    PCHAR pEndpoint;
+} FipsEndpointMapping;
+
 /**
  * Takes in a pointer to a public version of ChannelInfo object.
  * Validates and creates an internal object

--- a/src/source/Signaling/FileCache.c
+++ b/src/source/Signaling/FileCache.c
@@ -42,7 +42,7 @@ STATUS deserializeSignalingCacheEntries(PCHAR cachedFileContent, UINT64 fileSize
            remainingSize > MAX_SIGNALING_CACHE_ENTRY_TIMESTAMP_STR_LEN) {
         nextLine = STRCHR(pCurrent, '\n');
         while ((nextToken = STRCHR(pCurrent, ',')) != NULL && nextToken < nextLine) {
-            switch (tokenCount % 12) {
+            switch (tokenCount % 13) {
                 case 0:
                     STRNCPY(pSignalingFileCacheEntryList[entryCount].channelName, pCurrent, nextToken - pCurrent);
                     break;
@@ -66,25 +66,28 @@ STATUS deserializeSignalingCacheEntries(PCHAR cachedFileContent, UINT64 fileSize
                     STRNCPY(pSignalingFileCacheEntryList[entryCount].useDualStackEndpoints, pCurrent, nextToken - pCurrent);
                     break;
                 case 5:
-                    STRNCPY(pSignalingFileCacheEntryList[entryCount].channelArn, pCurrent, nextToken - pCurrent);
+                    STRNCPY(pSignalingFileCacheEntryList[entryCount].useFipsEndpoint, pCurrent, nextToken - pCurrent);
                     break;
                 case 6:
-                    STRNCPY(pSignalingFileCacheEntryList[entryCount].httpsEndpoint, pCurrent, nextToken - pCurrent);
+                    STRNCPY(pSignalingFileCacheEntryList[entryCount].channelArn, pCurrent, nextToken - pCurrent);
                     break;
                 case 7:
-                    STRNCPY(pSignalingFileCacheEntryList[entryCount].wssEndpoint, pCurrent, nextToken - pCurrent);
+                    STRNCPY(pSignalingFileCacheEntryList[entryCount].httpsEndpoint, pCurrent, nextToken - pCurrent);
                     break;
                 case 8:
-                    STRNCPY(pSignalingFileCacheEntryList[entryCount].storageEnabled, pCurrent, nextToken - pCurrent);
+                    STRNCPY(pSignalingFileCacheEntryList[entryCount].wssEndpoint, pCurrent, nextToken - pCurrent);
                     break;
                 case 9:
-                    STRNCPY(pSignalingFileCacheEntryList[entryCount].storageStreamArn, pCurrent, nextToken - pCurrent);
+                    STRNCPY(pSignalingFileCacheEntryList[entryCount].storageEnabled, pCurrent, nextToken - pCurrent);
                     break;
                 case 10:
+                    STRNCPY(pSignalingFileCacheEntryList[entryCount].storageStreamArn, pCurrent, nextToken - pCurrent);
+                    break;
+                case 11:
                     STRNCPY(pSignalingFileCacheEntryList[entryCount].webrtcEndpoint, pCurrent, nextToken - pCurrent);
                     break;
 
-                    /* case 11 is for creationTsEpochSeconds which is handled after this loop. */
+                    /* case 12 is for creationTsEpochSeconds which is handled after this loop. */
 
                 default:
                     break;
@@ -135,7 +138,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, PCHAR controlPlaneUrl, BOOL useDualStackEndpoints,
+STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, PCHAR controlPlaneUrl, BOOL useDualStackEndpoints, BOOL useFipsEndpoint,
                                   SIGNALING_CHANNEL_ROLE_TYPE role, PSignalingFileCacheEntry pSignalingFileCacheEntry, PBOOL pCacheFound,
                                   PCHAR cacheFilePath)
 {
@@ -147,6 +150,7 @@ STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, PCHAR control
     UINT32 entryCount = ARRAY_SIZE(entries), i;
     BOOL cacheFound = FALSE;
     PCHAR useDualStackStr = useDualStackEndpoints ? "1" : "0";
+    PCHAR useFipsStr = useFipsEndpoint ? "1" : "0";
 
     CHK(channelName != NULL && region != NULL && controlPlaneUrl != NULL && pSignalingFileCacheEntry != NULL && pCacheFound != NULL &&
             cacheFilePath != NULL,
@@ -170,7 +174,8 @@ STATUS signalingCacheLoadFromFile(PCHAR channelName, PCHAR region, PCHAR control
         for (i = 0; !cacheFound && i < entryCount; ++i) {
             /* Assume channel name and region has been validated */
             if (STRCMP(entries[i].channelName, channelName) == 0 && STRCMP(entries[i].region, region) == 0 && entries[i].role == role &&
-                STRCMP(entries[i].controlPlaneUrl, controlPlaneUrl) == 0 && STRCMP(entries[i].useDualStackEndpoints, useDualStackStr) == 0) {
+                STRCMP(entries[i].controlPlaneUrl, controlPlaneUrl) == 0 && STRCMP(entries[i].useDualStackEndpoints, useDualStackStr) == 0 &&
+                STRCMP(entries[i].useFipsEndpoint, useFipsStr) == 0) {
                 cacheFound = TRUE;
                 MEMCPY(pSignalingFileCacheEntry, &entries[i], SIZEOF(entries[i]));
             }
@@ -231,6 +236,7 @@ STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry pSignalingFileCacheEntr
         if (STRCMP(entries[i].channelName, pSignalingFileCacheEntry->channelName) == 0 &&
             STRCMP(entries[i].controlPlaneUrl, pSignalingFileCacheEntry->controlPlaneUrl) == 0 &&
             STRCMP(entries[i].useDualStackEndpoints, pSignalingFileCacheEntry->useDualStackEndpoints) == 0 &&
+            STRCMP(entries[i].useFipsEndpoint, pSignalingFileCacheEntry->useFipsEndpoint) == 0 &&
             STRCMP(entries[i].region, pSignalingFileCacheEntry->region) == 0 && entries[i].role == pSignalingFileCacheEntry->role) {
             newEntry = FALSE;
             break;
@@ -251,12 +257,13 @@ STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry pSignalingFileCacheEntr
 
     for (i = 0; i < entryCount; ++i) {
         serializedCacheEntryLen = SNPRINTF(serializedCacheEntry, ARRAY_SIZE(serializedCacheEntry),
-                                           "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%.10" PRIu64 "\n", entries[i].channelName,
+                                           "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%.10" PRIu64 "\n", entries[i].channelName,
                                            entries[i].role == SIGNALING_CHANNEL_ROLE_TYPE_MASTER ? SIGNALING_FILE_CACHE_ROLE_TYPE_MASTER_STR
                                                                                                  : SIGNALING_FILE_CACHE_ROLE_TYPE_VIEWER_STR,
-                                           entries[i].region, entries[i].controlPlaneUrl, entries[i].useDualStackEndpoints, entries[i].channelArn,
-                                           entries[i].httpsEndpoint, entries[i].wssEndpoint, entries[i].storageEnabled, entries[i].storageStreamArn,
-                                           entries[i].webrtcEndpoint, entries[i].creationTsEpochSeconds);
+                                           entries[i].region, entries[i].controlPlaneUrl, entries[i].useDualStackEndpoints,
+                                           entries[i].useFipsEndpoint, entries[i].channelArn, entries[i].httpsEndpoint, entries[i].wssEndpoint,
+                                           entries[i].storageEnabled, entries[i].storageStreamArn, entries[i].webrtcEndpoint,
+                                           entries[i].creationTsEpochSeconds);
         CHK_STATUS(writeFile(cacheFilePath, FALSE, i == 0 ? FALSE : TRUE, (PBYTE) serializedCacheEntry, serializedCacheEntryLen));
     }
 

--- a/src/source/Signaling/FileCache.h
+++ b/src/source/Signaling/FileCache.h
@@ -31,6 +31,7 @@ typedef struct {
     CHAR region[MAX_REGION_NAME_LEN + 1];
     CHAR controlPlaneUrl[MAX_CONTROL_PLANE_URI_CHAR_LEN + 1];
     CHAR useDualStackEndpoints[2];
+    CHAR useFipsEndpoint[2];
     CHAR httpsEndpoint[MAX_SIGNALING_ENDPOINT_URI_LEN + 1];
     CHAR wssEndpoint[MAX_SIGNALING_ENDPOINT_URI_LEN + 1];
     CHAR storageStreamArn[MAX_ARN_LEN + 1];
@@ -38,7 +39,7 @@ typedef struct {
 } SignalingFileCacheEntry, *PSignalingFileCacheEntry;
 
 STATUS deserializeSignalingCacheEntries(PCHAR, UINT64, PSignalingFileCacheEntry, PUINT32, PCHAR);
-STATUS signalingCacheLoadFromFile(PCHAR, PCHAR, PCHAR, BOOL, SIGNALING_CHANNEL_ROLE_TYPE, PSignalingFileCacheEntry, PBOOL, PCHAR);
+STATUS signalingCacheLoadFromFile(PCHAR, PCHAR, PCHAR, BOOL, BOOL, SIGNALING_CHANNEL_ROLE_TYPE, PSignalingFileCacheEntry, PBOOL, PCHAR);
 STATUS signalingCacheSaveToFile(PSignalingFileCacheEntry, PCHAR);
 
 #ifdef __cplusplus

--- a/src/source/Signaling/Signaling.c
+++ b/src/source/Signaling/Signaling.c
@@ -98,9 +98,10 @@ STATUS createSignalingSync(PSignalingClientInfoInternal pClientInfo, PChannelInf
 
     if (pSignalingClient->pChannelInfo->cachingPolicy == SIGNALING_API_CALL_CACHE_TYPE_FILE) {
         useDualStackEndpoints = isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR);
+        BOOL useFipsEndpoint = isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR);
 
         if (STATUS_FAILED(signalingCacheLoadFromFile(pSignalingClient->pChannelInfo->pChannelName, pSignalingClient->pChannelInfo->pRegion,
-                                                     pSignalingClient->pChannelInfo->pControlPlaneUrl, useDualStackEndpoints,
+                                                     pSignalingClient->pChannelInfo->pControlPlaneUrl, useDualStackEndpoints, useFipsEndpoint,
                                                      pSignalingClient->pChannelInfo->channelRoleType, pFileCacheEntry, &cacheFound,
                                                      pSignalingClient->clientInfo.cacheFilePath))) {
             DLOGW("Failed to load signaling cache from file");
@@ -1126,6 +1127,7 @@ STATUS getChannelEndpoint(PSignalingClient pSignalingClient, UINT64 time)
     BOOL apiCall = TRUE;
     SignalingFileCacheEntry signalingFileCacheEntry;
     BOOL useDualStackEndpoints = FALSE;
+    BOOL useFipsEndpoint = FALSE;
 
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
 
@@ -1166,6 +1168,7 @@ STATUS getChannelEndpoint(PSignalingClient pSignalingClient, UINT64 time)
 
                     if (pSignalingClient->pChannelInfo->cachingPolicy == SIGNALING_API_CALL_CACHE_TYPE_FILE) {
                         useDualStackEndpoints = isEnvVarEnabled(USE_DUAL_STACK_ENDPOINTS_ENV_VAR);
+                        useFipsEndpoint = isEnvVarEnabled(USE_FIPS_ENDPOINT_ENV_VAR);
 
                         signalingFileCacheEntry.creationTsEpochSeconds = time / HUNDREDS_OF_NANOS_IN_A_SECOND;
                         signalingFileCacheEntry.role = pSignalingClient->pChannelInfo->channelRoleType;
@@ -1178,6 +1181,7 @@ STATUS getChannelEndpoint(PSignalingClient pSignalingClient, UINT64 time)
                         STRCPY(signalingFileCacheEntry.controlPlaneUrl,
                                pSignalingClient->pChannelInfo->pControlPlaneUrl != NULL ? pSignalingClient->pChannelInfo->pControlPlaneUrl : "");
                         STRCPY(signalingFileCacheEntry.useDualStackEndpoints, useDualStackEndpoints ? "1" : "0");
+                        STRCPY(signalingFileCacheEntry.useFipsEndpoint, useFipsEndpoint ? "1" : "0");
                         STRCPY(signalingFileCacheEntry.channelArn, pSignalingClient->channelDescription.channelArn);
                         STRCPY(signalingFileCacheEntry.storageEnabled, pSignalingClient->mediaStorageConfig.storageStatus ? "1" : "0");
                         STRCPY(signalingFileCacheEntry.storageStreamArn, pSignalingClient->mediaStorageConfig.storageStreamArn);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added support for FIPS-compliant endpoints via the `USE_KVS_FIPS_ENDPOINT` environment variable
- Added FIPS endpoint mappings for AWS GovCloud and isolated regions (C2S/SC2S)
- Added early validation to fail fast when FIPS is enabled with an unsupported region


*Why was it changed?*
- To enable customers in regulated environments (GovCloud, C2S, SC2S) to use FIPS-compliant endpoints without needing to manually configure endpoint URLs
- To provide a simple, user-friendly way to enable FIPS compliance by just setting an environment variable
- To ensure clear error messaging when FIPS is requested for unsupported regions, preventing confusing retry loops

*How was it changed?*
- Added FIPS endpoint mapping tables in `ChannelInfo.c` for supported regions
- Added region validation in `samples/common/Common.c` to exit early for unsupported FIPS regions
- Supported regions: `us-iso-east-1`, `us-iso-west-1`, `us-isob-east-1`, `us-gov-west-1`, `us-gov-east-1`

*What testing was done for the changes?*
- Tested with WireShark to make sure hitting the correct endpoint when specified GovCloud supported region
<img width="898" height="330" alt="473 Client Mello (SNi-kinesisvideo-fies us-gov-east-1 api avs" src="https://github.com/user-attachments/assets/328e4986-e196-45ad-b6fb-eac1aa65f40d" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
