### PR TITLE
Compute intersection of local and remote TWCC capabilities in SDP

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1506,8 +1506,8 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     } else if (remoteHasTwccExtmap && remoteHasTwccRtcpFb) {
         pKvsPeerConnection->twccExtId = remoteTwccExtId;
         DLOGD("TWCC enabled, ext id: %u", pKvsPeerConnection->twccExtId);
-    } else if (remoteHasTwccExtmap || remoteHasTwccRtcpFb) {
-        DLOGI("TWCC not supported by remote (extmap=%s, rtcp-fb=%s), not enabling", remoteHasTwccExtmap ? "yes" : "no",
+    } else {
+        DLOGD("TWCC not advertised by remote (extmap=%s, rtcp-fb=%s), not enabling", remoteHasTwccExtmap ? "yes" : "no",
               remoteHasTwccRtcpFb ? "yes" : "no");
     }
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1507,8 +1507,8 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
         pKvsPeerConnection->twccExtId = remoteTwccExtId;
         DLOGD("TWCC enabled, ext id: %u", pKvsPeerConnection->twccExtId);
     } else if (remoteHasTwccExtmap || remoteHasTwccRtcpFb) {
-        DLOGI("TWCC not supported by remote (extmap=%s, rtcp-fb=%s), not enabling",
-              remoteHasTwccExtmap ? "yes" : "no", remoteHasTwccRtcpFb ? "yes" : "no");
+        DLOGI("TWCC not supported by remote (extmap=%s, rtcp-fb=%s), not enabling", remoteHasTwccExtmap ? "yes" : "no",
+              remoteHasTwccRtcpFb ? "yes" : "no");
     }
 
     CHK(remoteIceUfrag != NULL && remoteIcePwd != NULL, STATUS_SESSION_DESCRIPTION_MISSING_ICE_VALUES);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1392,6 +1392,8 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     PCHAR remoteIceUfrag = NULL, remoteIcePwd = NULL;
     UINT32 i, j;
     PSessionDescription pSessionDescription;
+    BOOL remoteHasTwccExtmap = FALSE, remoteHasTwccRtcpFb = FALSE;
+    UINT16 remoteTwccExtId = 0;
 
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
 
@@ -1486,9 +1488,27 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
                 // The standard dictates clearly that it should be a session level attribute:  https://tools.ietf.org/html/rfc5245#page-76
             } else if (STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "extmap") == 0 &&
                        STRSTR(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, TWCC_EXT_URL) != NULL) {
-                pKvsPeerConnection->twccExtId = parseExtId(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue);
+                remoteHasTwccExtmap = TRUE;
+                remoteTwccExtId = parseExtId(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue);
+            } else if (STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "rtcp-fb") == 0 &&
+                       STRSTR(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, TWCC_SDP_ATTR) != NULL) {
+                remoteHasTwccRtcpFb = TRUE;
             }
         }
+    }
+
+    // Enable TWCC if all 3 conditions are met:
+    // 1: remote has TWCC extmap line
+    // 2: remote has rtcp-fb transport-cc line
+    // 3: local configuration allows it
+    if (pKvsPeerConnection->pTwccManager == NULL) {
+        DLOGD("TWCC disabled by local configuration");
+    } else if (remoteHasTwccExtmap && remoteHasTwccRtcpFb) {
+        pKvsPeerConnection->twccExtId = remoteTwccExtId;
+        DLOGD("TWCC enabled, ext id: %u", pKvsPeerConnection->twccExtId);
+    } else if (remoteHasTwccExtmap || remoteHasTwccRtcpFb) {
+        DLOGI("TWCC not supported by remote (extmap=%s, rtcp-fb=%s), not enabling",
+              remoteHasTwccExtmap ? "yes" : "no", remoteHasTwccRtcpFb ? "yes" : "no");
     }
 
     CHK(remoteIceUfrag != NULL && remoteIcePwd != NULL, STATUS_SESSION_DESCRIPTION_MISSING_ICE_VALUES);

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -905,10 +905,9 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         attributeCount++;
 
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "extmap");
-        amountWritten =
-            SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
-                     SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s",
-                     pKvsPeerConnection->twccExtId, TWCC_EXT_URL);
+        amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
+                                 SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s", pKvsPeerConnection->twccExtId,
+                                 TWCC_EXT_URL);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
         attributeCount++;
     }

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -903,6 +903,14 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
                      SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " " TWCC_SDP_ATTR, payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full rtcp-fb twcc could not be written");
         attributeCount++;
+
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "extmap");
+        amountWritten =
+            SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
+                     SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s",
+                     pKvsPeerConnection->twccExtId, TWCC_EXT_URL);
+        CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
+        attributeCount++;
     }
 
     pSdpMediaDescription->mediaAttributesCount = attributeCount;

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -3495,6 +3495,273 @@ a=rtpmap:96 VP8/90000
                     [](PCHAR sdp) { runSetRemoteDescriptionAndAssertMissingFingerprint(sdp); });
 }
 
+TEST_F(SdpApiTest, whenRemoteOfferIncludesTwcc_thenAnswerIncludesTwcc)
+{
+    CHAR remoteSessionDescription[] = R"(v=0
+o=- 7732334361409071710 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=msid-semantic: WMS
+m=video 16485 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 205.251.233.176
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+a=fingerprint:sha-256 51:04:F9:20:45:5C:9D:85:AF:D7:AF:FB:2B:F8:DB:24:66:7B:6A:E3:E3:EF:EC:72:93:6E:01:B8:C9:53:A6:31
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 H264/90000
+a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=rtcp-fb:96 transport-cc
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+)";
+
+    assertLFAndCRLF(remoteSessionDescription, ARRAY_SIZE(remoteSessionDescription) - 1, [](PCHAR sdp) {
+        PRtcPeerConnection pRtcPeerConnection = NULL;
+        PRtcRtpTransceiver pRtcRtpTransceiver = NULL;
+        RtcConfiguration rtcConfiguration;
+        RtcMediaStreamTrack rtcMediaStreamTrack;
+        RtcRtpTransceiverInit rtcRtpTransceiverInit;
+        RtcSessionDescriptionInit rtcSessionDescriptionInit;
+
+        MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
+        MEMSET(&rtcMediaStreamTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+        MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
+
+        EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
+        EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);
+
+        rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+        rtcMediaStreamTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        rtcMediaStreamTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+        STRCPY(rtcMediaStreamTrack.streamId, "myKvsVideoStream");
+        STRCPY(rtcMediaStreamTrack.trackId, "myTrack");
+        EXPECT_EQ(addTransceiver(pRtcPeerConnection, &rtcMediaStreamTrack, &rtcRtpTransceiverInit, &pRtcRtpTransceiver), STATUS_SUCCESS);
+
+        STRCPY(rtcSessionDescriptionInit.sdp, sdp);
+        rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
+        EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+        EXPECT_EQ(createAnswer(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+
+        std::string answerSdp(rtcSessionDescriptionInit.sdp);
+
+        // Answer must contain the TWCC extmap with the same ext ID (5) from the offer
+        std::string expectedExtmap = "a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01";
+        EXPECT_NE(answerSdp.find(expectedExtmap), std::string::npos);
+
+        // Answer must also contain the rtcp-fb transport-cc line
+        EXPECT_NE(answerSdp.find("transport-cc"), std::string::npos);
+
+        closePeerConnection(pRtcPeerConnection);
+        freePeerConnection(&pRtcPeerConnection);
+    });
+}
+
+// Check: TWCC is NOT enabled when the remote offer has extmap but no rtcp-fb transport-cc (partial)
+TEST_F(SdpApiTest, whenRemoteOfferPartiallyIncludesTwccHasExtMapMissingTransportCC_thenAnswerDisablesTwcc)
+{
+    CHAR remoteSessionDescription[] = R"(v=0
+o=- 7732334361409071710 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=msid-semantic: WMS
+m=video 16485 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 205.251.233.176
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+a=fingerprint:sha-256 51:04:F9:20:45:5C:9D:85:AF:D7:AF:FB:2B:F8:DB:24:66:7B:6A:E3:E3:EF:EC:72:93:6E:01:B8:C9:53:A6:31
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 H264/90000
+a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+)";
+
+    assertLFAndCRLF(remoteSessionDescription, ARRAY_SIZE(remoteSessionDescription) - 1, [](PCHAR sdp) {
+        PRtcPeerConnection pRtcPeerConnection = NULL;
+        PRtcRtpTransceiver pRtcRtpTransceiver = NULL;
+        RtcConfiguration rtcConfiguration;
+        RtcMediaStreamTrack rtcMediaStreamTrack;
+        RtcRtpTransceiverInit rtcRtpTransceiverInit;
+        RtcSessionDescriptionInit rtcSessionDescriptionInit;
+
+        MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
+        MEMSET(&rtcMediaStreamTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+        MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
+
+        EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
+        EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);
+
+        rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+        rtcMediaStreamTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        rtcMediaStreamTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+        STRCPY(rtcMediaStreamTrack.streamId, "myKvsVideoStream");
+        STRCPY(rtcMediaStreamTrack.trackId, "myTrack");
+        EXPECT_EQ(addTransceiver(pRtcPeerConnection, &rtcMediaStreamTrack, &rtcRtpTransceiverInit, &pRtcRtpTransceiver), STATUS_SUCCESS);
+
+        STRCPY(rtcSessionDescriptionInit.sdp, sdp);
+        rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
+        EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+        EXPECT_EQ(createAnswer(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+
+        std::string answerSdp(rtcSessionDescriptionInit.sdp);
+
+        // Answer must NOT contain TWCC since the offer only had extmap without rtcp-fb
+        EXPECT_EQ(answerSdp.find(TWCC_EXT_URL), std::string::npos);
+        EXPECT_EQ(answerSdp.find("transport-cc"), std::string::npos);
+
+        closePeerConnection(pRtcPeerConnection);
+        freePeerConnection(&pRtcPeerConnection);
+    });
+}
+
+// Check: TWCC is NOT enabled when the remote offer has rtcp-fb transport-cc but no extmap (partial)
+TEST_F(SdpApiTest, whenRemoteOfferPartiallyIncludesTwccHasTransportCCMissingExtMap_thenAnswerDisablesTwcc)
+{
+    CHAR remoteSessionDescription[] = R"(v=0
+o=- 7732334361409071710 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=msid-semantic: WMS
+m=video 16485 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 205.251.233.176
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+a=fingerprint:sha-256 51:04:F9:20:45:5C:9D:85:AF:D7:AF:FB:2B:F8:DB:24:66:7B:6A:E3:E3:EF:EC:72:93:6E:01:B8:C9:53:A6:31
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 H264/90000
+a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=rtcp-fb:96 transport-cc
+)";
+
+    assertLFAndCRLF(remoteSessionDescription, ARRAY_SIZE(remoteSessionDescription) - 1, [](PCHAR sdp) {
+        PRtcPeerConnection pRtcPeerConnection = NULL;
+        PRtcRtpTransceiver pRtcRtpTransceiver = NULL;
+        RtcConfiguration rtcConfiguration;
+        RtcMediaStreamTrack rtcMediaStreamTrack;
+        RtcRtpTransceiverInit rtcRtpTransceiverInit;
+        RtcSessionDescriptionInit rtcSessionDescriptionInit;
+
+        MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
+        MEMSET(&rtcMediaStreamTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+        MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
+
+        EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
+        EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);
+
+        rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+        rtcMediaStreamTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        rtcMediaStreamTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+        STRCPY(rtcMediaStreamTrack.streamId, "myKvsVideoStream");
+        STRCPY(rtcMediaStreamTrack.trackId, "myTrack");
+        EXPECT_EQ(addTransceiver(pRtcPeerConnection, &rtcMediaStreamTrack, &rtcRtpTransceiverInit, &pRtcRtpTransceiver), STATUS_SUCCESS);
+
+        STRCPY(rtcSessionDescriptionInit.sdp, sdp);
+        rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
+        EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+        EXPECT_EQ(createAnswer(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+
+        std::string answerSdp(rtcSessionDescriptionInit.sdp);
+
+        // Answer must NOT contain TWCC since the offer only had rtcp-fb without extmap
+        EXPECT_EQ(answerSdp.find(TWCC_EXT_URL), std::string::npos);
+        EXPECT_EQ(answerSdp.find("transport-cc"), std::string::npos);
+
+        closePeerConnection(pRtcPeerConnection);
+        freePeerConnection(&pRtcPeerConnection);
+    });
+}
+
+// Check: TWCC is NOT enabled when the remote offer supports it, but the local configuration disables it
+TEST_F(SdpApiTest, whenLocalDisablesTwcc_thenAnswerExcludesTwcc)
+{
+    CHAR remoteSessionDescription[] = R"(v=0
+o=- 7732334361409071710 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=msid-semantic: WMS
+m=video 16485 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 205.251.233.176
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+a=fingerprint:sha-256 51:04:F9:20:45:5C:9D:85:AF:D7:AF:FB:2B:F8:DB:24:66:7B:6A:E3:E3:EF:EC:72:93:6E:01:B8:C9:53:A6:31
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 H264/90000
+a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=rtcp-fb:96 transport-cc
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+)";
+
+    assertLFAndCRLF(remoteSessionDescription, ARRAY_SIZE(remoteSessionDescription) - 1, [](PCHAR sdp) {
+        PRtcPeerConnection pRtcPeerConnection = NULL;
+        PRtcRtpTransceiver pRtcRtpTransceiver = NULL;
+        RtcConfiguration rtcConfiguration;
+        RtcMediaStreamTrack rtcMediaStreamTrack;
+        RtcRtpTransceiverInit rtcRtpTransceiverInit;
+        RtcSessionDescriptionInit rtcSessionDescriptionInit;
+
+        MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
+        MEMSET(&rtcMediaStreamTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+        MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
+
+        // Disable TWCC
+        rtcConfiguration.kvsRtcConfiguration.disableSenderSideBandwidthEstimation = TRUE;
+
+        EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
+        EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);
+
+        rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+        rtcMediaStreamTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        rtcMediaStreamTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+        STRCPY(rtcMediaStreamTrack.streamId, "myKvsVideoStream");
+        STRCPY(rtcMediaStreamTrack.trackId, "myTrack");
+        EXPECT_EQ(addTransceiver(pRtcPeerConnection, &rtcMediaStreamTrack, &rtcRtpTransceiverInit, &pRtcRtpTransceiver), STATUS_SUCCESS);
+
+        STRCPY(rtcSessionDescriptionInit.sdp, sdp);
+        rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
+        EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+        EXPECT_EQ(createAnswer(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+
+        std::string answerSdp(rtcSessionDescriptionInit.sdp);
+
+        // Answer must NOT contain TWCC since the local configuration disallowed it
+        EXPECT_EQ(answerSdp.find(TWCC_EXT_URL), std::string::npos);
+        EXPECT_EQ(answerSdp.find("transport-cc"), std::string::npos);
+
+        closePeerConnection(pRtcPeerConnection);
+        freePeerConnection(&pRtcPeerConnection);
+    });
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/discussions/2237

*What was changed?*
1. Fixed TWCC in the SDP answer generation to add both required properties:
    - Extmap line (new)
    - Transport-cc line (already added)
2. Made the `KvsRtcConfiguration.disableSenderSideBandwidthEstimation` configuration option enable and disable the local TWCC configuration
    - Now properly compute the intersection between the local and remote SDP
3. Added debug/info logs indicating why TWCC was or wasn't enabled

*Why was it changed?*
- The SDK was enabling TWCC based solely on the remote offer's extmap attribute, regardless of the local configuration
- The answer SDP was missing the TWCC extmap line, so the remote peer doesn't send any TWCC feedback, even though the SDK added the `TwccSeqNum` to the outbound RTP packets.

*How was it changed?*
- In SessionDescription.c, populateSingleMediaSection now writes the TWCC extmap attribute into the answer SDP alongside the existing rtcp-fb attribute
- In PeerConnection.c, setRemoteDescription now tracks both remoteHasTwccExtmap and remoteHasTwccRtcpFb flags and only sets twccExtId when both are present and the local pTwccManager is initialized (local configuration enabled TWCC)
- Added 4 unit tests in SdpApiTest.cpp covering: full TWCC negotiation, partial offer (extmap only), partial offer (rtcp-fb only), and local-disabled scenarios

*What testing was done for the changes?*
- Added 4 new unit tests validating TWCC is enabled only when both remote attributes are present and local config allows it
- CI/CD
- Manually checked with JS to verify it sends TWCC feedback:

Sample log:
```
2026-04-28 21:03:06.432 VERBOSE parseRtcpTwccPacket(): Checking seqNum 630 to 642 of TWCC reports
2026-04-28 21:03:06.498 VERBOSE parseRtcpTwccPacket(): Checking seqNum 643 to 656 of TWCC reports
...
2026-04-28 21:03:06.937 VERBOSE parseRtcpTwccPacket(): Checking seqNum 725 to 737 of TWCC reports
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
