### PR TITLE
Samples: Defer cert pre-generation when there are active PeerConnections

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -1150,6 +1150,9 @@ STATUS pregenerateCertTimerCallback(UINT32 timerId, UINT64 currentTime, UINT64 c
         locked = TRUE;
     }
 
+    // Don't pre-generate certs when there are active streaming sessions to avoid impacting existing connections
+    CHK(pSampleConfiguration->streamingSessionCount == 0, retStatus);
+
     // Quick check if there is anything that needs to be done.
     CHK_STATUS(stackQueueGetCount(pSampleConfiguration->pregeneratedCertificates, &certCount));
     CHK(certCount != MAX_RTCCONFIGURATION_CERTIFICATES, retStatus);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added an early return in `pregenerateCertTimerCallback` that defers certificate pre-generation when there are active streaming sessions

*Why was it changed?*
- When a new peer connection is created, a pre-generated certificate is dequeued from the pre-generated certificate queue. The timer callback then attempts to refill the queue (almost) immediately. Certificate generation involves CPU-intensive key pair creation that can impact the performance of active peer connections (e.g., increased latency or jitter during media streaming), more noticeable in lower-powered devices.
- This change defers refilling the queue until after all streaming sessions have ended.

*How was it changed?*
-  Added a check for `pSampleConfiguration->streamingSessionCount == 0` before proceeding with cert generation in `samples/common/Common.c`. If sessions are active, the callback returns early and defers generation to a future timer invocation.

*What testing was done for the changes?*
- CI/CD
- Ran locally with an immediate viewer peerconnection after master start. Observed the "New certificate has been pre-generated and added to the queue" log only after the viewer left (not during).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
