### PR TITLE
Profile log parsing script: Handle decimals in the time format

### DIFF
--- a/scripts/profile-stats/aggregate.py
+++ b/scripts/profile-stats/aggregate.py
@@ -12,8 +12,8 @@ from tabulate import tabulate
 def parse_profile_logs(log_file):
     stats = defaultdict(list)
     order = {}
-    pattern1 = r"PROFILE\s+\w+\(\):\s+\[([^\]]+)\]\s+Time taken:\s+(\d+)\s+ms"
-    pattern2 = r"PROFILE\s+\w+\(\):\s+\[([^\]]+)\]\s+(\d+)\s+ms"
+    pattern1 = r"PROFILE\s+\w+\(\):\s+\[([^\]]+)\]\s+Time taken:\s+(\d+(?:\.\d+)?)\s+ms"
+    pattern2 = r"PROFILE\s+\w+\(\):\s+\[([^\]]+)\]\s+(\d+(?:\.\d+)?)\s+ms"
 
     with open(log_file, "r") as f:
         for line in f:
@@ -22,7 +22,7 @@ def parse_profile_logs(log_file):
                 metric, time = match.groups()
                 if metric not in order:
                     order[metric] = len(order)
-                stats[metric].append(int(time))
+                stats[metric].append(float(time))
 
     return stats, order
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- In #2248, the format for the timing log lines was adjusted to add 2 decimals.
- However, the script didn't handle the decimal value (rounds down to nearest int)

*Why was it changed?*
- Providing additional accuracy in the timing info.

*How was it changed?*
- Adjust the regex to add the ms part

*What testing was done for the changes?*
- Ran the script locally
- Check the CI/CD output for the profile-stats job.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
