### PR TITLE
Upgrade CI deps to latest

### DIFF
--- a/.github/workflows/cache-dualstack-test.yml
+++ b/.github/workflows/cache-dualstack-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -55,15 +55,15 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/cache-media-storage-reverse-test.yml
+++ b/.github/workflows/cache-media-storage-reverse-test.yml
@@ -27,15 +27,15 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/cache-media-storage-test.yml
+++ b/.github/workflows/cache-media-storage-test.yml
@@ -27,15 +27,15 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'aws-samples/amazon-kinesis-video-streams-demos'
           path: demos-repo
@@ -55,7 +55,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Setup credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -96,15 +96,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -153,9 +153,9 @@ jobs:
 #      contents: read
 #    steps:
 #      - name: Clone repository
-#        uses: actions/checkout@v4
+#        uses: actions/checkout@v6
 #      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
+#        uses: aws-actions/configure-aws-credentials@v6
 #        with:
 #          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
 #          aws-region: ${{ secrets.AWS_REGION }}
@@ -171,7 +171,7 @@ jobs:
 #          sudo apt-get -y install gdb
 #          sudo apt-get -y install libcurl4-openssl-dev
 #      - name: Setup cmake
-#        uses: jwlawson/actions-setup-cmake@v2
+#        uses: jwlawson/actions-setup-cmake@v2.2.0
 #        with:
 #          cmake-version: '3.x'
 #      - name: Build repository
@@ -198,7 +198,7 @@ jobs:
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           apk update
@@ -225,7 +225,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install deps
         run: |
           apt-get update
@@ -238,7 +238,7 @@ jobs:
           apt-get -y install gcc-4.4
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
@@ -250,7 +250,7 @@ jobs:
           make -j
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -293,7 +293,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -316,7 +316,7 @@ jobs:
           echo "CXX=clang++" >> $GITHUB_ENV
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
@@ -329,7 +329,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: ${{ matrix.container.test == 'ON' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -349,7 +349,7 @@ jobs:
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Move cloned repo to shorter path
         shell: powershell
         run: |
@@ -380,7 +380,7 @@ jobs:
       #     cmake .. -DLWS_HAVE_PTHREAD_H=1 -DLWS_EXT_PTHREAD_INCLUDE_DIR="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\include" -DLWS_EXT_PTHREAD_LIBRARIES="C:\\tools\\pthreads-w32-2-9-1-release\\Pre-built.2\\lib\\x64\\libpthreadGC2.a" -DLWS_WITH_MINIMAL_EXAMPLES=1 -DLWS_OPENSSL_INCLUDE_DIRS="C:\\Program Files\\OpenSSL\\include" -DLWS_OPENSSL_LIBRARIES="C:\\Program Files\\OpenSSL\\lib\\libssl.lib;C:\\Program Files\\OpenSSL\\lib\\libcrypto.lib"
       #     cmake --build . --config DEBUG
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
       - name: Build repository
@@ -390,7 +390,7 @@ jobs:
           git config --system core.longpaths true
           .github\build_windows_openssl.bat
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -405,7 +405,7 @@ jobs:
   #     AWS_KVS_LOG_LEVEL: 7
   #   steps:
   #     - name: Clone repository
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #     - name: Move cloned repo
   #       shell: powershell
   #       run: |
@@ -440,10 +440,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
@@ -468,10 +468,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
   static-build-alpine-linux:
     runs-on: ubuntu-22.04
     container:
-      image: alpine:3.15.4
+      image: alpine:3.20.0
     env:
       CC: gcc
       CXX: g++

--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install clang-format
         run: |
           brew install clang-format

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # fetch all history, for Codecov
 
@@ -54,7 +54,7 @@ jobs:
           make -j
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/cross-compilation.yml
+++ b/.github/workflows/cross-compilation.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install requirements
         run: sudo apt-get install doxygen graphviz -y

--- a/.github/workflows/profile-stats.yml
+++ b/.github/workflows/profile-stats.yml
@@ -25,10 +25,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
@@ -38,7 +38,7 @@ jobs:
           python-version: '3.13'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -27,15 +27,15 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -68,13 +68,13 @@ jobs:
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -99,13 +99,13 @@ jobs:
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -161,10 +161,10 @@ jobs:
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -175,7 +175,7 @@ jobs:
           sudo apt-get -y install valgrind
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get -y install zlib1g-dev libcurl4-openssl-dev
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
@@ -78,10 +78,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -95,7 +95,7 @@ jobs:
           sudo apt-get -y install zlib1g-dev libcurl4-openssl-dev
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
@@ -119,7 +119,7 @@ jobs:
   #     AWS_KVS_LOG_LEVEL: 2
   #   steps:
   #     - name: Clone repository
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #     - name: Install dependencies
   #       run: |
   #         sudo apt clean && sudo apt update
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           apt-get update
@@ -157,7 +157,7 @@ jobs:
           apt-get -y install zlib1g-dev libcurl4-openssl-dev
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 
@@ -169,7 +169,7 @@ jobs:
           make -j
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/storage-samples.yml
+++ b/.github/workflows/storage-samples.yml
@@ -26,10 +26,10 @@ jobs:
       contents: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -71,7 +71,7 @@ jobs:
           sudo apt-get -y install valgrind 
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
           cmake-version: '3.x'
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get version from PR
         id: pr_version
@@ -23,7 +23,7 @@ jobs:
           echo "PR Version: $PR_VERSION"
 
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/tst/RollingBufferFunctionalityTest.cpp
+++ b/tst/RollingBufferFunctionalityTest.cpp
@@ -61,11 +61,11 @@ TEST_F(RollingBufferFunctionalityTest, insertDataToBufferAndVerify)
     EXPECT_EQ(STATUS_ROLLING_BUFFER_NOT_IN_RANGE, rollingBufferInsertData(pRollingBuffer, 0, second));
     EXPECT_EQ(3, pRollingBuffer->headIndex);
     EXPECT_EQ(1, pRollingBuffer->tailIndex);
-    EXPECT_EQ(NULL, pRollingBuffer->dataBuffer[0]);
+    EXPECT_EQ((UINT64) 0, pRollingBuffer->dataBuffer[0]);
     EXPECT_EQ(STATUS_ROLLING_BUFFER_NOT_IN_RANGE, rollingBufferInsertData(pRollingBuffer, 3, third));
     EXPECT_EQ(3, pRollingBuffer->headIndex);
     EXPECT_EQ(1, pRollingBuffer->tailIndex);
-    EXPECT_EQ(NULL, pRollingBuffer->dataBuffer[3]);
+    EXPECT_EQ((UINT64) 0, pRollingBuffer->dataBuffer[3]);
     EXPECT_EQ(STATUS_SUCCESS, rollingBufferInsertData(pRollingBuffer, 2, fourth));
     EXPECT_EQ(3, pRollingBuffer->headIndex);
     EXPECT_EQ(1, pRollingBuffer->tailIndex);
@@ -73,7 +73,7 @@ TEST_F(RollingBufferFunctionalityTest, insertDataToBufferAndVerify)
     EXPECT_EQ(STATUS_ROLLING_BUFFER_NOT_IN_RANGE, rollingBufferInsertData(pRollingBuffer, 5, fifth));
     EXPECT_EQ(3, pRollingBuffer->headIndex);
     EXPECT_EQ(1, pRollingBuffer->tailIndex);
-    EXPECT_EQ(NULL, pRollingBuffer->dataBuffer[5]);
+    EXPECT_EQ((UINT64) 0, pRollingBuffer->dataBuffer[5]);
     EXPECT_EQ(STATUS_SUCCESS, freeRollingBuffer(&pRollingBuffer));
 }
 
@@ -98,7 +98,7 @@ TEST_F(RollingBufferFunctionalityTest, extractDataFromBufferAndInsertBack)
     EXPECT_EQ(STATUS_SUCCESS, rollingBufferExtractData(pRollingBuffer, 2, &data));
     EXPECT_EQ(third, data);
     EXPECT_EQ(STATUS_SUCCESS, rollingBufferExtractData(pRollingBuffer, 2, &data));
-    EXPECT_EQ(NULL, data);
+    EXPECT_EQ((UINT64) 0, data);
     EXPECT_EQ(STATUS_SUCCESS, rollingBufferInsertData(pRollingBuffer, 2, third));
     EXPECT_EQ(third, pRollingBuffer->dataBuffer[2]);
     EXPECT_EQ(STATUS_SUCCESS, rollingBufferInsertData(pRollingBuffer, 3, third));

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -49,7 +49,7 @@ TEST_F(RtpFunctionalityTest, marshallUnmarshallGettingSameData)
     EXPECT_EQ(STATUS_SUCCESS,
               constructRtpPackets(&payloadArray, 8, 1, 1324857487, 0x1234ABCD, (PRtpPacket) packetList, payloadArray.payloadSubLenSize));
 
-    EXPECT_NE(NULL, (UINT64) packetList);
+    EXPECT_TRUE(packetList != NULL);
 
     for (i = 0; i < payloadArray.payloadSubLenSize; i++) {
         pRtpPacket = packetList + i;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Dependency updates in the CI
  - aws-actions/configure-aws-credentials@v4 -> v6
  - actions/checkout@v4 -> v6
  - jwlawson/actions-setup-cmake@v2 ->v2.2.0

*Why was it changed?*
- Node20 deprecation:

`Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`

*How was it changed?*
- Update the versions to the latest

*What testing was done for the changes?*
- CI/CD will confirm if the dependencies are compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
