### PR TITLE
General improvements v2

### DIFF
--- a/src/source/Crypto/Dtls.c
+++ b/src/source/Crypto/Dtls.c
@@ -85,6 +85,37 @@ CleanUp:
     return retStatus;
 }
 
+STATUS dtlsSessionCopyOptions(PDtlsSession pDtlsSession, PDtlsSessionOptions pDtlsSessionOptions)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 hostnameLen = 0;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+
+    pDtlsSession->validationMode = DTLS_SESSION_VALIDATION_MODE_RELAXED;
+    pDtlsSession->pExpectedServerHostname = NULL;
+
+    CHK(pDtlsSessionOptions != NULL, retStatus);
+
+    pDtlsSession->validationMode = pDtlsSessionOptions->validationMode;
+    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        CHK(pDtlsSessionOptions->pExpectedServerHostname != NULL && pDtlsSessionOptions->pExpectedServerHostname[0] != '\0', STATUS_INVALID_ARG);
+        hostnameLen = (UINT32) STRLEN(pDtlsSessionOptions->pExpectedServerHostname);
+#ifdef KVS_USE_MBEDTLS
+        CHK(hostnameLen <= MBEDTLS_SSL_MAX_HOST_NAME_LEN, STATUS_INVALID_ARG_LEN);
+#endif
+        pDtlsSession->pExpectedServerHostname = MEMCALLOC(hostnameLen + 1, SIZEOF(CHAR));
+        CHK(pDtlsSession->pExpectedServerHostname != NULL, STATUS_NOT_ENOUGH_MEMORY);
+        STRNCPY(pDtlsSession->pExpectedServerHostname, pDtlsSessionOptions->pExpectedServerHostname, hostnameLen);
+    }
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
 STATUS dtlsFillPseudoRandomBits(PBYTE pBuf, UINT32 bufSize)
 {
     ENTERS();

--- a/src/source/Crypto/Dtls.h
+++ b/src/source/Crypto/Dtls.h
@@ -66,8 +66,10 @@ typedef struct {
 } DtlsSessionCallbacks, *PDtlsSessionCallbacks;
 
 typedef enum {
-    DTLS_SESSION_VALIDATION_MODE_RELAXED,
-    DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER,
+    DTLS_SESSION_VALIDATION_MODE_RELAXED,       /* Default peer DTLS flow. Identity is validated later via SDP fingerprint and is not
+                                                 * recommended for production server certificate validation. */
+    DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, /* Require the remote certificate chain and hostname to validate against
+                                                 * pExpectedServerHostname and the configured CA bundle. */
 } DTLS_SESSION_VALIDATION_MODE;
 
 typedef struct {
@@ -201,6 +203,11 @@ STATUS dtlsSessionHandshakeInThread(PDtlsSession, BOOL);
 /******** Internal Functions **********/
 STATUS dtlsValidateRtcCertificates(PRtcCertificate, PUINT32);
 STATUS dtlsSessionChangeState(PDtlsSession, RTC_DTLS_TRANSPORT_STATE);
+/**
+ * Copy DTLS validation options into the session, defaulting to relaxed validation when options are omitted.
+ * Strict server validation requires a non-empty expected hostname.
+ */
+STATUS dtlsSessionCopyOptions(PDtlsSession, PDtlsSessionOptions);
 
 STATUS dtlsFillPseudoRandomBits(PBYTE, UINT32);
 

--- a/src/source/Crypto/Dtls.h
+++ b/src/source/Crypto/Dtls.h
@@ -65,6 +65,16 @@ typedef struct {
     DtlsSessionOnStateChange stateChangeFn;
 } DtlsSessionCallbacks, *PDtlsSessionCallbacks;
 
+typedef enum {
+    DTLS_SESSION_VALIDATION_MODE_RELAXED,
+    DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER,
+} DTLS_SESSION_VALIDATION_MODE;
+
+typedef struct {
+    DTLS_SESSION_VALIDATION_MODE validationMode;
+    PCHAR pExpectedServerHostname;
+} DtlsSessionOptions, *PDtlsSessionOptions;
+
 // DtlsKeyingMaterial is information extracted via https://tools.ietf.org/html/rfc5705
 // also includes the use_srtp value from Handshake
 typedef struct {
@@ -118,6 +128,9 @@ struct __DtlsSession {
     RTC_DTLS_TRANSPORT_STATE state;
     DTLS_HANDSHAKE_STATE handshakeState;
     MUTEX sslLock;
+    volatile ATOMIC_BOOL remoteCertVerificationFailed;
+    DTLS_SESSION_VALIDATION_MODE validationMode;
+    PCHAR pExpectedServerHostname;
 
 #ifdef KVS_USE_OPENSSL
     volatile ATOMIC_BOOL sslInitFinished;
@@ -138,6 +151,7 @@ struct __DtlsSession {
     mbedtls_ctr_drbg_context ctrDrbg;
     mbedtls_ssl_config sslCtxConfig;
     mbedtls_ssl_context sslCtx;
+    mbedtls_x509_crt trustedCaCert;
     DtlsSessionCertificateInfo certificates[MAX_RTCCONFIGURATION_CERTIFICATES];
 #else
 #error "A Crypto implementation is required."
@@ -156,6 +170,7 @@ struct __DtlsSession {
  * @return STATUS - status of operation
  */
 STATUS createDtlsSession(PDtlsSessionCallbacks, TIMER_QUEUE_HANDLE, INT32, BOOL, PRtcCertificate, PDtlsSession*);
+STATUS createDtlsSessionWithOptions(PDtlsSessionCallbacks, TIMER_QUEUE_HANDLE, INT32, BOOL, PRtcCertificate, PDtlsSessionOptions, PDtlsSession*);
 
 /**
  * Free DTLS session. Not thread safe.

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -72,13 +72,22 @@ STATUS dtlsSessionCheckRemoteCertificateVerification(PDtlsSession pDtlsSession)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
+    UINT32 verifyResult = 0;
 
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    verifyResult = (UINT32) mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx);
     CHK(mbedtls_ssl_get_peer_cert(&pDtlsSession->sslCtx) != NULL, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
-    CHK(mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx) == 0, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    CHK(verifyResult == 0, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    DLOGD("DTLS strict server certificate verification passed for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname, KVS_CA_CERT_PATH);
 
 CleanUp:
+    if (retStatus == STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED && pDtlsSession != NULL &&
+        pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        DLOGW("DTLS strict server certificate verification failed for %s. mbedTLS verify flags: 0x%08x",
+              pDtlsSession->pExpectedServerHostname != NULL ? pDtlsSession->pExpectedServerHostname : "(null)", verifyResult);
+    }
+
     CHK_LOG_ERR(retStatus);
     LEAVES();
     return retStatus;
@@ -87,13 +96,20 @@ CleanUp:
 STATUS dtlsSessionGetCertificateVerificationFailureStatus(PDtlsSession pDtlsSession, INT32 sslRet)
 {
     STATUS retStatus = STATUS_SUCCESS;
+    UINT32 verifyResult = 0;
 
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
-    CHK(sslRet == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED || mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx) != 0,
-        STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    verifyResult = (UINT32) mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx);
+    CHK(sslRet == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED || verifyResult != 0, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
 
 CleanUp:
+    if (retStatus == STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED && pDtlsSession != NULL &&
+        pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        DLOGW("DTLS strict server certificate verification failed for %s during handshake processing. mbedTLS verify flags: 0x%08x, sslRet: %d",
+              pDtlsSession->pExpectedServerHostname != NULL ? pDtlsSession->pExpectedServerHostname : "(null)", verifyResult, sslRet);
+    }
+
     return retStatus;
 }
 
@@ -419,6 +435,8 @@ STATUS dtlsSessionStart(PDtlsSession pDtlsSession, BOOL isServer)
                                     MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT) == 0,
         STATUS_CREATE_SSL_FAILED);
     if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        DLOGD("Configuring strict DTLS server certificate validation for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname,
+              KVS_CA_CERT_PATH);
         mbedtls_ssl_conf_ca_chain(&pDtlsSession->sslCtxConfig, &pDtlsSession->trustedCaCert, NULL);
         mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_REQUIRED);
     } else {

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -101,7 +101,9 @@ STATUS dtlsSessionGetCertificateVerificationFailureStatus(PDtlsSession pDtlsSess
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
     verifyResult = (UINT32) mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx);
-    CHK(sslRet == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED || verifyResult != 0, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    if (sslRet == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED || verifyResult != 0) {
+        retStatus = STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED;
+    }
 
 CleanUp:
     if (retStatus == STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED && pDtlsSession != NULL &&

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -63,8 +63,7 @@ static STATUS dtlsSessionConfigureRemoteCertificateValidation(PDtlsSession pDtls
 
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
-    DLOGD("Configuring strict DTLS server certificate validation for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname,
-          KVS_CA_CERT_PATH);
+    DLOGD("Configuring strict DTLS server certificate validation for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname, KVS_CA_CERT_PATH);
     mbedtls_ssl_conf_ca_chain(&pDtlsSession->sslCtxConfig, &pDtlsSession->trustedCaCert, NULL);
     mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_REQUIRED);
 

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -1,6 +1,8 @@
 #define LOG_CLASS "DTLS_mbedtls"
 #include "../Include_i.h"
 
+#define DTLS_MBEDTLS_ERROR_STRING_BUFFER_SIZE 128
+
 /**  https://tools.ietf.org/html/rfc5764#section-4.1.2 */
 mbedtls_ssl_srtp_profile DTLS_SRTP_SUPPORTED_PROFILES[] = {
     MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_80,
@@ -8,13 +10,14 @@ mbedtls_ssl_srtp_profile DTLS_SRTP_SUPPORTED_PROFILES[] = {
     MBEDTLS_TLS_SRTP_UNSET,
 };
 
+// Backend-local helper: only the mbedTLS DTLS implementation parses the shared CA bundle directly.
 static STATUS dtlsReadAndParseCACertificate(PDtlsSession pDtlsSession)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     UINT64 certLen = 0;
     PBYTE certBuf = NULL;
-    CHAR errBuf[128];
+    CHAR errBuf[DTLS_MBEDTLS_ERROR_STRING_BUFFER_SIZE];
     INT32 sslRet;
 
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
@@ -38,29 +41,48 @@ CleanUp:
     return retStatus;
 }
 
-STATUS dtlsSessionCopyOptions(PDtlsSession pDtlsSession, PDtlsSessionOptions pDtlsSessionOptions)
+static STATUS dtlsSessionLoadTrustedCaCertificate(PDtlsSession pDtlsSession)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT32 hostnameLen = 0;
 
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    CHK_STATUS(dtlsReadAndParseCACertificate(pDtlsSession));
 
-    pDtlsSession->validationMode = DTLS_SESSION_VALIDATION_MODE_RELAXED;
-    pDtlsSession->pExpectedServerHostname = NULL;
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
 
-    if (pDtlsSessionOptions == NULL) {
-        CHK(FALSE, retStatus);
-    }
+static STATUS dtlsSessionConfigureRemoteCertificateValidation(PDtlsSession pDtlsSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
 
-    pDtlsSession->validationMode = pDtlsSessionOptions->validationMode;
-    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
-        CHK(pDtlsSessionOptions->pExpectedServerHostname != NULL && pDtlsSessionOptions->pExpectedServerHostname[0] != '\0', STATUS_INVALID_ARG);
-        hostnameLen = (UINT32) STRLEN(pDtlsSessionOptions->pExpectedServerHostname);
-        pDtlsSession->pExpectedServerHostname = MEMCALLOC(hostnameLen + 1, SIZEOF(CHAR));
-        CHK(pDtlsSession->pExpectedServerHostname != NULL, STATUS_NOT_ENOUGH_MEMORY);
-        STRNCPY(pDtlsSession->pExpectedServerHostname, pDtlsSessionOptions->pExpectedServerHostname, hostnameLen);
-    }
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    DLOGD("Configuring strict DTLS server certificate validation for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname,
+          KVS_CA_CERT_PATH);
+    mbedtls_ssl_conf_ca_chain(&pDtlsSession->sslCtxConfig, &pDtlsSession->trustedCaCert, NULL);
+    mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_REQUIRED);
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+static STATUS dtlsSessionConfigureExpectedServerHostname(PDtlsSession pDtlsSession, BOOL isServer)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+    CHK(!isServer, retStatus);
+    CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    CHK(mbedtls_ssl_set_hostname(&pDtlsSession->sslCtx, pDtlsSession->pExpectedServerHostname) == 0, STATUS_SSL_CTX_CREATION_FAILED);
 
 CleanUp:
     CHK_LOG_ERR(retStatus);
@@ -77,6 +99,8 @@ STATUS dtlsSessionCheckRemoteCertificateVerification(PDtlsSession pDtlsSession)
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
     verifyResult = (UINT32) mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx);
+    // Strict mode requires both a parsed peer certificate and a clean verify result.
+    // The verify flags alone do not guarantee that the handshake surfaced a peer certificate.
     CHK(mbedtls_ssl_get_peer_cert(&pDtlsSession->sslCtx) != NULL, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
     CHK(verifyResult == 0, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
     DLOGD("DTLS strict server certificate verification passed for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname, KVS_CA_CERT_PATH);
@@ -95,11 +119,15 @@ CleanUp:
 
 STATUS dtlsSessionGetCertificateVerificationFailureStatus(PDtlsSession pDtlsSession, INT32 sslRet)
 {
+    ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     UINT32 verifyResult = 0;
 
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    // Handshake/read/write paths can fail before the normal post-handshake certificate check runs.
+    // Re-reading the verify flags here preserves the certificate failure reason even if the peer cert
+    // is not yet available through the completed-handshake path.
     verifyResult = (UINT32) mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx);
     if (sslRet == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED || verifyResult != 0) {
         retStatus = STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED;
@@ -112,6 +140,8 @@ CleanUp:
               pDtlsSession->pExpectedServerHostname != NULL ? pDtlsSession->pExpectedServerHostname : "(null)", verifyResult, sslRet);
     }
 
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
     return retStatus;
 }
 
@@ -152,12 +182,8 @@ STATUS createDtlsSessionWithOptions(PDtlsSessionCallbacks pDtlsSessionCallbacks,
     pDtlsSession->timerId = MAX_UINT32;
     pDtlsSession->sslLock = MUTEX_CREATE(TRUE);
     pDtlsSession->dtlsSessionCallbacks = *pDtlsSessionCallbacks;
-    pDtlsSession->validationMode = DTLS_SESSION_VALIDATION_MODE_RELAXED;
-    pDtlsSession->pExpectedServerHostname = NULL;
     CHK_STATUS(dtlsSessionCopyOptions(pDtlsSession, pDtlsSessionOptions));
-    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
-        CHK_STATUS(dtlsReadAndParseCACertificate(pDtlsSession));
-    }
+    CHK_STATUS(dtlsSessionLoadTrustedCaCertificate(pDtlsSession));
     if (certificateBits == 0) {
         certificateBits = GENERATED_CERTIFICATE_BITS;
     }
@@ -436,15 +462,10 @@ STATUS dtlsSessionStart(PDtlsSession pDtlsSession, BOOL isServer)
     CHK(mbedtls_ssl_config_defaults(&pDtlsSession->sslCtxConfig, isServer ? MBEDTLS_SSL_IS_SERVER : MBEDTLS_SSL_IS_CLIENT,
                                     MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT) == 0,
         STATUS_CREATE_SSL_FAILED);
-    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
-        DLOGD("Configuring strict DTLS server certificate validation for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname,
-              KVS_CA_CERT_PATH);
-        mbedtls_ssl_conf_ca_chain(&pDtlsSession->sslCtxConfig, &pDtlsSession->trustedCaCert, NULL);
-        mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_REQUIRED);
-    } else {
-        // No need to verify in the default peer DTLS path since the certificate will be verified through SDP later.
-        mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_OPTIONAL);
-    }
+    // Relaxed mode is only intended for peer DTLS flows that verify identity later via SDP fingerprint.
+    // Do not use it when production-style server certificate validation is required.
+    mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_OPTIONAL);
+    CHK_STATUS(dtlsSessionConfigureRemoteCertificateValidation(pDtlsSession));
     mbedtls_ssl_conf_rng(&pDtlsSession->sslCtxConfig, mbedtls_ctr_drbg_random, &pDtlsSession->ctrDrbg);
 
     for (i = 0; i < pDtlsSession->certificateCount; i++) {
@@ -461,9 +482,7 @@ STATUS dtlsSessionStart(PDtlsSession pDtlsSession, BOOL isServer)
     CHK(mbedtls_ssl_setup(&pDtlsSession->sslCtx, &pDtlsSession->sslCtxConfig) == 0, STATUS_SSL_CTX_CREATION_FAILED);
     mbedtls_ssl_set_mtu(&pDtlsSession->sslCtx, DEFAULT_MTU_SIZE_BYTES);
     mbedtls_ssl_set_bio(&pDtlsSession->sslCtx, pDtlsSession, dtlsSessionSendCallback, dtlsSessionReceiveCallback, NULL);
-    if (!isServer && pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
-        CHK(mbedtls_ssl_set_hostname(&pDtlsSession->sslCtx, pDtlsSession->pExpectedServerHostname) == 0, STATUS_SSL_CTX_CREATION_FAILED);
-    }
+    CHK_STATUS(dtlsSessionConfigureExpectedServerHostname(pDtlsSession, isServer));
 
 #if !MBEDTLS_BEFORE_V3
     mbedtls_ssl_set_export_keys_cb(&pDtlsSession->sslCtx, dtlsSessionKeyDerivationCallback, pDtlsSession);

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -8,8 +8,105 @@ mbedtls_ssl_srtp_profile DTLS_SRTP_SUPPORTED_PROFILES[] = {
     MBEDTLS_TLS_SRTP_UNSET,
 };
 
+static STATUS dtlsReadAndParseCACertificate(PDtlsSession pDtlsSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 certLen = 0;
+    PBYTE certBuf = NULL;
+    CHAR errBuf[128];
+    INT32 sslRet;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+
+    CHK_STATUS(readFile(KVS_CA_CERT_PATH, FALSE, NULL, &certLen));
+    CHK(certLen > 0, STATUS_INVALID_CERT_PATH_LENGTH);
+    certBuf = (PBYTE) MEMCALLOC(1, certLen + 1);
+    CHK(certBuf != NULL, STATUS_NOT_ENOUGH_MEMORY);
+    CHK_STATUS(readFile(KVS_CA_CERT_PATH, FALSE, certBuf, &certLen));
+    sslRet = mbedtls_x509_crt_parse(&pDtlsSession->trustedCaCert, certBuf, (SIZE_T) (certLen + 1));
+    if (sslRet != 0) {
+        mbedtls_strerror(sslRet, errBuf, SIZEOF(errBuf));
+        DLOGE("mbedtls_x509_crt_parse failed: %s", errBuf);
+    }
+    CHK(sslRet == 0, STATUS_INVALID_CA_CERT_PATH);
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    SAFE_MEMFREE(certBuf);
+    LEAVES();
+    return retStatus;
+}
+
+STATUS dtlsSessionCopyOptions(PDtlsSession pDtlsSession, PDtlsSessionOptions pDtlsSessionOptions)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 hostnameLen = 0;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+
+    pDtlsSession->validationMode = DTLS_SESSION_VALIDATION_MODE_RELAXED;
+    pDtlsSession->pExpectedServerHostname = NULL;
+
+    if (pDtlsSessionOptions == NULL) {
+        CHK(FALSE, retStatus);
+    }
+
+    pDtlsSession->validationMode = pDtlsSessionOptions->validationMode;
+    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        CHK(pDtlsSessionOptions->pExpectedServerHostname != NULL && pDtlsSessionOptions->pExpectedServerHostname[0] != '\0', STATUS_INVALID_ARG);
+        hostnameLen = (UINT32) STRLEN(pDtlsSessionOptions->pExpectedServerHostname);
+        pDtlsSession->pExpectedServerHostname = MEMCALLOC(hostnameLen + 1, SIZEOF(CHAR));
+        CHK(pDtlsSession->pExpectedServerHostname != NULL, STATUS_NOT_ENOUGH_MEMORY);
+        STRNCPY(pDtlsSession->pExpectedServerHostname, pDtlsSessionOptions->pExpectedServerHostname, hostnameLen);
+    }
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+STATUS dtlsSessionCheckRemoteCertificateVerification(PDtlsSession pDtlsSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    CHK(mbedtls_ssl_get_peer_cert(&pDtlsSession->sslCtx) != NULL, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    CHK(mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx) == 0, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+STATUS dtlsSessionGetCertificateVerificationFailureStatus(PDtlsSession pDtlsSession, INT32 sslRet)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    CHK(sslRet == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED || mbedtls_ssl_get_verify_result(&pDtlsSession->sslCtx) != 0,
+        STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+
+CleanUp:
+    return retStatus;
+}
+
 STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEUE_HANDLE timerQueueHandle, INT32 certificateBits,
                          BOOL generateRSACertificate, PRtcCertificate pRtcCertificates, PDtlsSession* ppDtlsSession)
+{
+    return createDtlsSessionWithOptions(pDtlsSessionCallbacks, timerQueueHandle, certificateBits, generateRSACertificate, pRtcCertificates, NULL,
+                                        ppDtlsSession);
+}
+
+STATUS createDtlsSessionWithOptions(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEUE_HANDLE timerQueueHandle, INT32 certificateBits,
+                                    BOOL generateRSACertificate, PRtcCertificate pRtcCertificates, PDtlsSessionOptions pDtlsSessionOptions,
+                                    PDtlsSession* ppDtlsSession)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -28,6 +125,7 @@ STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEU
     mbedtls_ctr_drbg_init(&pDtlsSession->ctrDrbg);
     mbedtls_ssl_config_init(&pDtlsSession->sslCtxConfig);
     mbedtls_ssl_init(&pDtlsSession->sslCtx);
+    mbedtls_x509_crt_init(&pDtlsSession->trustedCaCert);
     mbedtls_ctr_drbg_set_prediction_resistance(&pDtlsSession->ctrDrbg, MBEDTLS_CTR_DRBG_PR_ON);
     CHK(mbedtls_ctr_drbg_seed(&pDtlsSession->ctrDrbg, mbedtls_entropy_func, &pDtlsSession->entropy, NULL, 0) == 0, STATUS_CREATE_SSL_FAILED);
 
@@ -36,6 +134,12 @@ STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEU
     pDtlsSession->timerId = MAX_UINT32;
     pDtlsSession->sslLock = MUTEX_CREATE(TRUE);
     pDtlsSession->dtlsSessionCallbacks = *pDtlsSessionCallbacks;
+    pDtlsSession->validationMode = DTLS_SESSION_VALIDATION_MODE_RELAXED;
+    pDtlsSession->pExpectedServerHostname = NULL;
+    CHK_STATUS(dtlsSessionCopyOptions(pDtlsSession, pDtlsSessionOptions));
+    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        CHK_STATUS(dtlsReadAndParseCACertificate(pDtlsSession));
+    }
     if (certificateBits == 0) {
         certificateBits = GENERATED_CERTIFICATE_BITS;
     }
@@ -94,6 +198,7 @@ STATUS freeDtlsSession(PDtlsSession* ppDtlsSession)
         pCertInfo = pDtlsSession->certificates + i;
         freeCertificateAndKey(&pCertInfo->cert, &pCertInfo->privateKey);
     }
+    mbedtls_x509_crt_free(&pDtlsSession->trustedCaCert);
     mbedtls_entropy_free(&pDtlsSession->entropy);
     mbedtls_ctr_drbg_free(&pDtlsSession->ctrDrbg);
     mbedtls_ssl_config_free(&pDtlsSession->sslCtxConfig);
@@ -103,6 +208,7 @@ STATUS freeDtlsSession(PDtlsSession* ppDtlsSession)
     if (IS_VALID_MUTEX_VALUE(pDtlsSession->sslLock)) {
         MUTEX_FREE(pDtlsSession->sslLock);
     }
+    SAFE_MEMFREE(pDtlsSession->pExpectedServerHostname);
     SAFE_MEMFREE(*ppDtlsSession);
 
 CleanUp:
@@ -205,6 +311,7 @@ STATUS dtlsTransmissionTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 
     switch (handshakeStatus) {
         case 0:
             // success.
+            CHK_STATUS(dtlsSessionCheckRemoteCertificateVerification(pDtlsSession));
             CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_CONNECTED));
             CHK(FALSE, STATUS_TIMER_QUEUE_STOP_SCHEDULING);
             break;
@@ -216,8 +323,9 @@ STATUS dtlsTransmissionTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 
             break;
         default:
             LOG_MBEDTLS_ERROR("mbedtls_ssl_handshake", handshakeStatus);
+            retStatus = dtlsSessionGetCertificateVerificationFailureStatus(pDtlsSession, handshakeStatus);
             CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_FAILED));
-            CHK(FALSE, STATUS_TIMER_QUEUE_STOP_SCHEDULING);
+            CHK(FALSE, STATUS_FAILED(retStatus) ? retStatus : STATUS_TIMER_QUEUE_STOP_SCHEDULING);
             break;
     }
 
@@ -310,8 +418,13 @@ STATUS dtlsSessionStart(PDtlsSession pDtlsSession, BOOL isServer)
     CHK(mbedtls_ssl_config_defaults(&pDtlsSession->sslCtxConfig, isServer ? MBEDTLS_SSL_IS_SERVER : MBEDTLS_SSL_IS_CLIENT,
                                     MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT) == 0,
         STATUS_CREATE_SSL_FAILED);
-    // no need to verify since the certificate will be verified through SDP later
-    mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_OPTIONAL);
+    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        mbedtls_ssl_conf_ca_chain(&pDtlsSession->sslCtxConfig, &pDtlsSession->trustedCaCert, NULL);
+        mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_REQUIRED);
+    } else {
+        // No need to verify in the default peer DTLS path since the certificate will be verified through SDP later.
+        mbedtls_ssl_conf_authmode(&pDtlsSession->sslCtxConfig, MBEDTLS_SSL_VERIFY_OPTIONAL);
+    }
     mbedtls_ssl_conf_rng(&pDtlsSession->sslCtxConfig, mbedtls_ctr_drbg_random, &pDtlsSession->ctrDrbg);
 
     for (i = 0; i < pDtlsSession->certificateCount; i++) {
@@ -328,6 +441,9 @@ STATUS dtlsSessionStart(PDtlsSession pDtlsSession, BOOL isServer)
     CHK(mbedtls_ssl_setup(&pDtlsSession->sslCtx, &pDtlsSession->sslCtxConfig) == 0, STATUS_SSL_CTX_CREATION_FAILED);
     mbedtls_ssl_set_mtu(&pDtlsSession->sslCtx, DEFAULT_MTU_SIZE_BYTES);
     mbedtls_ssl_set_bio(&pDtlsSession->sslCtx, pDtlsSession, dtlsSessionSendCallback, dtlsSessionReceiveCallback, NULL);
+    if (!isServer && pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        CHK(mbedtls_ssl_set_hostname(&pDtlsSession->sslCtx, pDtlsSession->pExpectedServerHostname) == 0, STATUS_SSL_CTX_CREATION_FAILED);
+    }
 
 #if !MBEDTLS_BEFORE_V3
     mbedtls_ssl_set_export_keys_cb(&pDtlsSession->sslCtx, dtlsSessionKeyDerivationCallback, pDtlsSession);
@@ -398,7 +514,12 @@ STATUS dtlsSessionProcessPacket(PDtlsSession pDtlsSession, PBYTE pData, PINT32 p
         } else {
             LOG_MBEDTLS_ERROR("mbedtls_ssl_read", sslRet);
             readBytes = 0;
-            retStatus = STATUS_INTERNAL_ERROR;
+            retStatus = dtlsSessionGetCertificateVerificationFailureStatus(pDtlsSession, sslRet);
+            if (STATUS_FAILED(retStatus)) {
+                CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_FAILED));
+            } else {
+                retStatus = STATUS_INTERNAL_ERROR;
+            }
             iterate = FALSE;
         }
     }
@@ -408,6 +529,7 @@ STATUS dtlsSessionProcessPacket(PDtlsSession pDtlsSession, PBYTE pData, PINT32 p
 #else
     if (pDtlsSession->sslCtx.MBEDTLS_PRIVATE(state) == MBEDTLS_SSL_HANDSHAKE_OVER) {
 #endif
+        CHK_STATUS(dtlsSessionCheckRemoteCertificateVerification(pDtlsSession));
         CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_CONNECTED));
     }
 

--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -64,6 +64,7 @@ STATUS dtlsSessionConfigureRemoteCertificateValidation(PDtlsSession pDtlsSession
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
     CHK(pDtlsSession->pExpectedServerHostname != NULL && pDtlsSession->pExpectedServerHostname[0] != '\0', STATUS_INVALID_ARG);
+    DLOGD("Configuring strict DTLS server certificate validation for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname, KVS_CA_CERT_PATH);
     CHK(SSL_CTX_load_verify_locations(pDtlsSession->pSslCtx, KVS_CA_CERT_PATH, NULL) == 1, STATUS_SSL_CTX_CREATION_FAILED);
     CHK(SSL_set_tlsext_host_name(pDtlsSession->pSsl, pDtlsSession->pExpectedServerHostname) == 1, STATUS_SSL_CTX_CREATION_FAILED);
     CHK(SSL_set1_host(pDtlsSession->pSsl, pDtlsSession->pExpectedServerHostname) == 1, STATUS_SSL_CTX_CREATION_FAILED);
@@ -79,16 +80,25 @@ STATUS dtlsSessionCheckRemoteCertificateVerification(PDtlsSession pDtlsSession)
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     X509* pRemoteCertificate = NULL;
+    LONG verifyResult = X509_V_OK;
 
     CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
     CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    verifyResult = SSL_get_verify_result(pDtlsSession->pSsl);
     CHK(!ATOMIC_LOAD_BOOL(&pDtlsSession->remoteCertVerificationFailed), STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
     CHK((pRemoteCertificate = SSL_get_peer_certificate(pDtlsSession->pSsl)) != NULL, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
-    CHK(SSL_get_verify_result(pDtlsSession->pSsl) == X509_V_OK, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    CHK(verifyResult == X509_V_OK, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    DLOGD("DTLS strict server certificate verification passed for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname, KVS_CA_CERT_PATH);
 
 CleanUp:
     if (pRemoteCertificate != NULL) {
         X509_free(pRemoteCertificate);
+    }
+
+    if (retStatus == STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED && pDtlsSession != NULL &&
+        pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        DLOGW("DTLS strict server certificate verification failed for %s. OpenSSL verify result: %ld",
+              pDtlsSession->pExpectedServerHostname != NULL ? pDtlsSession->pExpectedServerHostname : "(null)", verifyResult);
     }
 
     CHK_LOG_ERR(retStatus);
@@ -150,6 +160,8 @@ STATUS dtlsTransmissionTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 
     locked = TRUE;
 
     if (ATOMIC_LOAD_BOOL(&pDtlsSession->remoteCertVerificationFailed)) {
+        DLOGW("DTLS strict server certificate verification failed for %s during timer-driven handshake processing",
+              pDtlsSession->pExpectedServerHostname != NULL ? pDtlsSession->pExpectedServerHostname : "(null)");
         CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_FAILED));
         CHK(FALSE, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
     }
@@ -578,6 +590,8 @@ STATUS dtlsSessionHandshakeInThread(PDtlsSession pDtlsSession, BOOL isServer)
                         CHK_STATUS(dtlsCheckOutgoingDataBuffer(pDtlsSession));
                     } else {
                         if (ATOMIC_LOAD_BOOL(&pDtlsSession->remoteCertVerificationFailed)) {
+                            DLOGW("DTLS strict server certificate verification failed for %s during threaded handshake processing",
+                                  pDtlsSession->pExpectedServerHostname != NULL ? pDtlsSession->pExpectedServerHostname : "(null)");
                             CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_FAILED));
                             retStatus = STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED;
                             dtlsHandshakeErrored = TRUE;
@@ -760,6 +774,8 @@ STATUS dtlsSessionProcessPacket(PDtlsSession pDtlsSession, PBYTE pData, PINT32 p
         sslRet = SSL_read(pDtlsSession->pSsl, pData, *pDataLen);
 
         if (ATOMIC_LOAD_BOOL(&pDtlsSession->remoteCertVerificationFailed)) {
+            DLOGW("DTLS strict server certificate verification failed for %s while processing handshake packets",
+                  pDtlsSession->pExpectedServerHostname != NULL ? pDtlsSession->pExpectedServerHostname : "(null)");
             CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_FAILED));
             CHK(FALSE, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
         }

--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -1,13 +1,99 @@
 #define LOG_CLASS "DTLS_openssl"
 #include "../Include_i.h"
 
-// Allow all certificates since they are checked via fingerprint in SDP later
-// https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_verify.html
 INT32 dtlsCertificateVerifyCallback(INT32 preverify_ok, X509_STORE_CTX* ctx)
 {
-    UNUSED_PARAM(preverify_ok);
-    UNUSED_PARAM(ctx);
+    SSL* pSsl = NULL;
+    PDtlsSession pDtlsSession = NULL;
+
+    if (ctx != NULL) {
+        pSsl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+    }
+
+    if (pSsl != NULL) {
+        pDtlsSession = (PDtlsSession) SSL_get_app_data(pSsl);
+    }
+
+    if (pDtlsSession != NULL && pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        if (!preverify_ok) {
+            ATOMIC_STORE_BOOL(&pDtlsSession->remoteCertVerificationFailed, TRUE);
+        }
+
+        return preverify_ok;
+    }
+
+    // Allow all certificates in the default peer DTLS path since identity is verified later via SDP fingerprint.
     return 1;
+}
+
+STATUS dtlsSessionCopyOptions(PDtlsSession pDtlsSession, PDtlsSessionOptions pDtlsSessionOptions)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 hostnameLen = 0;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+
+    pDtlsSession->validationMode = DTLS_SESSION_VALIDATION_MODE_RELAXED;
+    pDtlsSession->pExpectedServerHostname = NULL;
+
+    if (pDtlsSessionOptions == NULL) {
+        CHK(FALSE, retStatus);
+    }
+
+    pDtlsSession->validationMode = pDtlsSessionOptions->validationMode;
+    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
+        CHK(pDtlsSessionOptions->pExpectedServerHostname != NULL && pDtlsSessionOptions->pExpectedServerHostname[0] != '\0', STATUS_INVALID_ARG);
+        hostnameLen = (UINT32) STRLEN(pDtlsSessionOptions->pExpectedServerHostname);
+        pDtlsSession->pExpectedServerHostname = MEMCALLOC(hostnameLen + 1, SIZEOF(CHAR));
+        CHK(pDtlsSession->pExpectedServerHostname != NULL, STATUS_NOT_ENOUGH_MEMORY);
+        STRNCPY(pDtlsSession->pExpectedServerHostname, pDtlsSessionOptions->pExpectedServerHostname, hostnameLen);
+    }
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+STATUS dtlsSessionConfigureRemoteCertificateValidation(PDtlsSession pDtlsSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    CHK(pDtlsSession->pExpectedServerHostname != NULL && pDtlsSession->pExpectedServerHostname[0] != '\0', STATUS_INVALID_ARG);
+    CHK(SSL_CTX_load_verify_locations(pDtlsSession->pSslCtx, KVS_CA_CERT_PATH, NULL) == 1, STATUS_SSL_CTX_CREATION_FAILED);
+    CHK(SSL_set_tlsext_host_name(pDtlsSession->pSsl, pDtlsSession->pExpectedServerHostname) == 1, STATUS_SSL_CTX_CREATION_FAILED);
+    CHK(SSL_set1_host(pDtlsSession->pSsl, pDtlsSession->pExpectedServerHostname) == 1, STATUS_SSL_CTX_CREATION_FAILED);
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+STATUS dtlsSessionCheckRemoteCertificateVerification(PDtlsSession pDtlsSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    X509* pRemoteCertificate = NULL;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER, retStatus);
+    CHK(!ATOMIC_LOAD_BOOL(&pDtlsSession->remoteCertVerificationFailed), STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    CHK((pRemoteCertificate = SSL_get_peer_certificate(pDtlsSession->pSsl)) != NULL, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    CHK(SSL_get_verify_result(pDtlsSession->pSsl) == X509_V_OK, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+
+CleanUp:
+    if (pRemoteCertificate != NULL) {
+        X509_free(pRemoteCertificate);
+    }
+
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
 }
 
 VOID acquireDtlsSession(PDtlsSession pDtlsSession)
@@ -63,7 +149,13 @@ STATUS dtlsTransmissionTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 
     MUTEX_LOCK(pDtlsSession->sslLock);
     locked = TRUE;
 
+    if (ATOMIC_LOAD_BOOL(&pDtlsSession->remoteCertVerificationFailed)) {
+        CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_FAILED));
+        CHK(FALSE, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    }
+
     if (SSL_is_init_finished(pDtlsSession->pSsl)) {
+        CHK_STATUS(dtlsSessionCheckRemoteCertificateVerification(pDtlsSession));
         CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_CONNECTED));
         ATOMIC_STORE_BOOL(&pDtlsSession->sslInitFinished, TRUE);
         CHK(FALSE, STATUS_TIMER_QUEUE_STOP_SCHEDULING);
@@ -287,6 +379,14 @@ CleanUp:
 STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEUE_HANDLE timerQueueHandle, INT32 certificateBits,
                          BOOL generateRSACertificate, PRtcCertificate pRtcCertificates, PDtlsSession* ppDtlsSession)
 {
+    return createDtlsSessionWithOptions(pDtlsSessionCallbacks, timerQueueHandle, certificateBits, generateRSACertificate, pRtcCertificates, NULL,
+                                        ppDtlsSession);
+}
+
+STATUS createDtlsSessionWithOptions(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEUE_HANDLE timerQueueHandle, INT32 certificateBits,
+                                    BOOL generateRSACertificate, PRtcCertificate pRtcCertificates, PDtlsSessionOptions pDtlsSessionOptions,
+                                    PDtlsSession* ppDtlsSession)
+{
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PDtlsSession pDtlsSession = NULL;
@@ -312,8 +412,10 @@ STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEU
     pDtlsSession->receivePacketCvar = CVAR_CREATE();
     ATOMIC_STORE_BOOL(&pDtlsSession->isStarted, FALSE);
     ATOMIC_STORE_BOOL(&pDtlsSession->sslInitFinished, FALSE);
+    ATOMIC_STORE_BOOL(&pDtlsSession->remoteCertVerificationFailed, FALSE);
 
     pDtlsSession->dtlsSessionCallbacks = *pDtlsSessionCallbacks;
+    CHK_STATUS(dtlsSessionCopyOptions(pDtlsSession, pDtlsSessionOptions));
 
     if (certificateBits == 0) {
         certificateBits = GENERATED_CERTIFICATE_BITS;
@@ -335,6 +437,8 @@ STATUS createDtlsSession(PDtlsSessionCallbacks pDtlsSessionCallbacks, TIMER_QUEU
 
     PROFILE_CALL(CHK_STATUS(createSslCtx(certInfos, pDtlsSession->certificateCount, &pDtlsSession->pSslCtx)), "Create SSL Context");
     PROFILE_CALL(CHK_STATUS(createSsl(pDtlsSession->pSslCtx, &pDtlsSession->pSsl)), "Create SSL session");
+    SSL_set_app_data(pDtlsSession->pSsl, pDtlsSession);
+    CHK_STATUS(dtlsSessionConfigureRemoteCertificateValidation(pDtlsSession));
 
     // Generate and store the certificate fingerprints
     CHK_STATUS(dtlsGenerateCertificateFingerprints(pDtlsSession, certInfos));
@@ -473,6 +577,12 @@ STATUS dtlsSessionHandshakeInThread(PDtlsSession pDtlsSession, BOOL isServer)
                         DLOGD("Handshake want READ/WRITE");
                         CHK_STATUS(dtlsCheckOutgoingDataBuffer(pDtlsSession));
                     } else {
+                        if (ATOMIC_LOAD_BOOL(&pDtlsSession->remoteCertVerificationFailed)) {
+                            CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_FAILED));
+                            retStatus = STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED;
+                            dtlsHandshakeErrored = TRUE;
+                            break;
+                        }
                         DLOGI("Failed to complete handshake..but let it go on");
                         // Handle other errors
                         LOG_OPENSSL_ERROR("SSL_do_handshake");
@@ -481,6 +591,7 @@ STATUS dtlsSessionHandshakeInThread(PDtlsSession pDtlsSession, BOOL isServer)
                 } else {
                     pDtlsSession->handshakeState = DTLS_STATE_HANDSHAKE_COMPLETED;
                     ATOMIC_STORE_BOOL(&pDtlsSession->sslInitFinished, TRUE);
+                    CHK_STATUS(dtlsSessionCheckRemoteCertificateVerification(pDtlsSession));
                     CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_CONNECTED));
                 }
                 pDtlsSession->handshakeState = DTLS_STATE_HANDSHAKE_IN_PROGRESS;
@@ -489,6 +600,7 @@ STATUS dtlsSessionHandshakeInThread(PDtlsSession pDtlsSession, BOOL isServer)
                 if (SSL_is_init_finished(pDtlsSession->pSsl)) {
                     pDtlsSession->handshakeState = DTLS_STATE_HANDSHAKE_COMPLETED;
                     ATOMIC_STORE_BOOL(&pDtlsSession->sslInitFinished, TRUE);
+                    CHK_STATUS(dtlsSessionCheckRemoteCertificateVerification(pDtlsSession));
                     CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_CONNECTED));
                 } else {
                     // We check for timeout here. If the timeout is 0, it is likely it
@@ -610,6 +722,7 @@ STATUS freeDtlsSession(PDtlsSession* ppDtlsSession)
         CVAR_FREE(pDtlsSession->receivePacketCvar);
     }
 
+    SAFE_MEMFREE(pDtlsSession->pExpectedServerHostname);
     SAFE_MEMFREE(pDtlsSession);
     *ppDtlsSession = NULL;
 
@@ -645,6 +758,11 @@ STATUS dtlsSessionProcessPacket(PDtlsSession pDtlsSession, PBYTE pData, PINT32 p
         // should clear error before SSL_read: https://stackoverflow.com/a/47218133
         ERR_clear_error();
         sslRet = SSL_read(pDtlsSession->pSsl, pData, *pDataLen);
+
+        if (ATOMIC_LOAD_BOOL(&pDtlsSession->remoteCertVerificationFailed)) {
+            CHK_STATUS(dtlsSessionChangeState(pDtlsSession, RTC_DTLS_TRANSPORT_STATE_FAILED));
+            CHK(FALSE, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+        }
 
         if (sslRet == 0 && SSL_get_error(pDtlsSession->pSsl, sslRet) == SSL_ERROR_ZERO_RETURN) {
             DLOGI("Detected DTLS close_notify alert");

--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -26,36 +26,6 @@ INT32 dtlsCertificateVerifyCallback(INT32 preverify_ok, X509_STORE_CTX* ctx)
     return 1;
 }
 
-STATUS dtlsSessionCopyOptions(PDtlsSession pDtlsSession, PDtlsSessionOptions pDtlsSessionOptions)
-{
-    ENTERS();
-    STATUS retStatus = STATUS_SUCCESS;
-    UINT32 hostnameLen = 0;
-
-    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
-
-    pDtlsSession->validationMode = DTLS_SESSION_VALIDATION_MODE_RELAXED;
-    pDtlsSession->pExpectedServerHostname = NULL;
-
-    if (pDtlsSessionOptions == NULL) {
-        CHK(FALSE, retStatus);
-    }
-
-    pDtlsSession->validationMode = pDtlsSessionOptions->validationMode;
-    if (pDtlsSession->validationMode == DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER) {
-        CHK(pDtlsSessionOptions->pExpectedServerHostname != NULL && pDtlsSessionOptions->pExpectedServerHostname[0] != '\0', STATUS_INVALID_ARG);
-        hostnameLen = (UINT32) STRLEN(pDtlsSessionOptions->pExpectedServerHostname);
-        pDtlsSession->pExpectedServerHostname = MEMCALLOC(hostnameLen + 1, SIZEOF(CHAR));
-        CHK(pDtlsSession->pExpectedServerHostname != NULL, STATUS_NOT_ENOUGH_MEMORY);
-        STRNCPY(pDtlsSession->pExpectedServerHostname, pDtlsSessionOptions->pExpectedServerHostname, hostnameLen);
-    }
-
-CleanUp:
-    CHK_LOG_ERR(retStatus);
-    LEAVES();
-    return retStatus;
-}
-
 STATUS dtlsSessionConfigureStrictHostnameValidation(PDtlsSession pDtlsSession)
 {
     ENTERS();

--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -56,6 +56,33 @@ CleanUp:
     return retStatus;
 }
 
+STATUS dtlsSessionConfigureStrictHostnameValidation(PDtlsSession pDtlsSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    X509_VERIFY_PARAM* pVerifyParam = NULL;
+
+    CHK(pDtlsSession != NULL, STATUS_NULL_ARG);
+    CHK(pDtlsSession->pExpectedServerHostname != NULL && pDtlsSession->pExpectedServerHostname[0] != '\0', STATUS_INVALID_ARG);
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+    CHK(SSL_set1_host(pDtlsSession->pSsl, pDtlsSession->pExpectedServerHostname) == 1, STATUS_SSL_CTX_CREATION_FAILED);
+#elif (OPENSSL_VERSION_NUMBER >= 0x10002000L)
+    pVerifyParam = SSL_get0_param(pDtlsSession->pSsl);
+    CHK(pVerifyParam != NULL, STATUS_SSL_CTX_CREATION_FAILED);
+    CHK(X509_VERIFY_PARAM_set1_host(pVerifyParam, pDtlsSession->pExpectedServerHostname, 0) == 1, STATUS_SSL_CTX_CREATION_FAILED);
+#else
+    DLOGW("Strict DTLS server hostname validation for %s is not supported with OpenSSL versions older than 1.0.2",
+          pDtlsSession->pExpectedServerHostname);
+    CHK(FALSE, STATUS_NOT_IMPLEMENTED);
+#endif
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
 STATUS dtlsSessionConfigureRemoteCertificateValidation(PDtlsSession pDtlsSession)
 {
     ENTERS();
@@ -67,7 +94,7 @@ STATUS dtlsSessionConfigureRemoteCertificateValidation(PDtlsSession pDtlsSession
     DLOGD("Configuring strict DTLS server certificate validation for %s using CA bundle %s", pDtlsSession->pExpectedServerHostname, KVS_CA_CERT_PATH);
     CHK(SSL_CTX_load_verify_locations(pDtlsSession->pSslCtx, KVS_CA_CERT_PATH, NULL) == 1, STATUS_SSL_CTX_CREATION_FAILED);
     CHK(SSL_set_tlsext_host_name(pDtlsSession->pSsl, pDtlsSession->pExpectedServerHostname) == 1, STATUS_SSL_CTX_CREATION_FAILED);
-    CHK(SSL_set1_host(pDtlsSession->pSsl, pDtlsSession->pExpectedServerHostname) == 1, STATUS_SSL_CTX_CREATION_FAILED);
+    CHK_STATUS(dtlsSessionConfigureStrictHostnameValidation(pDtlsSession));
 
 CleanUp:
     CHK_LOG_ERR(retStatus);

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1897,6 +1897,12 @@ STATUS iceAgentInitSrflxCandidate(PIceAgent pIceAgent)
         CHK_STATUS(createSocketConnection(pCandidate->ipAddress.family, KVS_SOCKET_PROTOCOL_UDP, &pCandidate->ipAddress,
                                           pIceServer->scheme == ICE_SERVER_SCHEME_STUNS ? pStunServerAddress : NULL, (UINT64) pIceAgent,
                                           incomingDataHandler, pIceAgent->kvsRtcConfiguration.sendBufSize, &pCandidate->pSocketConnection));
+        if (pIceServer->scheme == ICE_SERVER_SCHEME_STUNS) {
+            UINT32 hostnameLen = (UINT32) STRLEN(pIceServer->url);
+            pCandidate->pSocketConnection->hostname = (PCHAR) MEMCALLOC(1, hostnameLen + 1);
+            CHK(pCandidate->pSocketConnection->hostname != NULL, STATUS_NOT_ENOUGH_MEMORY);
+            STRNCPY(pCandidate->pSocketConnection->hostname, pIceServer->url, hostnameLen);
+        }
         ATOMIC_STORE_BOOL(&pCandidate->pSocketConnection->receiveData, TRUE);
         // connectionListener will free the pSocketConnection at the end.
         CHK_STATUS(connectionListenerAddConnection(pIceAgent->pConnectionListener, pCandidate->pSocketConnection));

--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -233,6 +233,7 @@ STATUS socketConnectionInitSecureConnection(PSocketConnection pSocketConnection,
     ENTERS();
     TlsSessionCallbacks callbacks;
     DtlsSessionCallbacks dtlsCallbacks;
+    DtlsSessionOptions dtlsOptions;
     STATUS retStatus = STATUS_SUCCESS;
     PTlsSession pTlsSessionToFree = NULL;
     PDtlsSession pDtlsSessionToFree = NULL;
@@ -257,11 +258,18 @@ STATUS socketConnectionInitSecureConnection(PSocketConnection pSocketConnection,
         CHK(IS_VALID_TIMER_QUEUE_HANDLE(timerQueueHandle), STATUS_INVALID_ARG);
 
         MEMSET(&dtlsCallbacks, 0x00, SIZEOF(dtlsCallbacks));
+        MEMSET(&dtlsOptions, 0x00, SIZEOF(dtlsOptions));
         dtlsCallbacks.outBoundPacketFnCustomData = dtlsCallbacks.stateChangeFnCustomData = (UINT64) pSocketConnection;
         dtlsCallbacks.outboundPacketFn = socketConnectionDtlsSessionOutBoundPacket;
         dtlsCallbacks.stateChangeFn = socketConnectionDtlsSessionOnStateChange;
+        dtlsOptions.validationMode = DTLS_SESSION_VALIDATION_MODE_RELAXED;
+        if (pSocketConnection->hostname != NULL && pSocketConnection->hostname[0] != '\0') {
+            dtlsOptions.validationMode = DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER;
+            dtlsOptions.pExpectedServerHostname = pSocketConnection->hostname;
+        }
 
-        CHK_STATUS(createDtlsSession(&dtlsCallbacks, timerQueueHandle, GENERATED_CERTIFICATE_BITS, FALSE, NULL, &pSocketConnection->pDtlsSession));
+        CHK_STATUS(createDtlsSessionWithOptions(&dtlsCallbacks, timerQueueHandle, GENERATED_CERTIFICATE_BITS, FALSE, NULL, &dtlsOptions,
+                                                &pSocketConnection->pDtlsSession));
         CHK_STATUS(dtlsSessionStart(pSocketConnection->pDtlsSession, isServer));
     }
     pSocketConnection->secureConnection = TRUE;

--- a/src/source/Ice/SocketConnection.h
+++ b/src/source/Ice/SocketConnection.h
@@ -46,7 +46,7 @@ struct __SocketConnection {
     UINT64 dataAvailableCallbackCustomData;
     UINT64 tlsHandshakeStartTime;
 
-    /* Hostname for TLS verification */
+    /* Hostname for TLS/DTLS verification */
     PCHAR hostname;
 };
 typedef struct __SocketConnection* PSocketConnection;

--- a/tst/DtlsFunctionalityTest.cpp
+++ b/tst/DtlsFunctionalityTest.cpp
@@ -71,7 +71,7 @@ class DtlsFunctionalityTest : public WebRtcClientTestBase {
 
         // In case of mbedtls it will be a black return of SUCCESS
 #ifdef KVS_USE_OPENSSL
-        if(useThread) {
+        if (useThread) {
             dtlsClientThread = std::thread(dtlsSessionHandshakeInThread, pClient, TRUE);
             dtlsServerThread = std::thread(dtlsSessionHandshakeInThread, pServer, FALSE);
         } else {
@@ -95,7 +95,7 @@ class DtlsFunctionalityTest : public WebRtcClientTestBase {
         *ppServer = pServer;
 
 #ifdef KVS_USE_OPENSSL
-        if(useThread) {
+        if (useThread) {
             dtlsClientThread.join();
             dtlsServerThread.join();
         }
@@ -130,7 +130,7 @@ TEST_F(DtlsFunctionalityTest, putApplicationDataWithVariedSizes)
     TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
     PBYTE pData = NULL;
     INT32 dataSizes[] = {
-        4,                      // very small packet
+        4,                            // very small packet
         DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
         DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
     };
@@ -160,7 +160,7 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizes)
     TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
     PBYTE pData = NULL;
     INT32 dataSizes[] = {
-        4,                      // very small packet
+        4,                            // very small packet
         DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
         DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
     };
@@ -192,9 +192,9 @@ TEST_F(DtlsFunctionalityTest, putApplicationDataWithVariedSizesInThread)
     TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
     PBYTE pData = NULL;
     INT32 dataSizes[] = {
-            4,                      // very small packet
-            DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
-            DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
+        4,                            // very small packet
+        DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
+        DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
     };
 
     EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
@@ -213,7 +213,7 @@ TEST_F(DtlsFunctionalityTest, putApplicationDataWithVariedSizesInThread)
     freeDtlsSession(&pClient);
     freeDtlsSession(&pServer);
     timerQueueFree(&timerQueueHandle);
-MEMFREE(pData);
+    MEMFREE(pData);
 }
 
 TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizesInThread)
@@ -222,9 +222,9 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizesInThread)
     TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
     PBYTE pData = NULL;
     INT32 dataSizes[] = {
-            4,                      // very small packet
-            DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
-            DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
+        4,                            // very small packet
+        DEFAULT_MTU_SIZE_BYTES - 200, // small packet but should be still under mtu
+        DEFAULT_MTU_SIZE_BYTES + 200, // big packet and bigger than even a jumbo frame
     };
     INT32 readDataSize;
 
@@ -232,7 +232,6 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizesInThread)
     EXPECT_EQ(STATUS_SUCCESS, createAndConnect(timerQueueHandle, &pClient, &pServer, TRUE));
     EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pServer, 0, outboundPacketFnNoop));
     EXPECT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pClient, 0, outboundPacketFnNoop));
-
 
     for (int i = 0; i < (INT32) ARRAY_SIZE(dataSizes); i++) {
         pData = (PBYTE) MEMREALLOC(pData, dataSizes[i]);
@@ -248,6 +247,117 @@ TEST_F(DtlsFunctionalityTest, processPacketWithVariedSizesInThread)
     MEMFREE(pData);
 }
 
+TEST_F(DtlsFunctionalityTest, strictServerValidationRejectsUntrustedServerCertificate)
+{
+    struct PacketContext {
+        std::mutex mtx;
+        std::queue<std::vector<BYTE>> queue;
+    };
+    struct SessionState {
+        std::atomic<int> state{RTC_DTLS_TRANSPORT_STATE_NEW};
+        std::atomic<SIZE_T> connectedCount{0};
+        std::atomic<SIZE_T> failedCount{0};
+    };
+
+    STATUS retStatus = STATUS_SUCCESS;
+    DtlsSessionCallbacks serverCallbacks, clientCallbacks;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    PDtlsSession pServer = NULL, pStrictClient = NULL;
+    UINT64 sleepDelay = 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    UINT64 timeout = 5 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    PacketContext clientInboundCtx, serverInboundCtx;
+    SessionState serverState, clientState;
+    CHAR expectedServerHostname[] = "stun.kinesisvideo-fips.us-gov-west-1.amazonaws.com";
+    DtlsSessionOptions strictOptions;
+
+    MEMSET(&serverCallbacks, 0x00, SIZEOF(serverCallbacks));
+    MEMSET(&clientCallbacks, 0x00, SIZEOF(clientCallbacks));
+    MEMSET(&strictOptions, 0x00, SIZEOF(strictOptions));
+
+    serverCallbacks.stateChangeFn = [](UINT64 customData, RTC_DTLS_TRANSPORT_STATE state) {
+        SessionState* pState = reinterpret_cast<SessionState*>(customData);
+        pState->state.store((int) state);
+        if (state == RTC_DTLS_TRANSPORT_STATE_CONNECTED) {
+            pState->connectedCount.fetch_add(1);
+        } else if (state == RTC_DTLS_TRANSPORT_STATE_FAILED) {
+            pState->failedCount.fetch_add(1);
+        }
+    };
+    serverCallbacks.stateChangeFnCustomData = (UINT64) &serverState;
+    clientCallbacks.stateChangeFn = serverCallbacks.stateChangeFn;
+    clientCallbacks.stateChangeFnCustomData = (UINT64) &clientState;
+
+    DtlsSessionOutboundPacketFunc outboundPacketFn = [](UINT64 customData, PBYTE pData, UINT32 dataLen) {
+        PacketContext* pCtx = reinterpret_cast<PacketContext*>(customData);
+        assert(pCtx != NULL);
+        assert(pData != NULL);
+        std::lock_guard<std::mutex> lock(pCtx->mtx);
+        pCtx->queue.push(std::vector<BYTE>(pData, pData + dataLen));
+    };
+
+    auto consumeMessages = [](PacketContext* pCtx, PDtlsSession pPeer) -> STATUS {
+        STATUS retStatus = STATUS_SUCCESS;
+        std::queue<std::vector<BYTE>> pendingMessages;
+
+        assert(pCtx != NULL);
+        assert(pPeer != NULL);
+
+        {
+            std::lock_guard<std::mutex> lock(pCtx->mtx);
+            pCtx->queue.swap(pendingMessages);
+        }
+
+        while (!pendingMessages.empty()) {
+            auto& msg = pendingMessages.front();
+            INT32 readLen = (INT32) msg.size();
+            CHK_STATUS(dtlsSessionProcessPacket(pPeer, (PBYTE) msg.data(), &readLen));
+            pendingMessages.pop();
+        }
+
+    CleanUp:
+        return retStatus;
+    };
+
+    strictOptions.validationMode = DTLS_SESSION_VALIDATION_MODE_STRICT_SERVER;
+    strictOptions.pExpectedServerHostname = expectedServerHostname;
+
+    ASSERT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    ASSERT_EQ(STATUS_SUCCESS, createDtlsSession(&serverCallbacks, timerQueueHandle, 0, FALSE, NULL, &pServer));
+    ASSERT_EQ(STATUS_SUCCESS, createDtlsSessionWithOptions(&clientCallbacks, timerQueueHandle, 0, FALSE, NULL, &strictOptions, &pStrictClient));
+
+    ASSERT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pServer, (UINT64) &clientInboundCtx, outboundPacketFn));
+    ASSERT_EQ(STATUS_SUCCESS, dtlsSessionOnOutBoundData(pStrictClient, (UINT64) &serverInboundCtx, outboundPacketFn));
+
+    ASSERT_EQ(STATUS_SUCCESS, dtlsSessionStart(pServer, TRUE));
+    ASSERT_EQ(STATUS_SUCCESS, dtlsSessionStart(pStrictClient, FALSE));
+
+    for (UINT64 duration = 0; duration < timeout && clientState.failedCount.load() == 0 && clientState.connectedCount.load() == 0;
+         duration += sleepDelay) {
+        STATUS clientConsumeStatus = STATUS_SUCCESS;
+
+        EXPECT_EQ(STATUS_SUCCESS, consumeMessages(&serverInboundCtx, pServer));
+        clientConsumeStatus = consumeMessages(&clientInboundCtx, pStrictClient);
+        EXPECT_TRUE(clientConsumeStatus == STATUS_SUCCESS || clientConsumeStatus == STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+        if (clientConsumeStatus == STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED) {
+            break;
+        }
+        THREAD_SLEEP(sleepDelay);
+    }
+
+    EXPECT_EQ(clientState.failedCount.load(), 1);
+    EXPECT_EQ(clientState.connectedCount.load(), 0);
+    EXPECT_EQ(clientState.state.load(), RTC_DTLS_TRANSPORT_STATE_FAILED);
+
+    if (pStrictClient != NULL) {
+        freeDtlsSession(&pStrictClient);
+    }
+    if (pServer != NULL) {
+        freeDtlsSession(&pServer);
+    }
+    if (IS_VALID_TIMER_QUEUE_HANDLE(timerQueueHandle)) {
+        timerQueueFree(&timerQueueHandle);
+    }
+}
 
 } // namespace webrtcclient
 } // namespace video

--- a/tst/DtlsFunctionalityTest.cpp
+++ b/tst/DtlsFunctionalityTest.cpp
@@ -334,8 +334,10 @@ TEST_F(DtlsFunctionalityTest, strictServerValidationRejectsUntrustedServerCertif
     for (UINT64 duration = 0; duration < timeout && clientState.failedCount.load() == 0 && clientState.connectedCount.load() == 0;
          duration += sleepDelay) {
         STATUS clientConsumeStatus = STATUS_SUCCESS;
+        STATUS serverConsumeStatus = STATUS_SUCCESS;
 
-        EXPECT_EQ(STATUS_SUCCESS, consumeMessages(&serverInboundCtx, pServer));
+        serverConsumeStatus = consumeMessages(&serverInboundCtx, pServer);
+        EXPECT_TRUE(serverConsumeStatus == STATUS_SUCCESS || serverConsumeStatus == STATUS_INTERNAL_ERROR);
         clientConsumeStatus = consumeMessages(&clientInboundCtx, pStrictClient);
         EXPECT_TRUE(clientConsumeStatus == STATUS_SUCCESS || clientConsumeStatus == STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
         if (clientConsumeStatus == STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED) {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Cleaned up git history (rebased these changes on top of the latest from develop branch)
- Added strict CA + hostname validation for the `stuns:` DTLS path while preserving the existing relaxed peer-DTLS/fingerprint flow.
- Added a GovCloud `stuns:` integration test for srflx gathering and a DTLS test that verifies strict validation rejects an untrusted server certificate.
- Made the OpenSSL hostname-verification path version-aware so older OpenSSL support is preserved.

*Why was it changed?*
- We wanted `stuns:` to fail closed on untrusted or misconfigured certificates and to add coverage that proves both the success and rejection paths.
- The OpenSSL follow-up keeps the new validation behavior without breaking older supported OpenSSL versions at compile time.

*How was it changed?*
- Added an internal DTLS validation mode/options path and used it only for `stuns:` sockets.
- Plumbed the parsed STUNS hostname through ICE/socket setup so DTLS can load the CA bundle, set SNI, and verify the expected hostname.
- Added explicit validation logging and version-gated OpenSSL hostname verification:
  - `>= 1.1.0`: `SSL_set1_host(...)`
  - `>= 1.0.2` and `< 1.1.0`: `X509_VERIFY_PARAM_set1_host(...)`
  - `< 1.0.2`: fail closed with `STATUS_NOT_IMPLEMENTED`

*What testing was done for the changes?*
- Added `IceFunctionalityTest.IceAgentGovCloudStunsCandidateGatheringTest`
- Added `DtlsFunctionalityTest.strictServerValidationRejectsUntrustedServerCertificate`
- Verified local formatting with `clang-format` / `git diff --check`
- Verified local OpenSSL build with `cmake --build build-test-openssl --target kvsWebrtcClient`
- GitHub Actions on the fork were used to validate the new integration/unit coverage and follow-up fixes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.