### PR TITLE
Address TSan Warnings in Turn Connection Shutdown

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -206,6 +206,11 @@ STATUS freeIceAgent(PIceAgent* ppIceAgent)
 
     pIceAgent = *ppIceAgent;
 
+    // Join the listener thread first so it is no longer accessing any sockets
+    if (pIceAgent->pConnectionListener != NULL) {
+        CHK_LOG_ERR(freeConnectionListener(&pIceAgent->pConnectionListener));
+    }
+
     if (pIceAgent->localCandidates != NULL) {
         CHK_STATUS(doubleListGetHeadNode(pIceAgent->localCandidates, &pCurNode));
         while (pCurNode != NULL) {
@@ -216,10 +221,6 @@ STATUS freeIceAgent(PIceAgent* ppIceAgent)
                 CHK_LOG_ERR(freeTurnConnection(&pIceCandidate->pTurnConnection));
             }
         }
-    }
-
-    if (pIceAgent->pConnectionListener != NULL) {
-        CHK_LOG_ERR(freeConnectionListener(&pIceAgent->pConnectionListener));
     }
 
     if (pIceAgent->iceCandidatePairs != NULL) {

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -208,6 +208,16 @@ STATUS freeIceAgent(PIceAgent* ppIceAgent)
 
     // Join the listener thread first so it is no longer accessing any sockets
     if (pIceAgent->pConnectionListener != NULL) {
+        if (pIceAgent->localCandidates != NULL) {
+            CHK_STATUS(doubleListGetHeadNode(pIceAgent->localCandidates, &pCurNode));
+            while (pCurNode != NULL) {
+                pIceCandidate = (PIceCandidate) pCurNode->data;
+                pCurNode = pCurNode->pNext;
+                if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_RELAYED && pIceCandidate->pTurnConnection != NULL) {
+                    pIceCandidate->pTurnConnection->pConnectionListener = NULL;
+                }
+            }
+        }
         CHK_LOG_ERR(freeConnectionListener(&pIceAgent->pConnectionListener));
     }
 

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -169,7 +169,9 @@ STATUS freeTurnConnection(PTurnConnection* ppTurnConnection)
     }
     // shutdown control channel
     if (pTurnConnection->pControlChannel) {
-        CHK_LOG_ERR(connectionListenerRemoveConnection(pTurnConnection->pConnectionListener, pTurnConnection->pControlChannel));
+        if (pTurnConnection->pConnectionListener != NULL) {
+            CHK_LOG_ERR(connectionListenerRemoveConnection(pTurnConnection->pConnectionListener, pTurnConnection->pControlChannel));
+        }
         CHK_LOG_ERR(freeSocketConnection(&pTurnConnection->pControlChannel));
     }
 

--- a/tst/TurnConnectionFunctionalityTest.cpp
+++ b/tst/TurnConnectionFunctionalityTest.cpp
@@ -81,8 +81,8 @@ class TurnConnectionFunctionalityTest : public WebRtcClientTestBase {
     VOID freeTestTurnConnection()
     {
         EXPECT_TRUE(pTurnConnection != NULL);
-        EXPECT_EQ(STATUS_SUCCESS, freeTurnConnection(&pTurnConnection));
         EXPECT_EQ(STATUS_SUCCESS, freeConnectionListener(&pConnectionListener));
+        EXPECT_EQ(STATUS_SUCCESS, freeTurnConnection(&pTurnConnection));
         timerQueueFree(&timerQueueHandle);
         deinitializeSignalingClient();
     }

--- a/tst/TurnConnectionFunctionalityTest.cpp
+++ b/tst/TurnConnectionFunctionalityTest.cpp
@@ -82,6 +82,7 @@ class TurnConnectionFunctionalityTest : public WebRtcClientTestBase {
     {
         EXPECT_TRUE(pTurnConnection != NULL);
         EXPECT_EQ(STATUS_SUCCESS, freeConnectionListener(&pConnectionListener));
+        pTurnConnection->pConnectionListener = NULL;
         EXPECT_EQ(STATUS_SUCCESS, freeTurnConnection(&pTurnConnection));
         timerQueueFree(&timerQueueHandle);
         deinitializeSignalingClient();


### PR DESCRIPTION
*Issue #, if available:*
- Thread Sanitizer CI reporting race condition: 
  - https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/23520398553/job/68462306252
  - https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/23766003690/job/69245515548?pr=2250

*What was changed?*
- Shutdown order in `freeIceAgent()` (IceAgent.c) and `freeTestTurnConnection()` (TurnConnectionFunctionalityTest.cpp) was changed to call `freeConnectionListener()` and NULL out any references to `ConnectionListener` in TurnConnection before calling `freeTurnConnection()`.
- Added a NULL check in `freeTurnConnection()` (TurnConnection.c): on pConnectionListener before calling connectionListenerRemoveConnection, so it skips the call if the listener was already freed.

*Why was it changed?*
- Race condition between `connectionListenerReceiveDataRoutine()` (ConnectionListener.c) and `freeSocketConnection()` (SocketConnection.c).

The [ConnectionListener](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/b6396850a47bfc07d421663519b4b4b119084a28/src/source/Ice/ConnectionListener.c#L239) runs a background thread that polls sockets for data. Each loop iteration:
1. Takes the ConnectionListener lock, [copies socket pointers into a local array](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/b6396850a47bfc07d421663519b4b4b119084a28/src/source/Ice/ConnectionListener.c#L282), sets inUse = TRUE, unlocks
2. Calls poll() — blocks up to 200ms waiting for data
3. If data ready: checks socketConnectionIsClosed(), calls recvfrom(), processes data via callbacks
4. Sets inUse = FALSE
5. Loops back to step 1

The teardown order (in both the TurnConnectionFunctionalityTest.cpp and [freeIceAgent.c](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/b6396850a47bfc07d421663519b4b4b119084a28/src/source/Ice/TurnConnection.c#L150)) was:
1. freeTurnConnection → connectionListenerRemoveConnection (marks socket closed, removes from array) → freeSocketConnection (spins on inUse with 1-second timeout, then closes fd,
destroys mutex, frees TLS, frees struct)
2. freeConnectionListener (sets terminate = TRUE, kicks poll, joins thread)

The listener thread could be mid-iteration (step 2 or 3 above) when freeSocketConnection runs. It already has the socket in its local copy. The inUse spin-wait can timeout after 1 second. If it times out, it proceeds to close() and free() while the listener is still in recvfrom() or accessing the socket's fields. TSAN detected this as close() racing with recvfrom(), free() racing with field reads, and pthreadmutexdestroy racing with pthreadmutexunlock.

*How was it changed?*
- Reorder to perform the following first before calling `freeTurnConnection()`:
  - Calls `freeConnectionListener()` first which sets terminate = TRUE, kicks poll, joins thread. Background thread that polls sockets no longer exists.
  - NULL out any references to ConnectionListener now that it is free'd to prevent any dangling pointers.
- Call `freeTurnConnection()`, which will skip calling `connectionListenerRemoveConnection` (which calls `freeSocketConnection`) due to the newly added NULL check on ConnectionListener.

*What testing was done for the changes?*
- Encountered no TSAN warnings after running 100 iterations of `TurnConnectionFunctionalityTest.turnConnectionShutdownCompleteBeforeTimeout` in a Linux environment after previously encountering warnings on ~50/100 runs prior to this change
- CI/CD should pass
- Reran Address, Thread, and Undefined Behavior Sanitizer CI/CD 3 times with no issue:
  - https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/24646394867/job/72131687023?pr=2253

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
