### PR TITLE
Add more precise timing logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(INSTRUMENTED_ALLOCATORS "Enable memory instrumentation" OFF)
 option(ENABLE_AWS_SDK_IN_TESTS "Enable support for compiling AWS SDKs for tests" ON)
 option(ENABLE_STATS_CALCULATION_CONTROL "Enable support for runtime control of ice agent stat calculations." OFF)
 option(BUILD_OLD_MBEDTLS_VERSION "Use MbedTLS version 2.28.8." OFF)
+option(INCREASE_PRECISION_TIMING_LOGS "PROFILE-level timing logs have 2 decimals of milliseconds (otherwise truncated to whole millisecond)" ON)
 
 # Developer Flags
 option(BUILD_TEST "Build the testing tree." OFF)
@@ -145,6 +146,10 @@ endif()
 
 if (ENABLE_STATS_CALCULATION_CONTROL)
   add_definitions(-DENABLE_STATS_CALCULATION_CONTROL)
+endif()
+
+if (INCREASE_PRECISION_TIMING_LOGS)
+  add_definitions(-DINCREASE_PRECISION_TIMING_LOGS)
 endif()
 
 if(USE_OPENSSL)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ You can pass the following options to `cmake ..`:
 * `-DPKG_CONFIG_EXECUTABLE` -- Set pkg config path. This might be required to find gstreamer's pkg config specifically on Windows.
 * `-DENABLE_KVS_THREADPOOL` -- Enable the KVS threadpool which is off by default.
 * `-DENABLE_STATS_CALCULATION_CONTROL` -- Enable the runtime control of ICE agent stats calculations.
+* `-DINCREASE_PRECISION_TIMING_LOGS` -- Default ON. ON=Use 2 decimals in PROFILE-logs timing. OFF=Truncates down to whole ms.
 
 These options get propagated to [PIC](https://github.com/awslabs/amazon-kinesis-video-streams-pic):
 * `-DKVS_STACK_SIZE` -- Default stack size for threads created using THREAD_CREATE(), in bytes.

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -29,6 +29,11 @@ extern "C" {
 
 #ifdef INCREASE_PRECISION_TIMING_LOGS
 
+/**
+ * @brief Executes f and logs the elapsed time. Requires external startTimeInMacro variable, which will be set to the startTime in 100ns units.
+ * @param[in] f   Function call or expression to profile.
+ * @param[in] msg Log message string.
+ */
 #define PROFILE_CALL(f, msg)                                                                                                                         \
     do {                                                                                                                                             \
         startTimeInMacro = GETTIME();                                                                                                                \
@@ -38,6 +43,12 @@ extern "C" {
               (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
+/**
+ * @brief Executes f, stores elapsed time in t, and logs it. Requires external startTimeInMacro variable, which will be set to the startTime in 100ns units.
+ * @param[in]  f   Function call or expression to profile.
+ * @param[out] t   Output elapsed time in milliseconds.
+ * @param[in]  msg Log message string.
+ */
 #define PROFILE_CALL_WITH_T_OBJ(f, t, msg)                                                                                                           \
     do {                                                                                                                                             \
         startTimeInMacro = GETTIME();                                                                                                                \
@@ -48,6 +59,11 @@ extern "C" {
               (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
+/**
+ * @brief Logs elapsed time since a given start time. Does not store the result.
+ * @param[in] t   Input start time in 100ns units. Not modified.
+ * @param[in] msg Log message string.
+ */
 #define PROFILE_WITH_START_TIME(t, msg)                                                                                                              \
     do {                                                                                                                                             \
         UINT64 __dt = GETTIME() - (t);                                                                                                               \
@@ -55,6 +71,14 @@ extern "C" {
               (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
+/**
+ * @brief Executes f, stores start/end/delta times, and logs elapsed time.
+ * @param[in]  f   Function call or expression to profile.
+ * @param[out] s   Output start time in milliseconds.
+ * @param[out] e   Output end time in milliseconds.
+ * @param[out] d   Output elapsed time in milliseconds (e - s).
+ * @param[in]  msg Log message string.
+ */
 #define PROFILE_CALL_WITH_START_END_T_OBJ(f, s, e, d, msg)                                                                                           \
     do {                                                                                                                                             \
         UINT64 __s = GETTIME();                                                                                                                      \
@@ -68,6 +92,13 @@ extern "C" {
               (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
+/**
+ * @brief Profiles elapsed time from a given start time, storing start (converted to ms), end, and delta.
+ * @param[in,out] t1 Input start time in 100ns units. Modified: converted to milliseconds.
+ * @param[out]    t2 Output end time in milliseconds, calculated via GETTIME().
+ * @param[out]    d  Output elapsed time in milliseconds (t2 - t1).
+ * @param[in]     msg Log message string.
+ */
 #define PROFILE_WITH_START_END_TIME_OBJ(t1, t2, d, msg)                                                                                              \
     do {                                                                                                                                             \
         UINT64 __dt = GETTIME() - (t1);                                                                                                              \
@@ -78,6 +109,12 @@ extern "C" {
               (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
+/**
+ * @brief Profiles elapsed time from a given start time, storing the delta in t2.
+ * @param[in]  t1 Input start time in 100ns units. Not modified.
+ * @param[out] t2 Output elapsed time in milliseconds.
+ * @param[in]  msg Log message string.
+ */
 #define PROFILE_WITH_START_TIME_OBJ(t1, t2, msg)                                                                                                     \
     do {                                                                                                                                             \
         UINT64 __dt = GETTIME() - (t1);                                                                                                              \
@@ -88,6 +125,11 @@ extern "C" {
 
 #else // INCREASE_PRECISION_TIMING_LOGS
 
+/**
+ * @brief Executes f and logs the elapsed time. Requires external startTimeInMacro variable, which will be set to the startTime in 100ns units.
+ * @param[in] f   Function call or expression to profile.
+ * @param[in] msg Log message string.
+ */
 #define PROFILE_CALL(f, msg)                                                                                                                         \
     do {                                                                                                                                             \
         startTimeInMacro = GETTIME();                                                                                                                \
@@ -95,6 +137,12 @@ extern "C" {
         DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (GETTIME() - startTimeInMacro) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                        \
     } while (FALSE)
 
+/**
+ * @brief Executes f, stores elapsed time in t, and logs it. Requires external startTimeInMacro variable, which will be set to the startTime in 100ns units.
+ * @param[in]  f   Function call or expression to profile.
+ * @param[out] t   Output elapsed time in milliseconds.
+ * @param[in]  msg Log message string.
+ */
 #define PROFILE_CALL_WITH_T_OBJ(f, t, msg)                                                                                                           \
     do {                                                                                                                                             \
         startTimeInMacro = GETTIME();                                                                                                                \
@@ -103,11 +151,24 @@ extern "C" {
         DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (t));                                                                                        \
     } while (FALSE)
 
+/**
+ * @brief Logs elapsed time since a given start time. Does not store the result.
+ * @param[in] t   Input start time in 100ns units. Not modified.
+ * @param[in] msg Log message string.
+ */
 #define PROFILE_WITH_START_TIME(t, msg)                                                                                                              \
     do {                                                                                                                                             \
         DLOGP("[%s] Time taken: %" PRIu64 " ms", msg, (GETTIME() - (t)) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                       \
     } while (FALSE)
 
+/**
+ * @brief Executes f, stores start/end/delta times, and logs elapsed time.
+ * @param[in]  f   Function call or expression to profile.
+ * @param[out] s   Output start time in milliseconds.
+ * @param[out] e   Output end time in milliseconds.
+ * @param[out] d   Output elapsed time in milliseconds (e - s).
+ * @param[in]  msg Log message string.
+ */
 #define PROFILE_CALL_WITH_START_END_T_OBJ(f, s, e, d, msg)                                                                                           \
     do {                                                                                                                                             \
         s = GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                          \
@@ -117,6 +178,13 @@ extern "C" {
         DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (d));                                                                                        \
     } while (FALSE)
 
+/**
+ * @brief Profiles elapsed time from a given start time, storing start (converted to ms), end, and delta.
+ * @param[in,out] t1 Input start time in 100ns units. Modified: converted to milliseconds.
+ * @param[out]    t2 Output end time in milliseconds, calculated via GETTIME().
+ * @param[out]    d  Output elapsed time in milliseconds (t2 - t1).
+ * @param[in]     msg Log message string.
+ */
 #define PROFILE_WITH_START_END_TIME_OBJ(t1, t2, d, msg)                                                                                              \
     do {                                                                                                                                             \
         t1 = (t1 / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                                                                              \
@@ -125,6 +193,12 @@ extern "C" {
         DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (d));                                                                                        \
     } while (FALSE)
 
+/**
+ * @brief Profiles elapsed time from a given start time, storing the delta in t2.
+ * @param[in]  t1 Input start time in 100ns units. Not modified.
+ * @param[out] t2 Output elapsed time in milliseconds.
+ * @param[in]  msg Log message string.
+ */
 #define PROFILE_WITH_START_TIME_OBJ(t1, t2, msg)                                                                                                     \
     do {                                                                                                                                             \
         t2 = (GETTIME() - (t1)) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                \

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -26,14 +26,16 @@ extern "C" {
 #endif
 
 /* TODO: Potentially move these call to PIC instead. Moving to PIC in the future would not cause any backward compatibility issues */
+
+#ifdef INCREASE_PRECISION_TIMING_LOGS
+
 #define PROFILE_CALL(f, msg)                                                                                                                         \
     do {                                                                                                                                             \
         startTimeInMacro = GETTIME();                                                                                                                \
         f;                                                                                                                                           \
         UINT64 __dt = GETTIME() - startTimeInMacro;                                                                                                  \
-        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
-              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
-              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg), __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                     \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
 #define PROFILE_CALL_WITH_T_OBJ(f, t, msg)                                                                                                           \
@@ -42,17 +44,15 @@ extern "C" {
         f;                                                                                                                                           \
         UINT64 __dt = GETTIME() - startTimeInMacro;                                                                                                  \
         t = __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                               \
-        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
-              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
-              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg), __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                     \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
 #define PROFILE_WITH_START_TIME(t, msg)                                                                                                              \
     do {                                                                                                                                             \
         UINT64 __dt = GETTIME() - (t);                                                                                                               \
-        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", msg,                                                                                 \
-              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
-              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", msg, __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                       \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
 #define PROFILE_CALL_WITH_START_END_T_OBJ(f, s, e, d, msg)                                                                                           \
@@ -64,9 +64,8 @@ extern "C" {
         s = __s / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                                \
         e = __e / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                                \
         d = ((e) - (s));                                                                                                                             \
-        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
-              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
-              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg), __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                     \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
 #define PROFILE_WITH_START_END_TIME_OBJ(t1, t2, d, msg)                                                                                              \
@@ -75,23 +74,68 @@ extern "C" {
         t1 = (t1 / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                                                                              \
         t2 = (GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                                                                       \
         d = ((t2) - (t1));                                                                                                                           \
-        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
-              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
-              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg), __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                     \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
 
 #define PROFILE_WITH_START_TIME_OBJ(t1, t2, msg)                                                                                                     \
     do {                                                                                                                                             \
         UINT64 __dt = GETTIME() - (t1);                                                                                                              \
         t2 = __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                              \
-        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
-              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
-              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg), __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                     \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                             \
     } while (FALSE)
+
+#else // INCREASE_PRECISION_TIMING_LOGS
+
+#define PROFILE_CALL(f, msg)                                                                                                                         \
+    do {                                                                                                                                             \
+        startTimeInMacro = GETTIME();                                                                                                                \
+        f;                                                                                                                                           \
+        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (GETTIME() - startTimeInMacro) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                        \
+    } while (FALSE)
+
+#define PROFILE_CALL_WITH_T_OBJ(f, t, msg)                                                                                                           \
+    do {                                                                                                                                             \
+        startTimeInMacro = GETTIME();                                                                                                                \
+        f;                                                                                                                                           \
+        t = (GETTIME() - startTimeInMacro) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                     \
+        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (t));                                                                                        \
+    } while (FALSE)
+
+#define PROFILE_WITH_START_TIME(t, msg)                                                                                                              \
+    do {                                                                                                                                             \
+        DLOGP("[%s] Time taken: %" PRIu64 " ms", msg, (GETTIME() - (t)) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                       \
+    } while (FALSE)
+
+#define PROFILE_CALL_WITH_START_END_T_OBJ(f, s, e, d, msg)                                                                                           \
+    do {                                                                                                                                             \
+        s = GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                          \
+        f;                                                                                                                                           \
+        e = GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                          \
+        d = ((e) - (s));                                                                                                                             \
+        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (d));                                                                                        \
+    } while (FALSE)
+
+#define PROFILE_WITH_START_END_TIME_OBJ(t1, t2, d, msg)                                                                                              \
+    do {                                                                                                                                             \
+        t1 = (t1 / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                                                                              \
+        t2 = (GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                                                                       \
+        d = ((t2) - (t1));                                                                                                                           \
+        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (d));                                                                                        \
+    } while (FALSE)
+
+#define PROFILE_WITH_START_TIME_OBJ(t1, t2, msg)                                                                                                     \
+    do {                                                                                                                                             \
+        t2 = (GETTIME() - (t1)) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                \
+        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), t2);                                                                                         \
+    } while (FALSE)
+
+#endif // INCREASE_PRECISION_TIMING_LOGS
 
 /*! \addtogroup StatusCodes
  * WEBRTC related status codes. Each value is an positive integer formed by adding
- * a base integer inticating the category to an index. Users may run scripts/parse_status.py
+ * a base integer indicating the category to an index. Users may run scripts/parse_status.py
  * to print a list of all status codes and their hex value.
  *  @{
  */

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -44,7 +44,8 @@ extern "C" {
     } while (FALSE)
 
 /**
- * @brief Executes f, stores elapsed time in t, and logs it. Requires external startTimeInMacro variable, which will be set to the startTime in 100ns units.
+ * @brief Executes f, stores elapsed time in t, and logs it. Requires external startTimeInMacro variable, which will be set to the startTime in 100ns
+ * units.
  * @param[in]  f   Function call or expression to profile.
  * @param[out] t   Output elapsed time in milliseconds.
  * @param[in]  msg Log message string.
@@ -138,7 +139,8 @@ extern "C" {
     } while (FALSE)
 
 /**
- * @brief Executes f, stores elapsed time in t, and logs it. Requires external startTimeInMacro variable, which will be set to the startTime in 100ns units.
+ * @brief Executes f, stores elapsed time in t, and logs it. Requires external startTimeInMacro variable, which will be set to the startTime in 100ns
+ * units.
  * @param[in]  f   Function call or expression to profile.
  * @param[out] t   Output elapsed time in milliseconds.
  * @param[in]  msg Log message string.

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -30,43 +30,63 @@ extern "C" {
     do {                                                                                                                                             \
         startTimeInMacro = GETTIME();                                                                                                                \
         f;                                                                                                                                           \
-        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (GETTIME() - startTimeInMacro) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                        \
+        UINT64 __dt = GETTIME() - startTimeInMacro;                                                                                                  \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
+              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
     } while (FALSE)
 
 #define PROFILE_CALL_WITH_T_OBJ(f, t, msg)                                                                                                           \
     do {                                                                                                                                             \
         startTimeInMacro = GETTIME();                                                                                                                \
         f;                                                                                                                                           \
-        t = (GETTIME() - startTimeInMacro) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                     \
-        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (t));                                                                                        \
+        UINT64 __dt = GETTIME() - startTimeInMacro;                                                                                                  \
+        t = __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                               \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
+              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
     } while (FALSE)
 
 #define PROFILE_WITH_START_TIME(t, msg)                                                                                                              \
     do {                                                                                                                                             \
-        DLOGP("[%s] Time taken: %" PRIu64 " ms", msg, (GETTIME() - (t)) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                       \
+        UINT64 __dt = GETTIME() - (t);                                                                                                               \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", msg,                                                                                 \
+              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
     } while (FALSE)
 
 #define PROFILE_CALL_WITH_START_END_T_OBJ(f, s, e, d, msg)                                                                                           \
     do {                                                                                                                                             \
-        s = GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                          \
+        UINT64 __s = GETTIME();                                                                                                                      \
         f;                                                                                                                                           \
-        e = GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                          \
+        UINT64 __e = GETTIME();                                                                                                                      \
+        UINT64 __dt = __e - __s;                                                                                                                     \
+        s = __s / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                                \
+        e = __e / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                                \
         d = ((e) - (s));                                                                                                                             \
-        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (d));                                                                                        \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
+              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
     } while (FALSE)
 
 #define PROFILE_WITH_START_END_TIME_OBJ(t1, t2, d, msg)                                                                                              \
     do {                                                                                                                                             \
+        UINT64 __dt = GETTIME() - (t1);                                                                                                              \
         t1 = (t1 / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                                                                              \
         t2 = (GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);                                                                                       \
         d = ((t2) - (t1));                                                                                                                           \
-        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), (d));                                                                                        \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
+              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
     } while (FALSE)
 
 #define PROFILE_WITH_START_TIME_OBJ(t1, t2, msg)                                                                                                     \
     do {                                                                                                                                             \
-        t2 = (GETTIME() - (t1)) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                \
-        DLOGP("[%s] Time taken: %" PRIu64 " ms", (msg), t2);                                                                                         \
+        UINT64 __dt = GETTIME() - (t1);                                                                                                              \
+        t2 = __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;                                                                                              \
+        DLOGP("[%s] Time taken: %" PRIu64 ".%02" PRIu64 " ms", (msg),                                                                               \
+              __dt / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,                                                                                             \
+              (__dt % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));                                              \
     } while (FALSE)
 
 /*! \addtogroup StatusCodes


### PR DESCRIPTION
Summary of the macros:

| Macro | Executes f | Stores/Outputs Start | Stores/Outputs End | Stores/Outputs Elapsed Time (Delta) |
|-----|-----|-----|-----|-----|
| PROFILE_CALL(f, msg) | ✅ | ✅ startTimeInMacro variable | x | x |
| PROFILE_CALL_WITH_T_OBJ(f, t, msg) | ✅ | ✅ startTimeInMacro variable | x | ✅ t (ms) |
| PROFILE_WITH_START_TIME(t, msg) | x | x | x | x |
| PROFILE_CALL_WITH_START_END_T_OBJ(f, s, e, d, msg) | ✅ | ✅ s (ms) | ✅ e (ms) | ✅ d (ms) |
| PROFILE_WITH_START_END_TIME_OBJ(t1, t2, d, msg) | x | ✅ t1 converted from 100ns to ms | ✅ t2 (ms) | ✅ d (ms) |
| PROFILE_WITH_START_TIME_OBJ(t1, t2, msg) | x | x | x | ✅ t2 (ms) |

Notes:
- All macros expect time inputs (t, t1, start times) in 100ns units (the native GETTIME() format).
- All stored outputs are in milliseconds.
- PROFILE_CALL and PROFILE_CALL_WITH_T_OBJ depend on an external startTimeInMacro variable being in scope.


-------

*Issue #, if available:*
- N/A

*What was changed?*
- Added a new CMake option `INCREASE_PRECISION_TIMING_LOGS` (default ON) that controls whether PROFILE-level timing log macros display milliseconds with 2 decimal places (e.g., `5.49 ms`) instead of truncated whole milliseconds (e.g., `5 ms`)
- Minor: fixed typo "inticating" --> "indicating" in a nearby comment

*Why was it changed?*
- Previously, it would only show `Time taken: 0 ms`,  making it impossible to distinguish between a fast operation and one that wasn't executed at all

*How was it changed?*
- Updated 6 `PROFILE_*` macros in `Include.h` use a format string with fractional milliseconds, computing the sub-millisecond part from the remainder of `HUNDREDS_OF_NANOS_IN_A_MILLISECOND`
- When disabled (`-DINCREASE_PRECISION_TIMING_LOGS=OFF`), the original whole-millisecond format is preserved, no behavior change for existing users

*What testing was done for the changes?*

<details><summary>Ran it locally to confirm the logging changes:</summary>

```c
2026-03-30 17:07:20.590 PROFILE createIceAgent(): [ICE server parsing] Time taken: 5.49 ms
2026-03-30 17:07:20.590 PROFILE createIceAgent(): [ICE server parsing] Time taken: 0.01 ms
2026-03-30 17:07:20.590 PROFILE createIceAgent(): [ICE server parsing] Time taken: 0.00 ms
2026-03-30 17:07:20.590 PROFILE createIceAgent(): [ICE server parsing] Time taken: 0.00 ms
2026-03-30 17:07:20.590 PROFILE createPeerConnection(): [Create ICE agent object] Time taken: 5.69 ms
2026-03-30 17:07:20.590 PROFILE createPeerConnection(): [Peer connection object creation time] Time taken: 9.75 ms
2026-03-30 17:07:20.591 PROFILE iceAgentStartGathering(): [Host candidate gathering from local interfaces] Time taken: 0.08 ms
2026-03-30 17:07:20.592 PROFILE iceAgentStartGathering(): [Host candidates setup time] Time taken: 0.19 ms
2026-03-30 17:07:20.592 PROFILE iceAgentStartGathering(): [Srflx candidates setup time] Time taken: 0.13 ms
2026-03-30 17:07:20.592 PROFILE iceAgentStartGathering(): [Relay candidates setup time] Time taken: 0.35 ms
2026-03-30 17:07:20.592 PROFILE sendSignalingMessage(): [Signaling offer received to answer sent time] 11 ms
```

</details>

<details><summary>With `cmake .. -DINCREASE_PRECISION_TIMING_LOGS=OFF`:</summary>

```c
2026-03-30 17:14:23.636 PROFILE createPeerConnection(): [Create ICE agent object] Time taken: 1 ms
2026-03-30 17:14:23.636 PROFILE createPeerConnection(): [Peer connection object creation time] Time taken: 2 ms
2026-03-30 17:14:23.637 PROFILE iceAgentStartGathering(): [Host candidate gathering from local interfaces] Time taken: 0 ms
2026-03-30 17:14:23.637 PROFILE iceAgentStartGathering(): [Host candidates setup time] Time taken: 0 ms
2026-03-30 17:14:23.637 PROFILE iceAgentStartGathering(): [Srflx candidates setup time] Time taken: 0 ms
2026-03-30 17:14:23.637 PROFILE iceAgentStartGathering(): [Relay candidates setup time] Time taken: 0 ms
2026-03-30 17:14:23.638 PROFILE sendSignalingMessage(): [Signaling offer received to answer sent time] 5 ms
2026-03-30 17:14:23.640 WARN    socketConnectionIsConnected(): socket connection check failed with errno Operation already in progress(37)
2026-03-30 17:14:23.657 PROFILE turnConnectionHandleStunError(): [0x178008000 - TURN Get Credentials] Time taken: 16 ms
2026-03-30 17:14:23.657 PROFILE turnConnectionHandleStunError(): [0x178008000 - TURN Get Credentials] Time taken: 16 ms
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
