### PR TITLE
esp_port: Expose API for creating data channels and skip video media lines in offer if capture callback is not provided

### DIFF
--- a/esp_port/components/app_webrtc/include/app_webrtc.h
+++ b/esp_port/components/app_webrtc/include/app_webrtc.h
@@ -292,6 +292,21 @@ int app_webrtc_send_msg_to_signaling(webrtc_message_t *message);
 int app_webrtc_trigger_offer(char *pPeerId);
 
 /**
+ * @brief Create a data channel on the active peer session for @p peer_id.
+ *
+ * The channel's onOpen callback (from app_webrtc_config_t.data_channel_config
+ * or the session-level config) fires when DCEP negotiation completes.
+ *
+ * @param[in] peer_id  Peer identifier — must match an active session.
+ * @param[in] label    UTF-8 channel label (e.g. "control").
+ * @param[in] ordered  true for reliable/ordered SCTP semantics.
+ * @return WEBRTC_STATUS_SUCCESS on success, error otherwise.
+ */
+WEBRTC_STATUS app_webrtc_create_data_channel(const char *peer_id,
+                                             const char *label,
+                                             bool ordered);
+
+/**
  * @brief Get ICE servers configuration from the WebRTC application
  *
  * This function retrieves the ICE server configuration that was obtained from

--- a/esp_port/components/app_webrtc/src/app_webrtc.c
+++ b/esp_port/components/app_webrtc/src/app_webrtc.c
@@ -7,6 +7,7 @@
 
 #include "app_webrtc.h"
 #include "app_webrtc_internal.h"
+#include <com/amazonaws/kinesis/video/webrtcclient/Include.h>
 #include "webrtc_mem_utils.h"
 #include "esp_work_queue.h"
 
@@ -2654,6 +2655,70 @@ CleanUp:
     if (STATUS_FAILED(retStatus)) {
         ESP_LOGE(TAG, "Failed to set data channel callbacks: 0x%08" PRIx32, (UINT32) retStatus);
     }
+    return retStatus;
+}
+
+/**
+ * @brief Find an active streaming session by peer ID.
+ *
+ * Walks the streaming session list guarded by streamingSessionListReadLock.
+ * Returns NULL if no session matches or if app_webrtc isn't initialized.
+ */
+static PAppWebRTCSession find_session_by_peer_id(const char *peer_id)
+{
+    if (peer_id == NULL || gSampleConfiguration == NULL) {
+        return NULL;
+    }
+
+    PAppWebRTCSession match = NULL;
+    MUTEX_LOCK(gSampleConfiguration->streamingSessionListReadLock);
+    for (UINT32 i = 0; i < gSampleConfiguration->streamingSessionCount; i++) {
+        PAppWebRTCSession s = gSampleConfiguration->webrtcSessionList[i];
+        if (s != NULL && STRCMP(s->peerId, peer_id) == 0) {
+            match = s;
+            break;
+        }
+    }
+    MUTEX_UNLOCK(gSampleConfiguration->streamingSessionListReadLock);
+    return match;
+}
+
+/**
+ * @brief Create a data channel on the active peer session for @p peer_id.
+ */
+WEBRTC_STATUS app_webrtc_create_data_channel(const char *peer_id,
+                                             const char *label,
+                                             bool ordered)
+{
+    ENTERS();
+    WEBRTC_STATUS retStatus = WEBRTC_STATUS_SUCCESS;
+
+    CHK(peer_id != NULL && label != NULL && label[0] != '\0', WEBRTC_STATUS_NULL_ARG);
+    CHK(gWebRtcAppConfig.peer_connection_if != NULL &&
+        gWebRtcAppConfig.peer_connection_if->create_data_channel != NULL,
+        WEBRTC_STATUS_INVALID_OPERATION);
+
+    PAppWebRTCSession pSession = find_session_by_peer_id(peer_id);
+    if (pSession == NULL || pSession->interface_session_handle == NULL) {
+        ESP_LOGE(TAG, "No active session for peer: %s", peer_id);
+        CHK(FALSE, WEBRTC_STATUS_INVALID_OPERATION);
+    }
+
+    RtcDataChannelInit dcInit;
+    MEMSET(&dcInit, 0x00, SIZEOF(RtcDataChannelInit));
+    dcInit.ordered = ordered ? TRUE : FALSE;
+    NULLABLE_SET_EMPTY(dcInit.maxPacketLifeTime);
+    NULLABLE_SET_EMPTY(dcInit.maxRetransmits);
+
+    void *pChannel = NULL;
+    retStatus = gWebRtcAppConfig.peer_connection_if->create_data_channel(
+        pSession->interface_session_handle, label, &dcInit, &pChannel);
+
+CleanUp:
+    if (WEBRTC_STATUS_FAILED(retStatus)) {
+        ESP_LOGE(TAG, "app_webrtc_create_data_channel failed: 0x%08x", retStatus);
+    }
+    LEAVES();
     return retStatus;
 }
 

--- a/esp_port/components/kvs_webrtc/src/kvs_media.c
+++ b/esp_port/components/kvs_webrtc/src/kvs_media.c
@@ -916,6 +916,10 @@ STATUS kvs_media_start_reception(kvs_pc_session_t* session, kvs_media_config_t* 
     // Setup media players
     CHK_STATUS(kvs_media_setup_players(session, config));
 
+    // Register per-transceiver frame callbacks so inbound RTP reaches the
+    // video/audio player interfaces.
+    CHK_STATUS(kvs_media_setup_frame_callbacks(session));
+
     // Start receive thread if needed
     if (config->receive_media && !session->receive_thread_started) {
         CHK_STATUS(THREAD_CREATE_EX_EXT(&session->receive_audio_video_tid, "kvs_receiveAV", 8 * 1024, TRUE,
@@ -1051,15 +1055,15 @@ STATUS kvs_media_setup_frame_callbacks(kvs_pc_session_t* session)
         goto CleanUp;
     }
 
-    // Set up video frame callback
+    // Set up video frame callback (only when the transceiver exists — audio-only
+    // configurations skip the video transceiver entirely in kvs_setupMediaTracks).
     if (session->video_transceiver == NULL) {
-        ESP_LOGW(TAG, "video_transceiver is NULL for peer: %s - cannot set up video callback", session->peer_id);
-        CHK(FALSE, retStatus);  // Return error to retry later
+        ESP_LOGD(TAG, "video_transceiver is NULL for peer: %s - skipping video callback", session->peer_id);
+    } else {
+        CHK_STATUS(transceiverOnFrame(session->video_transceiver,
+                                      POINTER_TO_HANDLE(session),
+                                      kvs_media_video_frame_handler));
     }
-
-    CHK_STATUS(transceiverOnFrame(session->video_transceiver,
-                                  POINTER_TO_HANDLE(session),
-                                  kvs_media_video_frame_handler));
 
     // Set up audio frame callback
     if (session->audio_transceiver == NULL) {

--- a/esp_port/components/kvs_webrtc/src/kvs_webrtc.c
+++ b/esp_port/components/kvs_webrtc/src/kvs_webrtc.c
@@ -1775,29 +1775,36 @@ static STATUS kvs_setupMediaTracks(kvs_pc_session_t* session)
 
     ESP_LOGI(TAG, "Setting up media tracks for peer: %s", session->peer_id);
 
+    BOOL hasVideo = (session->client->config.video_capture != NULL);
+
     // Add supported codecs from configuration
-    CHK_STATUS(addSupportedCodec(session->peer_connection, session->client->config.video_codec));
+    if (hasVideo) {
+        CHK_STATUS(addSupportedCodec(session->peer_connection, session->client->config.video_codec));
+    }
     CHK_STATUS(addSupportedCodec(session->peer_connection, session->client->config.audio_codec));
 
-    // Add video transceiver (match legacy identifiers for compatibility)
-    videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
-    videoTrack.codec = session->client->config.video_codec;
-    videoRtpTransceiverInit.direction = session->client->config.receive_media
-        ? RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV
-        : RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;
-    STRCPY(videoTrack.streamId, "myKvsVideoStream");
-    STRCPY(videoTrack.trackId, "myVideoTrack");
-    CHK_STATUS(addTransceiver(session->peer_connection, &videoTrack, &videoRtpTransceiverInit, &session->video_transceiver));
+    // Add video transceiver only when video capture is available
+    if (hasVideo) {
+        videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        videoTrack.codec = session->client->config.video_codec;
+        videoRtpTransceiverInit.direction = session->client->config.receive_media
+            ? RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV
+            : RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;
+        STRCPY(videoTrack.streamId, "myKvsVideoStream");
+        STRCPY(videoTrack.trackId, "myVideoTrack");
+        CHK_STATUS(addTransceiver(session->peer_connection, &videoTrack, &videoRtpTransceiverInit, &session->video_transceiver));
 
-    // Set up bandwidth estimation for video transceiver
-    CHK_STATUS(transceiverOnBandwidthEstimation(session->video_transceiver, POINTER_TO_HANDLE(session), kvs_videoBandwidthEstimationHandler));
+        // Set up bandwidth estimation for video transceiver
+        CHK_STATUS(transceiverOnBandwidthEstimation(session->video_transceiver, POINTER_TO_HANDLE(session), kvs_videoBandwidthEstimationHandler));
+    } else {
+        ESP_LOGI(TAG, "Skipping video transceiver (no video capture configured)");
+    }
 
-    // Add audio transceiver (match legacy identifiers for compatibility)
+    // Add audio transceiver
     audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
     audioTrack.codec = session->client->config.audio_codec;
     audioRtpTransceiverInit.direction = session->client->config.receive_media
         ? RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV
-
         : RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;
     STRCPY(audioTrack.streamId, "myKvsVideoStream");
     STRCPY(audioTrack.trackId, "myAudioTrack");


### PR DESCRIPTION
- If an application wants to use the WebRTC SDK for application involving only audio streaming, the SDK is still including the video lines in the SDP offer.
- Check if video_capture callbacks are provided. If not, don't include the video lines in the SDP offer
- Earlier there was no provision to create data channels using the SDK. Data channels could be used only if the other peer created them.
- This PR exposes a function which creates a data channel with the specified label, peerId, and reliability.
- Additionally it includes a bugfix wherein the audio/video frame callbacks were not being set if we are the ones sending offer.