### PR TITLE
Additional logging for RTP transmission path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ CMakeLists.txt.user
 *.swp
 venv/
 
+.SignalingCache_v*
+.kiro/

--- a/README.md
+++ b/README.md
@@ -519,12 +519,12 @@ AWS access keys are ignored from environment variables if the sample was built i
 
 ### SDK environment variables
 
-| Variable                                   | Description                                                                                                   | Type  | Default           | Notes                                           |
-|--------------------------------------------|---------------------------------------------------------------------------------------------------------------|-------|-------------------|-------------------------------------------------|
-| `KVS_DEBUG_LOG_SENDER_RECEIVER_REPORTS`    | Print sender/receiver reports to DEBUG logs                                                                   | Bool  | `1`/`ON`/`TRUE`   | `0`/`OFF`/`FALSE` to disable. Case insensitive. |
-| `KVS_DEBUG_LOG_RTP_PACKETS`                | Print RTP debug info to DEBUG logs                                                                            | Bool  | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
-| `KVS_DEBUG_LOG_EXTRA_TIMING_INFO`          | Print extra timing info to DEBUG logs                                                                         | Bool  | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
-| `KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_MS`  | When printing the extra timing info to DEBUG logs, the minimum duration to wait before printing the next one. | Int   | 1000ms (1s)       | Milliseconds                                    |
+| Variable                                | Description                                                                                                                                     | Type  | Default           | Notes                                           |
+|-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------|-------------------|-------------------------------------------------|
+| `KVS_DEBUG_LOG_SENDER_RECEIVER_REPORTS` | Print sender/receiver reports to DEBUG logs                                                                                                     | Bool  | `1`/`ON`/`TRUE`   | `0`/`OFF`/`FALSE` to disable. Case insensitive. |
+| `KVS_DEBUG_LOG_RTP_PACKETS`             | Print RTP packet headers to DEBUG logs                                                                                                          | Bool  | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
+| `KVS_DEBUG_LOG_EXTRA_TX_TIMING_INFO`    | Print RTP timestamps on the transmission path to DEBUG logs and print start + stop for WriteFrame, SRTP encrypt, and SocketSend to VERBOSE logs | Bool  | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
+| `KVS_DEBUG_FRAME_TIMING_FREQUENCY_MS`   | When printing the extra timing info to DEBUG logs, the minimum duration to wait before printing the next one.                                   | Int   | 1000ms (1s)       | Milliseconds                                    |
 
 ## TWCC support
 

--- a/README.md
+++ b/README.md
@@ -519,12 +519,12 @@ AWS access keys are ignored from environment variables if the sample was built i
 
 ### SDK environment variables
 
-| Variable                                | Description                                                                                                                                     | Type  | Default           | Notes                                           |
-|-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------|-------------------|-------------------------------------------------|
-| `KVS_DEBUG_LOG_SENDER_RECEIVER_REPORTS` | Print sender/receiver reports to DEBUG logs                                                                                                     | Bool  | `1`/`ON`/`TRUE`   | `0`/`OFF`/`FALSE` to disable. Case insensitive. |
-| `KVS_DEBUG_LOG_RTP_PACKETS`             | Print RTP packet headers to DEBUG logs                                                                                                          | Bool  | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
-| `KVS_DEBUG_LOG_EXTRA_TX_TIMING_INFO`    | Print RTP timestamps on the transmission path to DEBUG logs and print start + stop for WriteFrame, SRTP encrypt, and SocketSend to VERBOSE logs | Bool  | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
-| `KVS_DEBUG_FRAME_TIMING_FREQUENCY_MS`   | When printing the extra timing info to DEBUG logs, the minimum duration to wait before printing the next one.                                   | Int   | 1000ms (1s)       | Milliseconds                                    |
+| Variable                                | Description                                                                                                                                     | Type | Default           | Notes                                           |
+|-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|------|-------------------|-------------------------------------------------|
+| `KVS_DEBUG_LOG_SENDER_RECEIVER_REPORTS` | Print sender/receiver reports to DEBUG logs                                                                                                     | Bool | `1`/`ON`/`TRUE`   | `0`/`OFF`/`FALSE` to disable. Case insensitive. |
+| `KVS_DEBUG_LOG_RTP_PACKETS`             | Print RTP packet headers to DEBUG logs                                                                                                          | Bool | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
+| `KVS_DEBUG_LOG_EXTRA_TX_TIMING_INFO`    | Print RTP timestamps on the transmission path to DEBUG logs and print start + stop for WriteFrame, SRTP encrypt, and SocketSend to VERBOSE logs | Bool | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
+| `KVS_DEBUG_FRAME_TIMING_FREQUENCY_MS`   | When printing the extra timing info to DEBUG logs, the minimum duration to wait before printing the next one.                                   | Int  | 1000ms (1s)       | Milliseconds                                    |
 
 ## TWCC support
 

--- a/README.md
+++ b/README.md
@@ -517,6 +517,15 @@ AWS access keys are ignored from environment variables if the sample was built i
 | `CONTROL_PLANE_URI`        | Endpoint override                   | String               | Based on the region   | Example: "https://kinesisvideo.us-west-2.api.aws" |
 | `KVS_ICE_TRANSPORT_POLICY` | Types of ICE candidates to consider | Enum (`relay`/`all`) | `all`                 | Case insensitive                                  |
 
+### SDK environment variables
+
+| Variable                                   | Description                                                                                                   | Type  | Default           | Notes                                           |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------|-------|-------------------|-------------------------------------------------|
+| `KVS_DEBUG_LOG_SENDER_RECEIVER_REPORTS`    | Print sender/receiver reports to DEBUG logs                                                                   | Bool  | `1`/`ON`/`TRUE`   | `0`/`OFF`/`FALSE` to disable. Case insensitive. |
+| `KVS_DEBUG_LOG_RTP_PACKETS`                | Print RTP debug info to DEBUG logs                                                                            | Bool  | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
+| `KVS_DEBUG_LOG_EXTRA_TIMING_INFO`          | Print extra timing info to DEBUG logs                                                                         | Bool  | `0`/`OFF`/`FALSE` | `1`/`ON`/`TRUE` to enable. Case insensitive.    |
+| `KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_MS`  | When printing the extra timing info to DEBUG logs, the minimum duration to wait before printing the next one. | Int   | 1000ms (1s)       | Milliseconds                                    |
+
 ## TWCC support
 
 Transport Wide Congestion Control (TWCC) is a mechanism in WebRTC designed to enhance the performance and reliability of real-time communication over the internet. TWCC addresses the challenges of network congestion by providing detailed feedback on the transport of packets across the network, enabling adaptive bitrate control and optimization of media streams in real-time. This feedback mechanism is crucial for maintaining high-quality audio and video communication, as it allows senders to adjust their transmission strategies based on comprehensive information about packet losses, delays, and jitter experienced across the entire transport path.

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -727,7 +727,7 @@ extern "C" {
 /**
  * Env to print extra timing information to the debug log
  */
-#define KVS_LOG_TIMING_INFO_ENV_VAR ((PCHAR) "KVS_DEBUG_LOG_EXTRA_TIMING_INFO")
+#define KVS_LOG_TIMING_INFO_ENV_VAR ((PCHAR) "KVS_DEBUG_LOG_EXTRA_TX_TIMING_INFO")
 
 /**
  * Env to print sender/receiver reports to the debug log
@@ -737,7 +737,7 @@ extern "C" {
 /**
  * Env for the frame debug log frequency in ms
  */
-#define KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_ENV_VAR_MS ((PCHAR) "KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_MS")
+#define KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_ENV_VAR_MS ((PCHAR) "KVS_DEBUG_FRAME_TIMING_FREQUENCY_MS")
 
 /**
  * Env to print nack/retransmit requests to the debug log

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -540,6 +540,18 @@ extern "C" {
  * Maximum length of signaling message
  */
 #define MAX_SIGNALING_MESSAGE_LEN 18750
+
+/**
+ * Maximum length of RTP packet dump string
+ */
+#define RTP_PACKET_TOSTRING_LEN 255
+
+/**
+ * Maximum allowed ICE URI buffer length, including the null terminator.
+ *
+ * \sa RTP_PACKET_TOSTRING_LEN
+ */
+#define RTP_PACKET_TOSTRING_BUFFER_LEN (RTP_PACKET_TOSTRING_LEN + 1)
 /*!@} */
 
 /////////////////////////////////////////////////////
@@ -706,6 +718,36 @@ extern "C" {
  */
 #define DISABLE_IPV4_TURN_ENV_VAR ((PCHAR) "KVS_DISABLE_IPV4_TURN")
 #define DISABLE_IPV6_TURN_ENV_VAR ((PCHAR) "KVS_DISABLE_IPV6_TURN")
+
+/**
+ * Env to print RTP packet headers to the debug log
+ */
+#define KVS_LOG_RTP_PACKETS_ENV_VAR ((PCHAR) "KVS_DEBUG_LOG_RTP_PACKETS")
+
+/**
+ * Env to print extra timing information to the debug log
+ */
+#define KVS_LOG_TIMING_INFO_ENV_VAR ((PCHAR) "KVS_DEBUG_LOG_EXTRA_TIMING_INFO")
+
+/**
+ * Env to print sender/receiver reports to the debug log
+ */
+#define KVS_LOG_SENDER_RECEIVER_REPORTS_ENV_VAR ((PCHAR) "KVS_DEBUG_LOG_SENDER_RECEIVER_REPORTS")
+
+/**
+ * Env for the frame debug log frequency in ms
+ */
+#define KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_ENV_VAR_MS ((PCHAR) "KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_MS")
+
+/**
+ * Env to print nack/retransmit requests to the debug log
+ */
+#define KVS_LOG_NACKS_ENV_VAR ((PCHAR) "KVS_DEBUG_LOG_NACKS")
+
+/**
+ * Default interval for frame debug log frequency in ms
+ */
+#define KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_DEFAULT_MS 1000
 
 #ifdef _WIN32
 /**

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -676,12 +676,19 @@ STATUS iceAgentSendPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen)
     UINT32 bytesDiscarded = 0;
     UINT32 bytesSent = 0;
     UINT32 packetsSent = 0;
+    UINT64 iceLockWaitStart = 0, iceLockAcquiredTime = 0, iceSendStart = 0, iceSendDuration = 0;
 
     CHK(pIceAgent != NULL && pBuffer != NULL, STATUS_NULL_ARG);
     CHK(bufferLen != 0, STATUS_INVALID_ARG);
 
+    iceLockWaitStart = GETTIME();
     MUTEX_LOCK(pIceAgent->lock);
     locked = TRUE;
+    iceLockAcquiredTime = GETTIME();
+    if (iceLockAcquiredTime - iceLockWaitStart > 5 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
+        DLOGW("iceAgentSendPacket(): ICE lock wait took %" PRIu64 " ms, bufLen=%u",
+              (iceLockAcquiredTime - iceLockWaitStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, bufferLen);
+    }
 
     /* Do not proceed if ice is shutting down */
     CHK(!ATOMIC_LOAD_BOOL(&pIceAgent->shutdown), retStatus);
@@ -700,8 +707,14 @@ STATUS iceAgentSendPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen)
         pTurnConnection = pIceAgent->pDataSendingIceCandidatePair->local->pTurnConnection;
     }
 
+    iceSendStart = GETTIME();
     retStatus = iceUtilsSendData(pBuffer, bufferLen, &pIceAgent->pDataSendingIceCandidatePair->remote->ipAddress,
                                  pIceAgent->pDataSendingIceCandidatePair->local->pSocketConnection, pTurnConnection, isRelay);
+    iceSendDuration = GETTIME() - iceSendStart;
+    if (iceSendDuration > 5 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
+        DLOGW("iceAgentSendPacket(): iceUtilsSendData took %" PRIu64 " ms, bufLen=%u, relay=%s",
+              iceSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, bufferLen, isRelay ? "yes" : "no");
+    }
 
     if (STATUS_FAILED(retStatus)) {
         DLOGW("iceUtilsSendData failed with 0x%08x", retStatus);

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -712,8 +712,8 @@ STATUS iceAgentSendPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen)
                                  pIceAgent->pDataSendingIceCandidatePair->local->pSocketConnection, pTurnConnection, isRelay);
     iceSendDuration = GETTIME() - iceSendStart;
     if (iceSendDuration > 5 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
-        DLOGW("iceAgentSendPacket(): iceUtilsSendData took %" PRIu64 " ms, bufLen=%u, relay=%s",
-              iceSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, bufferLen, isRelay ? "yes" : "no");
+        DLOGW("iceAgentSendPacket(): iceUtilsSendData took %" PRIu64 " ms, bufLen=%u, relay=%s", iceSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+              bufferLen, isRelay ? "yes" : "no");
     }
 
     if (STATUS_FAILED(retStatus)) {

--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -447,7 +447,9 @@ STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOO
 
         DLOGS("jitterBufferPush get packet timestamp %lu seqNum %lu", pRtpPacket->header.timestamp, pRtpPacket->header.sequenceNumber);
     } else {
-        // Free the packet if it is out of range, jitter buffer need to own the packet and do free
+        DLOGW("jitterBufferPush: DISCARDED packet seq=%u ts=%u outside latency tolerance (head=%u tail=%u maxLatency=%u)",
+              pRtpPacket->header.sequenceNumber, pRtpPacket->header.timestamp,
+              pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp, pJitterBuffer->maxLatency);
         freeRtpPacket(&pRtpPacket);
         if (pPacketDiscarded != NULL) {
             *pPacketDiscarded = TRUE;
@@ -511,6 +513,11 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
         if (!hasEntry) {
             isFrameDataContinuous = FALSE;
             // if the max latency has not been reached, or the buffer is not being closed, exit parse when a missing entry is found
+            if (pJitterBuffer->headTimestamp < earliestAllowedTimestamp) {
+                DLOGW("jitterBufferParse: missing seq=%u, latency exceeded (headTs=%u tailTs=%u gap=%u maxLatency=%u)",
+                      index, pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp,
+                      pJitterBuffer->tailTimestamp - pJitterBuffer->headTimestamp, pJitterBuffer->maxLatency);
+            }
             CHK(pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed, retStatus);
         } else {
             lastNonNullIndex = index;
@@ -538,6 +545,9 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
                 }
                 // are we forcibly clearing out the buffer? if so drop the contents of incomplete frame
                 else if (pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed) {
+                    DLOGW("jitterBufferParse: DROPPING incomplete frame headTs=%u tailTs=%u earliestAllowed=%u seqRange=[%u-%u] bufferClosed=%s",
+                          pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp, earliestAllowedTimestamp,
+                          startDropIndex, UINT16_DEC(index), bufferClosed ? "yes" : "no");
                     // do not CHK_STATUS of onFrameDropped because we need to clear the jitter buffer no matter what else happens.
                     pJitterBuffer->onFrameDroppedFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), pJitterBuffer->headTimestamp);
                     CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, UINT16_DEC(index), curTimestamp));

--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -448,8 +448,8 @@ STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOO
         DLOGS("jitterBufferPush get packet timestamp %lu seqNum %lu", pRtpPacket->header.timestamp, pRtpPacket->header.sequenceNumber);
     } else {
         DLOGW("jitterBufferPush: DISCARDED packet seq=%u ts=%u outside latency tolerance (head=%u tail=%u maxLatency=%u)",
-              pRtpPacket->header.sequenceNumber, pRtpPacket->header.timestamp,
-              pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp, pJitterBuffer->maxLatency);
+              pRtpPacket->header.sequenceNumber, pRtpPacket->header.timestamp, pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp,
+              pJitterBuffer->maxLatency);
         freeRtpPacket(&pRtpPacket);
         if (pPacketDiscarded != NULL) {
             *pPacketDiscarded = TRUE;
@@ -514,9 +514,9 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
             isFrameDataContinuous = FALSE;
             // if the max latency has not been reached, or the buffer is not being closed, exit parse when a missing entry is found
             if (pJitterBuffer->headTimestamp < earliestAllowedTimestamp) {
-                DLOGW("jitterBufferParse: missing seq=%u, latency exceeded (headTs=%u tailTs=%u gap=%u maxLatency=%u)",
-                      index, pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp,
-                      pJitterBuffer->tailTimestamp - pJitterBuffer->headTimestamp, pJitterBuffer->maxLatency);
+                DLOGW("jitterBufferParse: missing seq=%u, latency exceeded (headTs=%u tailTs=%u gap=%u maxLatency=%u)", index,
+                      pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp, pJitterBuffer->tailTimestamp - pJitterBuffer->headTimestamp,
+                      pJitterBuffer->maxLatency);
             }
             CHK(pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed, retStatus);
         } else {
@@ -546,8 +546,8 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
                 // are we forcibly clearing out the buffer? if so drop the contents of incomplete frame
                 else if (pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed) {
                     DLOGW("jitterBufferParse: DROPPING incomplete frame headTs=%u tailTs=%u earliestAllowed=%u seqRange=[%u-%u] bufferClosed=%s",
-                          pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp, earliestAllowedTimestamp,
-                          startDropIndex, UINT16_DEC(index), bufferClosed ? "yes" : "no");
+                          pJitterBuffer->headTimestamp, pJitterBuffer->tailTimestamp, earliestAllowedTimestamp, startDropIndex, UINT16_DEC(index),
+                          bufferClosed ? "yes" : "no");
                     // do not CHK_STATUS of onFrameDropped because we need to clear the jitter buffer no matter what else happens.
                     pJitterBuffer->onFrameDroppedFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), pJitterBuffer->headTimestamp);
                     CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, UINT16_DEC(index), curTimestamp));

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1075,7 +1075,7 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
 
     NULLABLE_SET_EMPTY(pKvsPeerConnection->canTrickleIce);
 
-    if (FALSE) {
+    if (!pConfiguration->kvsRtcConfiguration.disableSenderSideBandwidthEstimation) {
         pKvsPeerConnection->twccLock = MUTEX_CREATE(TRUE);
         pKvsPeerConnection->pTwccManager = (PTwccManager) MEMCALLOC(1, SIZEOF(TwccManager));
         CHK(pKvsPeerConnection->pTwccManager != NULL, STATUS_NOT_ENOUGH_MEMORY);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1075,7 +1075,7 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
 
     NULLABLE_SET_EMPTY(pKvsPeerConnection->canTrickleIce);
 
-    if (!pConfiguration->kvsRtcConfiguration.disableSenderSideBandwidthEstimation) {
+    if (FALSE) {
         pKvsPeerConnection->twccLock = MUTEX_CREATE(TRUE);
         pKvsPeerConnection->pTwccManager = (PTwccManager) MEMCALLOC(1, SIZEOF(TwccManager));
         CHK(pKvsPeerConnection->pTwccManager != NULL, STATUS_NOT_ENOUGH_MEMORY);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -746,7 +746,9 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
     ready = pKvsPeerConnection->pSrtpSession != NULL &&
         currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime >= 2500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     if (!ready) {
-        DLOGD("sender report no frames sent %u", ssrc);
+        if (pKvsPeerConnection->printSenderReceiverReports) {
+            DLOGD("sender report no frames sent %u", ssrc);
+        }
     } else {
         // create rtcp sender report packet
         // https://tools.ietf.org/html/rfc3550#section-6.4.1
@@ -757,7 +759,9 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         packetCount = pKvsRtpTransceiver->outboundStats.sent.packetsSent;
         octetCount = pKvsRtpTransceiver->outboundStats.sent.bytesSent;
         MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
-        DLOGD("sender report %u %" PRIu64 " %" PRIu64 " : %u packets %u bytes", ssrc, ntpTime, rtpTime, packetCount, octetCount);
+        if (pKvsPeerConnection->printSenderReceiverReports) {
+            DLOGD("sender report %u %" PRIu64 " %" PRIu64 " : %u packets %u bytes", ssrc, ntpTime, rtpTime, packetCount, octetCount);
+        }
         packetLen = RTCP_PACKET_HEADER_LEN + 24;
 
         // srtp_protect_rtcp() in encryptRtcpPacket() assumes memory availability to write 10 bytes of authentication tag and
@@ -990,6 +994,7 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     PConnectionListener pConnectionListener = NULL;
     UINT64 startTime = 0;
     UINT64 startTimeInMacro = 0;
+    PCHAR envVarVal = NULL;
 
     CHK(pConfiguration != NULL && ppPeerConnection != NULL, STATUS_NULL_ARG);
 
@@ -1029,6 +1034,32 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
         ? DEFAULT_MTU_SIZE_BYTES
         : pConfiguration->kvsRtcConfiguration.maximumTransmissionUnit;
     ATOMIC_STORE_BOOL(&pKvsPeerConnection->sctpIsEnabled, FALSE);
+
+    // default=OFF
+    pKvsPeerConnection->logRtpPackets = (loggerGetLogLevel() <= LOG_LEVEL_DEBUG && isEnvVarEnabled(KVS_LOG_RTP_PACKETS_ENV_VAR));
+    pKvsPeerConnection->printExtraTimingInfo = (loggerGetLogLevel() <= LOG_LEVEL_DEBUG && isEnvVarEnabled(KVS_LOG_TIMING_INFO_ENV_VAR));
+    pKvsPeerConnection->printNacks = (loggerGetLogLevel() <= LOG_LEVEL_DEBUG && isEnvVarEnabled(KVS_LOG_NACKS_ENV_VAR));
+
+    // default=ON
+    envVarVal = GETENV(KVS_LOG_SENDER_RECEIVER_REPORTS_ENV_VAR);
+    if (envVarVal == NULL) {
+        pKvsPeerConnection->printSenderReceiverReports = loggerGetLogLevel() <= LOG_LEVEL_DEBUG;
+    } else {
+        pKvsPeerConnection->printSenderReceiverReports =
+            (loggerGetLogLevel() <= LOG_LEVEL_DEBUG &&
+             (STRCMPI(envVarVal, "1") == 0 || STRCMPI(envVarVal, "true") == 0 || STRCMPI(envVarVal, "on") == 0));
+    }
+
+    envVarVal = GETENV(KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_ENV_VAR_MS);
+    if (envVarVal == NULL) {
+        pKvsPeerConnection->writeFrameLoggingIntervalMs = KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_DEFAULT_MS;
+    } else {
+        STATUS convertStatus = STRTOUI64(envVarVal, NULL, 10, &pKvsPeerConnection->writeFrameLoggingIntervalMs);
+        if (STATUS_FAILED(convertStatus)) {
+            DLOGW("Unrecognized value for %s, using the default: %d ms", envVarVal, KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_DEFAULT_MS);
+            pKvsPeerConnection->writeFrameLoggingIntervalMs = KVS_LOG_DEBUG_FRAME_TIMING_FREQUENCY_DEFAULT_MS;
+        }
+    }
 
     iceAgentCallbacks.customData = (UINT64) pKvsPeerConnection;
     iceAgentCallbacks.inboundPacketFn = onInboundPacket;

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -110,6 +110,21 @@ typedef struct {
     // (TRUE = viewer mode, FALSE = master mode)
     BOOL isOffer;
 
+    // Debug logs for RTP packets
+    BOOL logRtpPackets;
+
+    // Print extra debug logs related to timing
+    BOOL printExtraTimingInfo;
+
+    // Print extra debug logs related to sender/receiver reports
+    BOOL printSenderReceiverReports;
+
+    // Print extra debug logs related to nacks
+    BOOL printNacks;
+
+    // Throttle debug logging for frame timing information. Use 0 to print timing for every frame.
+    UINT64 writeFrameLoggingIntervalMs;
+
     TIMER_QUEUE_HANDLE timerQueueHandle;
 
     // Codecs that we support and their payloadTypes

--- a/src/source/PeerConnection/Retransmitter.c
+++ b/src/source/PeerConnection/Retransmitter.c
@@ -75,6 +75,9 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
     filledLen = pRetransmitter->seqNumListLen;
     CHK_STATUS(rtcpNackListGet(pRtcpPacket->payload, pRtcpPacket->payloadLength, &senderSsrc, &receiverSsrc, pRetransmitter->sequenceNumberList,
                                &filledLen));
+    if (pKvsPeerConnection->printNacks) {
+        DLOGD("NACK received: senderSsrc %u receiverSsrc %u requestedSeqNums %u", senderSsrc, receiverSsrc, filledLen);
+    }
     validIndexListLen = pRetransmitter->validIndexListLen;
     CHK_STATUS(rtpRollingBufferGetValidSeqIndexList(pSenderTranceiver->sender.packetBuffer, pRetransmitter->sequenceNumberList, filledLen,
                                                     pRetransmitter->validIndexList, &validIndexListLen));
@@ -98,10 +101,17 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
                 pRtpPacket->sentTime = GETTIME();
                 retransmittedPacketsSent++;
                 retransmittedBytesSent += pRtpPacket->rawPacketLength - RTP_HEADER_LEN(pRtpPacket);
-                DLOGV("Resent packet ssrc %lu seq %lu succeeded", pRtpPacket->header.ssrc, pRtpPacket->header.sequenceNumber);
+                if (pKvsPeerConnection->printNacks) {
+                    DLOGD("Retransmit (%s) ssrc %u seqNum %u timestamp %u payloadType %u marker %u size %u",
+                          (pSenderTranceiver->sender.payloadType == pSenderTranceiver->sender.rtxPayloadType) ? "resent as-is"
+                                                                                                              : "reconstructed as RTX",
+                          pRtpPacket->header.ssrc, pRtpPacket->header.sequenceNumber, pRtpPacket->header.timestamp, pRtpPacket->header.payloadType,
+                          pRtpPacket->header.marker, pRtpPacket->rawPacketLength);
+                }
                 twccManagerOnPacketSent(pKvsPeerConnection, pRtpPacket);
             } else {
-                DLOGV("Resent packet ssrc %lu seq %lu failed 0x%08x", pRtpPacket->header.ssrc, pRtpPacket->header.sequenceNumber, retStatus);
+                DLOGV("Retransmit FAILED ssrc %u seqNum %u timestamp %u err 0x%08x", pRtpPacket->header.ssrc, pRtpPacket->header.sequenceNumber,
+                      pRtpPacket->header.timestamp, retStatus);
             }
             // putBackPacketToRollingBuffer
             retStatus =

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -286,15 +286,21 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     UINT32 extpayload;
     STATUS sendStatus;
 
-    // timing information
-    BOOL shouldLog;
-    UINT64 sendStart = 0, sendEnd = 0;
-    UINT64 srtpStart = 0, srtpEnd = 0;
+    // timing information; duration = total sum for this frame
+    BOOL shouldLogDebugTimingInfo = FALSE;
+    UINT64 sendStart = 0, sendEnd = 0, sendDuration = 0;
+    UINT64 srtpStart = 0, srtpEnd = 0, srtpDuration = 0;
 
     CHK(pKvsRtpTransceiver != NULL && pFrame != NULL, STATUS_NULL_ARG);
     pKvsPeerConnection = pKvsRtpTransceiver->pKvsPeerConnection;
 
-    if (pKvsPeerConnection->printExtraTimingInfo) {
+    /* log on an interval as to not consume so much CPU */
+    shouldLogDebugTimingInfo = pKvsPeerConnection->printExtraTimingInfo &&
+            (now - pKvsRtpTransceiver->lastWriteFrameLogTime >=
+             pKvsPeerConnection->writeFrameLoggingIntervalMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) ||
+        (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind && 0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME));
+
+    if (shouldLogDebugTimingInfo) {
         if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
             DLOGV("Start writeFrame VIDEO: pts=%" PRIu64, pFrame->presentationTs);
         } else {
@@ -354,12 +360,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     rtpTimestamp += randomRtpTimeoffset;
 
-    /* log the rtp time codes about every second */
-    shouldLog = pKvsPeerConnection->printExtraTimingInfo &&
-            (now - pKvsRtpTransceiver->lastWriteFrameLogTime >=
-             pKvsPeerConnection->writeFrameLoggingIntervalMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) ||
-        (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind && 0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME));
-
     CHK_STATUS(rtpPayloadFunc(pKvsPeerConnection->MTU, (PBYTE) pFrame->frameData, pFrame->size, NULL, &(pPayloadArray->payloadLength), NULL,
                               &(pPayloadArray->payloadSubLenSize)));
     if (pPayloadArray->payloadLength > pPayloadArray->maxPayloadLength) {
@@ -416,24 +416,26 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             }
         }
 
-        if (pKvsPeerConnection->printExtraTimingInfo) {
+        if (shouldLogDebugTimingInfo) {
             DLOGV("Start encrypting RTP seqNum=%d", pRtpPacket->header.sequenceNumber);
         }
         srtpStart = GETTIME();
         CHK_STATUS(encryptRtpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
         srtpEnd = GETTIME();
-        if (pKvsPeerConnection->printExtraTimingInfo) {
+        if (shouldLogDebugTimingInfo) {
             DLOGV("Finish encrypting RTP seqNum=%d", pRtpPacket->header.sequenceNumber);
+            srtpDuration += (srtpEnd - srtpStart);
         }
 
-        if (pKvsPeerConnection->printExtraTimingInfo) {
+        if (shouldLogDebugTimingInfo) {
             DLOGV("Start sending RTP seqNum=%d", pRtpPacket->header.sequenceNumber);
         }
         sendStart = GETTIME();
         sendStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, packetLen);
         sendEnd = GETTIME();
-        if (pKvsPeerConnection->printExtraTimingInfo) {
+        if (shouldLogDebugTimingInfo) {
             DLOGV("Finish sending RTP seqNum=%d", pRtpPacket->header.sequenceNumber);
+            sendDuration += (sendEnd - sendStart);
         }
 
         if (sendStatus == STATUS_SEND_DATA_FAILED) {
@@ -469,22 +471,25 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         framesSent++;
     }
 
-    if (shouldLog) {
+    if (shouldLogDebugTimingInfo) {
         UINT64 postSendWallClock = GETTIME();
         if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
-            DLOGD("VIDEO SENT: %s, pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u, bytes=%u, discarded=%u"
-                  ", wallClock_ms=%" PRIu64 ", srtpDuration=%" PRIu64 ".%02" PRIu64 " ms, frameSendDuration=%" PRIu64 ".%02" PRIu64 " ms",
+            DLOGD("VIDEO SENT: %s, pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u (%u-%u), bytes=%u, discarded=%u"
+                  ", wallClock_ms=%" PRIu64 ", srtpDuration=%" PRIu64 ".%02" PRIu64 " ms, socketWriteDuration=%" PRIu64 ".%02" PRIu64 " ms",
                   (0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME)) ? "[KEY]" : "[non-KEY]", pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  rtpTimestamp, packetsSent, bytesSent, packetsDiscardedOnSend, postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  (srtpEnd - srtpStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  ((srtpEnd - srtpStart) % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100),
-                  (sendEnd - sendStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  ((sendEnd - sendStart) % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));
+                  rtpTimestamp, packetsSent, pKvsRtpTransceiver->sender.sequenceNumber - packetsSent, pKvsRtpTransceiver->sender.sequenceNumber - 1,
+                  bytesSent, packetsDiscardedOnSend, postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  srtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  (srtpDuration % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100),
+                  sendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  (sendDuration % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));
         } else {
-            DLOGD("AUDIO SENT: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u, bytes=%u, discarded=%u"
-                  ", wallClock_ms=%" PRIu64 ", srtpDuration=%" PRIu64 ".%02" PRIu64 " ms, frameSendDuration=%" PRIu64 ".%02" PRIu64 " ms",
-                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp, packetsSent, bytesSent, packetsDiscardedOnSend,
-                  postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, (srtpEnd - srtpStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+            DLOGD("AUDIO SENT: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u (%u-%u), bytes=%u, discarded=%u"
+                  ", wallClock_ms=%" PRIu64 ", srtpDuration=%" PRIu64 ".%02" PRIu64 " ms, socketWriteDuration=%" PRIu64 ".%02" PRIu64 " ms",
+                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp, packetsSent,
+                  pKvsRtpTransceiver->sender.sequenceNumber - packetsSent, pKvsRtpTransceiver->sender.sequenceNumber - 1, bytesSent,
+                  packetsDiscardedOnSend, postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  (srtpEnd - srtpStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
                   ((srtpEnd - srtpStart) % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100),
                   (sendEnd - sendStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
                   ((sendEnd - sendStart) % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));
@@ -538,7 +543,7 @@ CleanUp:
         CHK_LOG_ERR(retStatus);
     }
 
-    if (pKvsRtpTransceiver != NULL && pFrame != NULL && pKvsPeerConnection->printExtraTimingInfo) {
+    if (pKvsRtpTransceiver != NULL && pFrame != NULL && shouldLogDebugTimingInfo) {
         if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
             DLOGV("Finish writeFrame VIDEO: pts=%" PRIu64, pFrame->presentationTs);
         } else {

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -264,7 +264,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     STATUS retStatus = STATUS_SUCCESS;
     PKvsPeerConnection pKvsPeerConnection = NULL;
     PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pRtcRtpTransceiver;
-    BOOL locked = FALSE, bufferAfterEncrypt = FALSE, shouldLog = FALSE;
+    BOOL locked = FALSE, bufferAfterEncrypt = FALSE;
     PRtpPacket pPacketList = NULL, pRtpPacket = NULL;
     UINT32 i = 0, packetLen = 0, headerLen = 0, allocSize;
     PBYTE rawPacket = NULL;
@@ -286,13 +286,22 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     UINT32 extpayload;
     STATUS sendStatus;
 
-    // send delay instrumentation
-    UINT64 lockWaitStart = 0, lockAcquiredTime = 0, frameSendStart = 0, frameSendDuration = 0;
-    UINT64 sendStart = 0, sendDuration = 0, maxSendDuration = 0, totalSendDuration = 0;
-    UINT64 srtpStart = 0, srtpDuration = 0, maxSrtpDuration = 0, totalSrtpDuration = 0;
+    // timing information
+    BOOL shouldLog;
+    UINT64 sendStart = 0, sendEnd = 0;
+    UINT64 srtpStart = 0, srtpEnd = 0;
 
     CHK(pKvsRtpTransceiver != NULL && pFrame != NULL, STATUS_NULL_ARG);
     pKvsPeerConnection = pKvsRtpTransceiver->pKvsPeerConnection;
+
+    if (pKvsPeerConnection->printExtraTimingInfo) {
+        if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
+            DLOGV("Start writeFrame VIDEO: pts=%" PRIu64, pFrame->presentationTs);
+        } else {
+            DLOGV("Start writeFrame AUDIO: pts=%" PRIu64, pFrame->presentationTs);
+        }
+    }
+
     pPayloadArray = &(pKvsRtpTransceiver->sender.payloadArray);
     if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
         frames++;
@@ -309,15 +318,8 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         }
     }
 
-    lockWaitStart = GETTIME();
     MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
     locked = TRUE;
-    lockAcquiredTime = GETTIME();
-    if (lockAcquiredTime - lockWaitStart > 5 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
-        DLOGW("writeFrame(): SRTP lock wait took %" PRIu64 " ms",
-              (lockAcquiredTime - lockWaitStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
-    }
-    frameSendStart = lockAcquiredTime;
     CHK(pKvsPeerConnection->pSrtpSession != NULL, STATUS_SRTP_NOT_READY_YET); // Discard packets till SRTP is ready
     switch (pKvsRtpTransceiver->sender.track.codec) {
         case RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE:
@@ -352,23 +354,11 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     rtpTimestamp += randomRtpTimeoffset;
 
-     /* log the rtp time codes about every second */
-    shouldLog = (now - pKvsRtpTransceiver->lastWriteFrameLogTime >= HUNDREDS_OF_NANOS_IN_A_SECOND) ||
-                (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind &&
-                 0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME));
-    if (shouldLog) {
-        if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
-            DLOGD("VIDEO: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", wallClock_ms=%" PRIu64 " %s",
-                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp,
-                  now / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  (0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME)) ? "[KEY]" : "[non-KEY]");
-        } else {
-            DLOGD("AUDIO: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", wallClock_ms=%" PRIu64,
-                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp,
-                  now / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
-        }
-        pKvsRtpTransceiver->lastWriteFrameLogTime = now;
-    }
+    /* log the rtp time codes about every second */
+    shouldLog = pKvsPeerConnection->printExtraTimingInfo &&
+            (now - pKvsRtpTransceiver->lastWriteFrameLogTime >=
+             pKvsPeerConnection->writeFrameLoggingIntervalMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) ||
+        (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind && 0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME));
 
     CHK_STATUS(rtpPayloadFunc(pKvsPeerConnection->MTU, (PBYTE) pFrame->frameData, pFrame->size, NULL, &(pPayloadArray->payloadLength), NULL,
                               &(pPayloadArray->payloadSubLenSize)));
@@ -415,25 +405,37 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             CHK_STATUS(rtpRollingBufferAddRtpPacket(pKvsRtpTransceiver->sender.packetBuffer, pRtpPacket));
         }
 
+        if (pKvsPeerConnection->logRtpPackets) {
+            CHAR packetContents[RTP_PACKET_TOSTRING_BUFFER_LEN];
+            STATUS toStringStatus = rtpPacketHeaderToString(pRtpPacket, packetContents, SIZEOF(packetContents));
+
+            if (STATUS_SUCCEEDED(toStringStatus)) {
+                DLOGD("%s", packetContents);
+            } else {
+                DLOGW("Error printing packet contents: 0x%08x", toStringStatus);
+            }
+        }
+
+        if (pKvsPeerConnection->printExtraTimingInfo) {
+            DLOGV("Start encrypting RTP seqNum=%d", pRtpPacket->header.sequenceNumber);
+        }
         srtpStart = GETTIME();
         CHK_STATUS(encryptRtpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
-        srtpDuration = GETTIME() - srtpStart;
-        totalSrtpDuration += srtpDuration;
-        if (srtpDuration > maxSrtpDuration) {
-            maxSrtpDuration = srtpDuration;
+        srtpEnd = GETTIME();
+        if (pKvsPeerConnection->printExtraTimingInfo) {
+            DLOGV("Finish encrypting RTP seqNum=%d", pRtpPacket->header.sequenceNumber);
+        }
+
+        if (pKvsPeerConnection->printExtraTimingInfo) {
+            DLOGV("Start sending RTP seqNum=%d", pRtpPacket->header.sequenceNumber);
         }
         sendStart = GETTIME();
         sendStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, packetLen);
-        sendDuration = GETTIME() - sendStart;
-        totalSendDuration += sendDuration;
-        if (sendDuration > maxSendDuration) {
-            maxSendDuration = sendDuration;
+        sendEnd = GETTIME();
+        if (pKvsPeerConnection->printExtraTimingInfo) {
+            DLOGV("Finish sending RTP seqNum=%d", pRtpPacket->header.sequenceNumber);
         }
-        if (sendDuration > 5 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
-            DLOGW("writeFrame(): slow iceAgentSendPacket: %" PRIu64 " ms, seq=%u, size=%u",
-                  sendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  pRtpPacket->header.sequenceNumber, packetLen);
-        }
+
         if (sendStatus == STATUS_SEND_DATA_FAILED) {
             packetsDiscardedOnSend++;
             bytesDiscardedOnSend += packetLen - headerLen;
@@ -470,41 +472,30 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     if (shouldLog) {
         UINT64 postSendWallClock = GETTIME();
         if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
-            DLOGD("VIDEO SENT: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u, bytes=%u, discarded=%u, "
-                  "totalSrtp_ms=%" PRIu64 ", maxSrtp_ms=%" PRIu64 ", totalSocketSend_ms=%" PRIu64 ", maxSocketSend_ms=%" PRIu64
-                  ", wallClock_ms=%" PRIu64 " %s",
-                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp, packetsSent, bytesSent, packetsDiscardedOnSend,
-                  totalSrtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, maxSrtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  totalSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, maxSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  (0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME)) ? "[KEY]" : "[non-KEY]");
+            DLOGD("VIDEO SENT: %s, pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u, bytes=%u, discarded=%u"
+                  ", wallClock_ms=%" PRIu64 ", srtpDuration=%" PRIu64 ".%02" PRIu64 " ms, frameSendDuration=%" PRIu64 ".%02" PRIu64 " ms",
+                  (0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME)) ? "[KEY]" : "[non-KEY]", pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  rtpTimestamp, packetsSent, bytesSent, packetsDiscardedOnSend, postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  (srtpEnd - srtpStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  ((srtpEnd - srtpStart) % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100),
+                  (sendEnd - sendStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  ((sendEnd - sendStart) % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));
         } else {
-            DLOGD("AUDIO SENT: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u, bytes=%u, discarded=%u, "
-                  "totalSrtp_ms=%" PRIu64 ", maxSrtp_ms=%" PRIu64 ", totalSocketSend_ms=%" PRIu64 ", maxSocketSend_ms=%" PRIu64
-                  ", wallClock_ms=%" PRIu64,
+            DLOGD("AUDIO SENT: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u, bytes=%u, discarded=%u"
+                  ", wallClock_ms=%" PRIu64 ", srtpDuration=%" PRIu64 ".%02" PRIu64 " ms, frameSendDuration=%" PRIu64 ".%02" PRIu64 " ms",
                   pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp, packetsSent, bytesSent, packetsDiscardedOnSend,
-                  totalSrtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, maxSrtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  totalSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, maxSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+                  postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, (srtpEnd - srtpStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  ((srtpEnd - srtpStart) % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100),
+                  (sendEnd - sendStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  ((sendEnd - sendStart) % HUNDREDS_OF_NANOS_IN_A_MILLISECOND) / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND / 100));
         }
+
+        pKvsRtpTransceiver->lastWriteFrameLogTime = now;
     }
 
     if (pKvsRtpTransceiver->sender.firstFrameWallClockTime == 0) {
         pKvsRtpTransceiver->sender.rtpTimeOffset = randomRtpTimeoffset;
         pKvsRtpTransceiver->sender.firstFrameWallClockTime = now;
-    }
-
-    if (frameSendStart > 0) {
-        frameSendDuration = GETTIME() - frameSendStart;
-        if (frameSendDuration > 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
-            DLOGW("writeFrame(): %s frame send took %" PRIu64 " ms (packets=%u, totalSend=%" PRIu64 " ms, maxSend=%" PRIu64
-                  " ms, frameSize=%u, pts_ms=%" PRIu64 ")",
-                  MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind ? "VIDEO" : "AUDIO",
-                  frameSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, packetsSent,
-                  totalSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
-                  maxSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pFrame->size,
-                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
-        }
     }
 
 CleanUp:
@@ -545,6 +536,14 @@ CleanUp:
     SAFE_MEMFREE(pPacketList);
     if (retStatus != STATUS_SRTP_NOT_READY_YET) {
         CHK_LOG_ERR(retStatus);
+    }
+
+    if (pKvsRtpTransceiver != NULL && pFrame != NULL && pKvsPeerConnection->printExtraTimingInfo) {
+        if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
+            DLOGV("Finish writeFrame VIDEO: pts=%" PRIu64, pFrame->presentationTs);
+        } else {
+            DLOGV("Finish writeFrame AUDIO: pts=%" PRIu64, pFrame->presentationTs);
+        }
     }
 
     return retStatus;
@@ -606,5 +605,57 @@ STATUS findTransceiverBySsrc(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTrans
 
 CleanUp:
     CHK_LOG_ERR(retStatus);
+    return retStatus;
+}
+
+STATUS rtpPacketHeaderToString(PRtpPacket pRtpPacket, PCHAR buffer, UINT32 bufferLen)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    INT32 charsWritten;
+    UINT32 i;
+
+    CHK(pRtpPacket != NULL && buffer != NULL, STATUS_NULL_ARG);
+    CHK(bufferLen > 0, STATUS_INVALID_ARG_LEN);
+
+    // Construct fixed header string
+    charsWritten = SNPRINTF(buffer, bufferLen, "RtpPacket: V=%u P=%u X=%u CC=%u M=%u PT=%u SEQ=%u TS=%u SSRC=%u payloadLen=%u",
+                            pRtpPacket->header.version, pRtpPacket->header.padding, pRtpPacket->header.extension, pRtpPacket->header.csrcCount,
+                            pRtpPacket->header.marker, pRtpPacket->header.payloadType, pRtpPacket->header.sequenceNumber,
+                            pRtpPacket->header.timestamp, pRtpPacket->header.ssrc, pRtpPacket->payloadLength);
+
+    CHK(charsWritten >= 0 && (UINT32) charsWritten < bufferLen, STATUS_BUFFER_TOO_SMALL);
+
+    // Add header extensions if present
+    if (pRtpPacket->header.extension && pRtpPacket->header.extensionPayload != NULL) {
+        charsWritten += SNPRINTF(buffer + charsWritten, bufferLen - charsWritten, " extProfile=0x%04X extLen=%u", pRtpPacket->header.extensionProfile,
+                                 pRtpPacket->header.extensionLength);
+        CHK(charsWritten >= 0 && (UINT32) charsWritten < bufferLen, STATUS_BUFFER_TOO_SMALL);
+
+        if (pRtpPacket->header.extensionProfile == TWCC_EXT_PROFILE && pRtpPacket->header.extensionLength >= 3) {
+            // TWCC is currently the only supported extension
+            charsWritten += SNPRINTF(buffer + charsWritten, bufferLen - charsWritten, " twccExtId=%u twccSeqNum=%u",
+                                     (pRtpPacket->header.extensionPayload[0] >> 4), TWCC_SEQNUM(pRtpPacket->header.extensionPayload));
+            CHK(charsWritten >= 0 && (UINT32) charsWritten < bufferLen, STATUS_BUFFER_TOO_SMALL);
+        } else {
+            // Unknown extension, dump the bytes
+            charsWritten += SNPRINTF(buffer + charsWritten, bufferLen - charsWritten, " extData=");
+            CHK(charsWritten >= 0 && (UINT32) charsWritten < bufferLen, STATUS_BUFFER_TOO_SMALL);
+
+            for (i = 0; i < pRtpPacket->header.extensionLength; i++) {
+                charsWritten += snprintf(buffer + charsWritten, bufferLen - charsWritten, "%02x", pRtpPacket->header.extensionPayload[i]);
+                CHK(charsWritten >= 0 && (UINT32) charsWritten < bufferLen, STATUS_BUFFER_TOO_SMALL);
+            }
+        }
+    }
+
+CleanUp:
+    if (STATUS_FAILED(retStatus) && buffer != NULL && bufferLen > 0) {
+        buffer[0] = '\0';
+    }
+
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
     return retStatus;
 }

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -289,6 +289,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     // send delay instrumentation
     UINT64 lockWaitStart = 0, lockAcquiredTime = 0, frameSendStart = 0, frameSendDuration = 0;
     UINT64 sendStart = 0, sendDuration = 0, maxSendDuration = 0, totalSendDuration = 0;
+    UINT64 srtpStart = 0, srtpDuration = 0, maxSrtpDuration = 0, totalSrtpDuration = 0;
 
     CHK(pKvsRtpTransceiver != NULL && pFrame != NULL, STATUS_NULL_ARG);
     pKvsPeerConnection = pKvsRtpTransceiver->pKvsPeerConnection;
@@ -414,7 +415,13 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             CHK_STATUS(rtpRollingBufferAddRtpPacket(pKvsRtpTransceiver->sender.packetBuffer, pRtpPacket));
         }
 
+        srtpStart = GETTIME();
         CHK_STATUS(encryptRtpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
+        srtpDuration = GETTIME() - srtpStart;
+        totalSrtpDuration += srtpDuration;
+        if (srtpDuration > maxSrtpDuration) {
+            maxSrtpDuration = srtpDuration;
+        }
         sendStart = GETTIME();
         sendStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, packetLen);
         sendDuration = GETTIME() - sendStart;
@@ -458,6 +465,28 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
         framesSent++;
+    }
+
+    if (shouldLog) {
+        UINT64 postSendWallClock = GETTIME();
+        if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
+            DLOGD("VIDEO SENT: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u, bytes=%u, discarded=%u, "
+                  "totalSrtp_ms=%" PRIu64 ", maxSrtp_ms=%" PRIu64 ", totalSocketSend_ms=%" PRIu64 ", maxSocketSend_ms=%" PRIu64
+                  ", wallClock_ms=%" PRIu64 " %s",
+                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp, packetsSent, bytesSent, packetsDiscardedOnSend,
+                  totalSrtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, maxSrtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  totalSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, maxSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  (0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME)) ? "[KEY]" : "[non-KEY]");
+        } else {
+            DLOGD("AUDIO SENT: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", packets=%u, bytes=%u, discarded=%u, "
+                  "totalSrtp_ms=%" PRIu64 ", maxSrtp_ms=%" PRIu64 ", totalSocketSend_ms=%" PRIu64 ", maxSocketSend_ms=%" PRIu64
+                  ", wallClock_ms=%" PRIu64,
+                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp, packetsSent, bytesSent, packetsDiscardedOnSend,
+                  totalSrtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, maxSrtpDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  totalSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, maxSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  postSendWallClock / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        }
     }
 
     if (pKvsRtpTransceiver->sender.firstFrameWallClockTime == 0) {

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -264,7 +264,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     STATUS retStatus = STATUS_SUCCESS;
     PKvsPeerConnection pKvsPeerConnection = NULL;
     PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pRtcRtpTransceiver;
-    BOOL locked = FALSE, bufferAfterEncrypt = FALSE;
+    BOOL locked = FALSE, bufferAfterEncrypt = FALSE, shouldLog = FALSE;
     PRtpPacket pPacketList = NULL, pRtpPacket = NULL;
     UINT32 i = 0, packetLen = 0, headerLen = 0, allocSize;
     PBYTE rawPacket = NULL;
@@ -339,6 +339,24 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     }
 
     rtpTimestamp += randomRtpTimeoffset;
+
+     /* log the rtp time codes about every second */
+    shouldLog = (now - pKvsRtpTransceiver->lastWriteFrameLogTime >= HUNDREDS_OF_NANOS_IN_A_SECOND) ||
+                (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind &&
+                 0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME));
+    if (shouldLog) {
+        if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
+            DLOGD("VIDEO: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", wallClock_ms=%" PRIu64 " %s",
+                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp,
+                  now / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  (0 != (pFrame->flags & FRAME_FLAG_KEY_FRAME)) ? "[KEY]" : "[non-KEY]");
+        } else {
+            DLOGD("AUDIO: pts_ms=%" PRIu64 ", rtpTs=%" PRIu64 ", wallClock_ms=%" PRIu64,
+                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, rtpTimestamp,
+                  now / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        }
+        pKvsRtpTransceiver->lastWriteFrameLogTime = now;
+    }
 
     CHK_STATUS(rtpPayloadFunc(pKvsPeerConnection->MTU, (PBYTE) pFrame->frameData, pFrame->size, NULL, &(pPayloadArray->payloadLength), NULL,
                               &(pPayloadArray->payloadSubLenSize)));

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -286,6 +286,10 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     UINT32 extpayload;
     STATUS sendStatus;
 
+    // send delay instrumentation
+    UINT64 lockWaitStart = 0, lockAcquiredTime = 0, frameSendStart = 0, frameSendDuration = 0;
+    UINT64 sendStart = 0, sendDuration = 0, maxSendDuration = 0, totalSendDuration = 0;
+
     CHK(pKvsRtpTransceiver != NULL && pFrame != NULL, STATUS_NULL_ARG);
     pKvsPeerConnection = pKvsRtpTransceiver->pKvsPeerConnection;
     pPayloadArray = &(pKvsRtpTransceiver->sender.payloadArray);
@@ -304,8 +308,15 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         }
     }
 
+    lockWaitStart = GETTIME();
     MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
     locked = TRUE;
+    lockAcquiredTime = GETTIME();
+    if (lockAcquiredTime - lockWaitStart > 5 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
+        DLOGW("writeFrame(): SRTP lock wait took %" PRIu64 " ms",
+              (lockAcquiredTime - lockWaitStart) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    }
+    frameSendStart = lockAcquiredTime;
     CHK(pKvsPeerConnection->pSrtpSession != NULL, STATUS_SRTP_NOT_READY_YET); // Discard packets till SRTP is ready
     switch (pKvsRtpTransceiver->sender.track.codec) {
         case RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE:
@@ -404,7 +415,18 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         }
 
         CHK_STATUS(encryptRtpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
+        sendStart = GETTIME();
         sendStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, packetLen);
+        sendDuration = GETTIME() - sendStart;
+        totalSendDuration += sendDuration;
+        if (sendDuration > maxSendDuration) {
+            maxSendDuration = sendDuration;
+        }
+        if (sendDuration > 5 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
+            DLOGW("writeFrame(): slow iceAgentSendPacket: %" PRIu64 " ms, seq=%u, size=%u",
+                  sendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  pRtpPacket->header.sequenceNumber, packetLen);
+        }
         if (sendStatus == STATUS_SEND_DATA_FAILED) {
             packetsDiscardedOnSend++;
             bytesDiscardedOnSend += packetLen - headerLen;
@@ -441,6 +463,19 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     if (pKvsRtpTransceiver->sender.firstFrameWallClockTime == 0) {
         pKvsRtpTransceiver->sender.rtpTimeOffset = randomRtpTimeoffset;
         pKvsRtpTransceiver->sender.firstFrameWallClockTime = now;
+    }
+
+    if (frameSendStart > 0) {
+        frameSendDuration = GETTIME() - frameSendStart;
+        if (frameSendDuration > 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
+            DLOGW("writeFrame(): %s frame send took %" PRIu64 " ms (packets=%u, totalSend=%" PRIu64 " ms, maxSend=%" PRIu64
+                  " ms, frameSize=%u, pts_ms=%" PRIu64 ")",
+                  MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind ? "VIDEO" : "AUDIO",
+                  frameSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, packetsSent,
+                  totalSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                  maxSendDuration / HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pFrame->size,
+                  pFrame->presentationTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        }
     }
 
 CleanUp:

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -82,6 +82,8 @@ typedef struct {
     RtcOutboundRtpStreamStats outboundStats;
     RtcRemoteInboundRtpStreamStats remoteInboundStats;
     RtcInboundRtpStreamStats inboundStats;
+
+    UINT64 lastWriteFrameLogTime; // 100ns precision, for throttling writeFrame debug logs
 } KvsRtpTransceiver, *PKvsRtpTransceiver;
 
 STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION, PKvsPeerConnection, UINT32, UINT32, PRtcMediaStreamTrack, PJitterBuffer, RTC_CODEC,

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -905,10 +905,9 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         attributeCount++;
 
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "extmap");
-        amountWritten =
-            SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
-                     SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s",
-                     pKvsPeerConnection->twccExtId, TWCC_EXT_URL);
+        amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
+                                 SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s", pKvsPeerConnection->twccExtId,
+                                 TWCC_EXT_URL);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
         attributeCount++;
     }

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -904,12 +904,13 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full rtcp-fb twcc could not be written");
         attributeCount++;
 
-        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "extmap");
-        amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
-                                 SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s", pKvsPeerConnection->twccExtId,
-                                 TWCC_EXT_URL);
-        CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
-        attributeCount++;
+        // TODO: Add additional testing for TWCC features
+        // STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "extmap");
+        // amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
+        //                         SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s", pKvsPeerConnection->twccExtId,
+        //                         TWCC_EXT_URL);
+        // CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
+        //attributeCount++;
     }
 
     pSdpMediaDescription->mediaAttributesCount = attributeCount;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -903,6 +903,14 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
                      SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " " TWCC_SDP_ATTR, payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full rtcp-fb twcc could not be written");
         attributeCount++;
+
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "extmap");
+        amountWritten =
+            SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
+                     SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s",
+                     pKvsPeerConnection->twccExtId, TWCC_EXT_URL);
+        CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
+        attributeCount++;
     }
 
     pSdpMediaDescription->mediaAttributesCount = attributeCount;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -910,7 +910,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         //                         SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s", pKvsPeerConnection->twccExtId,
         //                         TWCC_EXT_URL);
         // CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
-        //attributeCount++;
+        // attributeCount++;
     }
 
     pSdpMediaDescription->mediaAttributesCount = attributeCount;

--- a/src/source/Rtp/RtpPacket.h
+++ b/src/source/Rtp/RtpPacket.h
@@ -118,6 +118,7 @@ STATUS setRtpPacketFromBytes(PBYTE, UINT32, PRtpPacket);
 STATUS createBytesFromRtpPacket(PRtpPacket, PBYTE, PUINT32);
 STATUS setBytesFromRtpPacket(PRtpPacket, PBYTE, UINT32);
 STATUS constructRtpPackets(PPayloadArray, UINT8, UINT16, UINT32, UINT32, PRtpPacket, UINT32);
+STATUS rtpPacketHeaderToString(PRtpPacket, PCHAR, UINT32);
 
 #ifdef __cplusplus
 }

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -631,6 +631,113 @@ TEST_F(RtpFunctionalityTest, twccPayload)
     EXPECT_EQ(0, ptr[3]);
 }
 
+// --------------- rtpPacketHeaderToString -----------------
+
+TEST_F(RtpFunctionalityTest, rtpPacketHeaderToString_invalidParameters)
+{
+    CHAR buffer[100] = {0};
+    UINT32 bufferLen = SIZEOF(buffer);
+
+    BYTE payload[] = {0x00, 0x01, 0x02, 0x03};
+    BYTE rawbytes[1024] = {0};
+    PBYTE ptr = reinterpret_cast<PBYTE>(&rawbytes);
+    PRtpPacket pRtpPacket = NULL;
+    PRtpPacket pParsedPacket = NULL;
+    UINT16 twccSeqNum = 9876;
+    UINT8 twccExtId = 5;
+    UINT32 extpayload = TWCC_PAYLOAD(twccExtId, twccSeqNum);
+    UINT32 packetLen = 0;
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRtpPacket(2, FALSE, TRUE, 0, FALSE, 96, 1, 1000, 0xDEADBEEF, NULL,
+                              TWCC_EXT_PROFILE, SIZEOF(UINT32), reinterpret_cast<PBYTE>(&extpayload),
+                              payload, SIZEOF(payload), &pRtpPacket));
+
+    // Check invalid arguments
+    EXPECT_EQ(STATUS_NULL_ARG, rtpPacketHeaderToString(NULL, buffer, bufferLen));
+    EXPECT_EQ(STATUS_NULL_ARG, rtpPacketHeaderToString(pRtpPacket, NULL, bufferLen));
+    EXPECT_EQ(STATUS_INVALID_ARG_LEN, rtpPacketHeaderToString(pRtpPacket, buffer, 0));
+
+    freeRtpPacket(&pRtpPacket);
+}
+
+TEST_F(RtpFunctionalityTest, rtpPacketHeaderToString_zeroBufferWhenTooSmall)
+{
+    CHAR buffer[6];
+    SNPRINTF(buffer, SIZEOF(buffer), "Hello");
+
+    BYTE payload[] = {0x00, 0x01, 0x02, 0x03};
+    BYTE rawbytes[1024] = {0};
+    PBYTE ptr = reinterpret_cast<PBYTE>(&rawbytes);
+    PRtpPacket pRtpPacket = NULL;
+    PRtpPacket pParsedPacket = NULL;
+    UINT16 twccSeqNum = 9876;
+    UINT8 twccExtId = 5;
+    UINT32 extpayload = TWCC_PAYLOAD(twccExtId, twccSeqNum);
+    UINT32 packetLen = 0;
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRtpPacket(2, FALSE, TRUE, 0, FALSE, 96, 1, 1000, 0xDEADBEEF, NULL,
+                              TWCC_EXT_PROFILE, SIZEOF(UINT32), reinterpret_cast<PBYTE>(&extpayload),
+                              payload, SIZEOF(payload), &pRtpPacket));
+
+    // It should clear the buffer when it's too small to avoid partial strings
+    EXPECT_EQ(STATUS_BUFFER_TOO_SMALL, rtpPacketHeaderToString(pRtpPacket, buffer, SIZEOF(buffer)));
+    EXPECT_STREQ("", buffer);
+
+    freeRtpPacket(&pRtpPacket);
+}
+
+TEST_F(RtpFunctionalityTest, twccExtensionRoundTrip)
+{
+    BYTE payload[] = {0x00, 0x01, 0x02, 0x03};
+    BYTE rawbytes[1024] = {0};
+    PBYTE ptr = reinterpret_cast<PBYTE>(&rawbytes);
+    PRtpPacket pRtpPacket = NULL;
+    PRtpPacket pParsedPacket = NULL;
+    UINT16 twccSeqNum = 9876;
+    UINT8 twccExtId = 5;
+    UINT32 extpayload = TWCC_PAYLOAD(twccExtId, twccSeqNum);
+    UINT32 packetLen = 0;
+    CHAR packetToString[10000];
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRtpPacket(2, FALSE, TRUE, 0, FALSE, 96, 1, 1000, 0xDEADBEEF, NULL,
+                              TWCC_EXT_PROFILE, SIZEOF(UINT32), reinterpret_cast<PBYTE>(&extpayload),
+                              payload, SIZEOF(payload), &pRtpPacket));
+
+    // Serialize to bytes
+    EXPECT_EQ(STATUS_SUCCESS, createBytesFromRtpPacket(pRtpPacket, NULL, &packetLen));
+    EXPECT_TRUE(packetLen <= SIZEOF(rawbytes));
+    EXPECT_EQ(STATUS_SUCCESS, createBytesFromRtpPacket(pRtpPacket, ptr, &packetLen));
+
+    // Parse back from bytes
+    EXPECT_EQ(STATUS_SUCCESS, createRtpPacketFromBytes(ptr, packetLen, &pParsedPacket));
+
+    // Verify TWCC extension survived the round trip
+    EXPECT_TRUE(pParsedPacket->header.extension);
+    EXPECT_EQ(TWCC_EXT_PROFILE, pParsedPacket->header.extensionProfile);
+    EXPECT_EQ(SIZEOF(UINT32), pParsedPacket->header.extensionLength);
+    EXPECT_EQ(twccSeqNum, TWCC_SEQNUM(pParsedPacket->header.extensionPayload));
+
+    // Verify the ext ID is preserved in the payload
+    EXPECT_EQ(twccExtId, (pParsedPacket->header.extensionPayload[0] >> 4));
+
+    // Check the toString output
+    EXPECT_EQ(STATUS_SUCCESS, rtpPacketHeaderToString(pParsedPacket, packetToString, SIZEOF(packetToString)));
+    DLOGD("toString output: %s", packetToString);
+
+    // Contains the expected parameters
+    EXPECT_NE(std::string::npos, std::string(packetToString).find("X=1")); // header extension is present
+    EXPECT_NE(std::string::npos, std::string(packetToString).find("extProfile=0xbede")); // 1-byte header extension
+    EXPECT_NE(std::string::npos, std::string(packetToString).find("twccExtId=5")); // ext ID
+    EXPECT_NE(std::string::npos, std::string(packetToString).find("twccSeqNum=9876")); // seqNum part of TWCC
+
+    freeRtpPacket(&pRtpPacket);
+    pParsedPacket->pRawPacket = NULL;
+    freeRtpPacket(&pParsedPacket);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -729,7 +729,7 @@ TEST_F(RtpFunctionalityTest, twccExtensionRoundTrip)
 
     // Contains the expected parameters
     EXPECT_NE(std::string::npos, std::string(packetToString).find("X=1")); // header extension is present
-    EXPECT_NE(std::string::npos, std::string(packetToString).find("extProfile=0xbede")); // 1-byte header extension
+    EXPECT_NE(std::string::npos, std::string(packetToString).find("extProfile=0xBEDE")); // 1-byte header extension
     EXPECT_NE(std::string::npos, std::string(packetToString).find("twccExtId=5")); // ext ID
     EXPECT_NE(std::string::npos, std::string(packetToString).find("twccSeqNum=9876")); // seqNum part of TWCC
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added new optional logs (default=OFF) to print RTP headers, timestamps, and timing information for the following transmission (Tx) operations:
  - Write frame
  - SRTP encrypt
  - Socket Send
 - Implemented a configurable logging frequency to throttle logging output to prevent logging from becoming a bottleneck
 - Cached the value of the parsed environment variable values as to not need to re-compute the static value for every log

*Why was it changed?*
- Adding more observability to the SDK, making it easier to troubleshoot and debug issues related to timestamps

*How was it changed?*
- Added the new environment variables to enable or disable the logs.
- Added the string construction/concatenation/formatting into the conditional to prevent running when disabled
- Cached the value of the environment variable parsed values into the KvsPeerConnection (SDK-internal struct)

*What testing was done for the changes?*
- Ran it locally and checked the timestamps to confirm the logging frequency is working as expected:

<details><summary>Interval=1000ms</summary>

```sh
export AWS_KVS_LOG_LEVEL=2
export KVS_DEBUG_LOG_SENDER_RECEIVER_REPORTS=OFF
export KVS_DEBUG_LOG_RTP_PACKETS=OFF
export KVS_DEBUG_LOG_EXTRA_TX_TIMING_INFO=ON
export KVS_DEBUG_FRAME_TIMING_FREQUENCY_MS=1000
./samples/kvsWebrtcClientMaster demo-channel-7
```
```c
2026-03-30 15:06:57.625 DEBUG   writeFrame(): VIDEO SENT: [non-KEY], pts_ms=8160, rtpTs=734400, packets=5 (1086-1090), bytes=1239, discarded=0, wallClock_ms=1774883217625, srtpDuration=0.04 ms, socketWriteDuration=0.05 ms
2026-03-30 15:06:57.652 DEBUG   writeFrame(): AUDIO SENT: pts_ms=6080, rtpTs=291840, packets=1 (303-303), bytes=170, discarded=0, wallClock_ms=1774883217652, srtpDuration=0.00 ms, socketWriteDuration=0.02 ms
2026-03-30 15:06:58.654 DEBUG   writeFrame(): AUDIO SENT: pts_ms=6780, rtpTs=325440, packets=1 (338-338), bytes=170, discarded=0, wallClock_ms=1774883218654, srtpDuration=0.01 ms, socketWriteDuration=0.06 ms
2026-03-30 15:06:58.660 DEBUG   writeFrame(): VIDEO SENT: [non-KEY], pts_ms=9200, rtpTs=827999, packets=6 (1226-1231), bytes=1543, discarded=0, wallClock_ms=1774883218660, srtpDuration=0.04 ms, socketWriteDuration=0.06 ms
2026-03-30 15:06:59.684 DEBUG   writeFrame(): AUDIO SENT: pts_ms=7460, rtpTs=358079, packets=1 (372-372), bytes=170, discarded=0, wallClock_ms=1774883219684, srtpDuration=0.02 ms, socketWriteDuration=0.06 ms
2026-03-30 15:06:59.697 DEBUG   writeFrame(): VIDEO SENT: [non-KEY], pts_ms=10240, rtpTs=921599, packets=6 (1376-1381), bytes=1596, discarded=0, wallClock_ms=1774883219697, srtpDuration=0.05 ms, socketWriteDuration=0.06 ms
2026-03-30 15:06:59.902 WARN    iceAgentSendPacket(): iceAgentSendPacket(): iceUtilsSendData took 5 ms, bufLen=42, relay=no
2026-03-30 15:07:00.695 DEBUG   writeFrame(): AUDIO SENT: pts_ms=8180, rtpTs=392639, packets=1 (408-408), bytes=170, discarded=0, wallClock_ms=1774883220695, srtpDuration=0.01 ms, socketWriteDuration=0.04 ms
2026-03-30 15:07:00.700 DEBUG   writeFrame(): VIDEO SENT: [non-KEY], pts_ms=11240, rtpTs=1011599, packets=6 (1519-1524), bytes=1806, discarded=0, wallClock_ms=1774883220700, srtpDuration=0.04 ms, socketWriteDuration=0.06 ms
```

</details>

<details><summary>Interval=1000ms</summary>

```sh
export AWS_KVS_LOG_LEVEL=2
export KVS_DEBUG_LOG_SENDER_RECEIVER_REPORTS=OFF
export KVS_DEBUG_LOG_RTP_PACKETS=OFF
export KVS_DEBUG_LOG_EXTRA_TX_TIMING_INFO=ON
export KVS_DEBUG_FRAME_TIMING_FREQUENCY_MS=5000
./samples/kvsWebrtcClientMaster demo-channel-7
```
```c
2026-03-30 15:10:43.889 DEBUG   writeFrame(): AUDIO SENT: pts_ms=3640, rtpTs=174719, packets=1 (181-181), bytes=170, discarded=0, wallClock_ms=1774883443889, srtpDuration=0.03 ms, socketWriteDuration=0.41 ms
2026-03-30 15:10:43.890 DEBUG   writeFrame(): VIDEO SENT: [non-KEY], pts_ms=5040, rtpTs=453599, packets=10 (664-673), bytes=6561, discarded=0, wallClock_ms=1774883443890, srtpDuration=0.25 ms, socketWriteDuration=0.14 ms
2026-03-30 15:10:48.889 DEBUG   writeFrame(): AUDIO SENT: pts_ms=7120, rtpTs=341759, packets=1 (355-355), bytes=170, discarded=0, wallClock_ms=1774883448889, srtpDuration=0.05 ms, socketWriteDuration=0.02 ms
2026-03-30 15:10:48.926 DEBUG   writeFrame(): VIDEO SENT: [non-KEY], pts_ms=10080, rtpTs=907199, packets=7 (1352-1358), bytes=2724, discarded=0, wallClock_ms=1774883448926, srtpDuration=0.18 ms, socketWriteDuration=0.17 ms
2026-03-30 15:10:53.890 DEBUG   writeFrame(): AUDIO SENT: pts_ms=10720, rtpTs=514559, packets=1 (535-535), bytes=170, discarded=0, wallClock_ms=1774883453890, srtpDuration=0.01 ms, socketWriteDuration=0.04 ms
2026-03-30 15:10:53.926 DEBUG   writeFrame(): VIDEO SENT: [non-KEY], pts_ms=15080, rtpTs=1357200, packets=7 (2039-2045), bytes=3027, discarded=0, wallClock_ms=1774883453926, srtpDuration=0.08 ms, socketWriteDuration=0.10 ms
2026-03-30 15:10:58.890 DEBUG   writeFrame(): AUDIO SENT: pts_ms=14420, rtpTs=692159, packets=1 (720-720), bytes=170, discarded=0, wallClock_ms=1774883458890, srtpDuration=0.01 ms, socketWriteDuration=0.02 ms
2026-03-30 15:10:58.927 DEBUG   writeFrame(): VIDEO SENT: [non-KEY], pts_ms=20080, rtpTs=1807199, packets=7 (2739-2745), bytes=3065, discarded=0, wallClock_ms=1774883458927, srtpDuration=0.16 ms, socketWriteDuration=0.12 ms
```

</details>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
