### PR TITLE
esp_port: Fix invalid include in app_webrtc.c

### DIFF
--- a/esp_port/components/app_webrtc/include/app_webrtc.h
+++ b/esp_port/components/app_webrtc/include/app_webrtc.h
@@ -299,12 +299,12 @@ int app_webrtc_trigger_offer(char *pPeerId);
  *
  * @param[in] peer_id  Peer identifier — must match an active session.
  * @param[in] label    UTF-8 channel label (e.g. "control").
- * @param[in] ordered  true for reliable/ordered SCTP semantics.
+ * @param[in] pInit    Data channel init parameters (NULL for defaults: ordered=true).
  * @return WEBRTC_STATUS_SUCCESS on success, error otherwise.
  */
 WEBRTC_STATUS app_webrtc_create_data_channel(const char *peer_id,
                                              const char *label,
-                                             bool ordered);
+                                             const app_webrtc_data_channel_init_t *pInit);
 
 /**
  * @brief Get ICE servers configuration from the WebRTC application

--- a/esp_port/components/app_webrtc/include/app_webrtc_if.h
+++ b/esp_port/components/app_webrtc/include/app_webrtc_if.h
@@ -275,6 +275,14 @@ typedef struct {
 } webrtc_data_channel_config_t;
 
 /**
+ * @brief Configuration for creating a data channel.
+ *
+ */
+typedef struct {
+    bool ordered; //!< true for reliable/ordered SCTP semantics
+} app_webrtc_data_channel_init_t;
+
+/**
  * @brief Generic WebRTC peer connection configuration
  *
  * This configuration can be used by any peer connection implementation
@@ -343,7 +351,7 @@ typedef struct {
     // Create a data channel for a session
     WEBRTC_STATUS (*create_data_channel)(void *pSession,
                                         const char *channelName,
-                                        void *pDataChannelInit,
+                                        const app_webrtc_data_channel_init_t *pInit,
                                         void **ppDataChannel);
 
     // Event handler registration

--- a/esp_port/components/app_webrtc/src/app_webrtc.c
+++ b/esp_port/components/app_webrtc/src/app_webrtc.c
@@ -7,7 +7,6 @@
 
 #include "app_webrtc.h"
 #include "app_webrtc_internal.h"
-#include <com/amazonaws/kinesis/video/webrtcclient/Include.h>
 #include "webrtc_mem_utils.h"
 #include "esp_work_queue.h"
 
@@ -2688,7 +2687,7 @@ static PAppWebRTCSession find_session_by_peer_id(const char *peer_id)
  */
 WEBRTC_STATUS app_webrtc_create_data_channel(const char *peer_id,
                                              const char *label,
-                                             bool ordered)
+                                             const app_webrtc_data_channel_init_t *pInit)
 {
     ENTERS();
     WEBRTC_STATUS retStatus = WEBRTC_STATUS_SUCCESS;
@@ -2704,15 +2703,9 @@ WEBRTC_STATUS app_webrtc_create_data_channel(const char *peer_id,
         CHK(FALSE, WEBRTC_STATUS_INVALID_OPERATION);
     }
 
-    RtcDataChannelInit dcInit;
-    MEMSET(&dcInit, 0x00, SIZEOF(RtcDataChannelInit));
-    dcInit.ordered = ordered ? TRUE : FALSE;
-    NULLABLE_SET_EMPTY(dcInit.maxPacketLifeTime);
-    NULLABLE_SET_EMPTY(dcInit.maxRetransmits);
-
     void *pChannel = NULL;
     retStatus = gWebRtcAppConfig.peer_connection_if->create_data_channel(
-        pSession->interface_session_handle, label, &dcInit, &pChannel);
+        pSession->interface_session_handle, label, pInit, &pChannel);
 
 CleanUp:
     if (WEBRTC_STATUS_FAILED(retStatus)) {

--- a/esp_port/components/kvs_webrtc/src/kvs_webrtc.c
+++ b/esp_port/components/kvs_webrtc/src/kvs_webrtc.c
@@ -1473,7 +1473,8 @@ CleanUp:
  * @return WEBRTC_STATUS
  */
 static WEBRTC_STATUS kvs_pc_create_data_channel(void *pSession, const char *channelName,
-                                               void *pDataChannelInit, void **ppDataChannel)
+                                               const app_webrtc_data_channel_init_t *pInit,
+                                               void **ppDataChannel)
 {
     STATUS retStatus = STATUS_SUCCESS;
     kvs_pc_session_t *session = NULL;
@@ -1486,9 +1487,14 @@ static WEBRTC_STATUS kvs_pc_create_data_channel(void *pSession, const char *chan
 
     ESP_LOGI(TAG, "Creating data channel '%s' for peer: %s", channelName, session->peer_id);
 
-    // Create the data channel
+    RtcDataChannelInit dcInit;
+    MEMSET(&dcInit, 0x00, SIZEOF(RtcDataChannelInit));
+    dcInit.ordered = (pInit != NULL) ? (pInit->ordered ? TRUE : FALSE) : TRUE;
+    NULLABLE_SET_EMPTY(dcInit.maxPacketLifeTime);
+    NULLABLE_SET_EMPTY(dcInit.maxRetransmits);
+
     CHK_STATUS(createDataChannel(session->peer_connection, (PCHAR)channelName,
-                                (PRtcDataChannelInit)pDataChannelInit, &pDataChannel));
+                                 &dcInit, &pDataChannel));
 
     // Store the data channel in the session
     session->data_channel = pDataChannel;
@@ -1601,7 +1607,8 @@ CleanUp:
  * @brief Stub implementation for data channel creation when data channels are disabled
  */
 static WEBRTC_STATUS kvs_pc_create_data_channel(void *pSession, const char *channelName,
-                                                void *pDataChannelInit, void **ppDataChannel)
+                                                const app_webrtc_data_channel_init_t *pInit,
+                                                void **ppDataChannel)
 {
     ESP_LOGW(TAG, "Data channel support is disabled");
     return WEBRTC_STATUS_NOT_IMPLEMENTED;


### PR DESCRIPTION
*Issue #, if available:*
- Build fails on projects that do not depend on KVS WebRTC SDK(kvs_webrtc component)

*What was changed?*
- Created a new struct `app_webrtc_data_channel_init_t` for passing the data channel configuration between app_webrtc_create_data_channel() and the callback that is supposed to be implementing the WebRTC communication
- This struct currently only has a `bool ordered` fields. More fields can be added later.
- This PR breaks the `app_webrtc_create_data_channel` API from `app_webrtc.h`:
   It changes the 3rd argument(which was a boolean representing if the data channel is ordered) to a pointer of a struct containing data channel configuration parameters.
Users can migrate their applications as follows:
```
// old API
app_webrtc_create_data_channel(peer, "control", true);

// new API
app_webrtc_data_channel_init_t init = { .ordered = true };
app_webrtc_create_data_channel(peer, "control", &init);   // or NULL for default
```

*Why was it changed?*
- Having `#include <com/amazonaws/kinesis/video/webrtcclient/Include.h>` in [app_webrtc.c](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/blob/776682029b900dd57e3a01cbc0e518da3d2a9087/esp_port/components/app_webrtc/src/app_webrtc.c) causes build time errors.
- This happens because app_webrtc does not depend on the KVS WebRTC SDK.

*What testing was done for the changes?*
- webrtc_classic still builds. Another non-KVS-WebRTC project that previously failed against app_webrtc.h now compiles successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
