### PR TITLE
fix(SessionDescription): pick the sha-256 a=fingerprint line in offers/answers

### DIFF
--- a/src/source/Crypto/Dtls.h
+++ b/src/source/Crypto/Dtls.h
@@ -26,6 +26,14 @@ extern "C" {
 #define GENERATED_CERTIFICATE_NAME     "KVS-WebRTC-Client"
 #define KEYING_EXTRACTOR_LABEL         "EXTRACTOR-dtls_srtp"
 
+// All DTLS certificate fingerprints emitted and validated by this SDK use
+// SHA-256 (see `dtlsCertificateFingerprint` in both Dtls_mbedtls.c and
+// Dtls_openssl.c). The corresponding `a=fingerprint:` SDP attribute value is
+// therefore prefixed by "sha-256 " (RFC 8122 §5).
+#define DTLS_FINGERPRINT_SHA256_HASH_NAME  "sha-256"
+#define DTLS_FINGERPRINT_SHA256_PREFIX     DTLS_FINGERPRINT_SHA256_HASH_NAME " "
+#define DTLS_FINGERPRINT_SHA256_PREFIX_LEN (SIZEOF(DTLS_FINGERPRINT_SHA256_PREFIX) - 1)
+
 /*
  * DTLS transmission interval timer (in 100ns)
  */

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1419,8 +1419,18 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
             // are silently skipped — RFC 8122 §5 permits multiple lines and selecting one of them.
             if (STRNCMP(pSessionDescription->sdpAttributes[i].attributeValue, DTLS_FINGERPRINT_SHA256_PREFIX, DTLS_FINGERPRINT_SHA256_PREFIX_LEN) ==
                 0) {
+                DLOGV("Found SHA-256 session-level fingerprint");
                 STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint,
                         pSessionDescription->sdpAttributes[i].attributeValue + DTLS_FINGERPRINT_SHA256_PREFIX_LEN, CERTIFICATE_FINGERPRINT_LENGTH);
+            } else {
+                // Log just the algorithm name (everything up to the first space) — the hex hash that follows
+                // is long and adds nothing to the diagnostic. Drop this `else` branch once the SDK supports
+                // the other hash algorithms.
+                PCHAR space = STRCHR(pSessionDescription->sdpAttributes[i].attributeValue, ' ');
+                INT32 algoLen = (space != NULL) ? (INT32) (space - pSessionDescription->sdpAttributes[i].attributeValue)
+                                                : (INT32) STRLEN(pSessionDescription->sdpAttributes[i].attributeValue);
+                DLOGV("Ignoring unsupported session-level fingerprint algorithm: %.*s", algoLen,
+                      pSessionDescription->sdpAttributes[i].attributeValue);
             }
         } else if (pKvsPeerConnection->isOffer && STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "setup") == 0) {
             // possible values are actpass, passive and active. If the incoming SDP has active, it indicates it is taking up a client role
@@ -1454,9 +1464,17 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
                 // Only sha-256 — see the matching session-level fingerprint loop above for the rationale.
                 if (STRNCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, DTLS_FINGERPRINT_SHA256_PREFIX,
                             DTLS_FINGERPRINT_SHA256_PREFIX_LEN) == 0) {
+                    DLOGV("Found SHA-256 media-level fingerprint");
                     STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint,
                             pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue + DTLS_FINGERPRINT_SHA256_PREFIX_LEN,
                             CERTIFICATE_FINGERPRINT_LENGTH);
+                } else {
+                    // Drop this `else` branch once the SDK supports the other hash algorithms.
+                    PCHAR space = STRCHR(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, ' ');
+                    INT32 algoLen = (space != NULL) ? (INT32) (space - pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue)
+                                                    : (INT32) STRLEN(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue);
+                    DLOGV("Ignoring unsupported media-level fingerprint algorithm: %.*s", algoLen,
+                          pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue);
                 }
             } else if (pKvsPeerConnection->isOffer &&
                        STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "setup") == 0) {

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1411,8 +1411,17 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
 
     for (i = 0; i < pSessionDescription->sessionAttributesCount; i++) {
         if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "fingerprint") == 0) {
-            STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint, pSessionDescription->sdpAttributes[i].attributeValue + 8,
-                    CERTIFICATE_FINGERPRINT_LENGTH);
+            // Modern peers (e.g. aiortc) advertise multiple `a=fingerprint:` lines per session — sha-256, sha-384,
+            // sha-512 — in that order. `dtlsSessionVerifyRemoteCertificateFingerprint` compares the stored value
+            // against a SHA-256 digest of the peer's certificate, so only the sha-256 line is usable here. Without
+            // this filter the loop overwrites with each successive fingerprint, the sha-512 hex string wins, and
+            // DTLS verification fails with `STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED`. Other algorithms
+            // are silently skipped — RFC 8122 §5 permits multiple lines and selecting one of them.
+            if (STRNCMP(pSessionDescription->sdpAttributes[i].attributeValue, DTLS_FINGERPRINT_SHA256_PREFIX, DTLS_FINGERPRINT_SHA256_PREFIX_LEN) ==
+                0) {
+                STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint,
+                        pSessionDescription->sdpAttributes[i].attributeValue + DTLS_FINGERPRINT_SHA256_PREFIX_LEN, CERTIFICATE_FINGERPRINT_LENGTH);
+            }
         } else if (pKvsPeerConnection->isOffer && STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "setup") == 0) {
             // possible values are actpass, passive and active. If the incoming SDP has active, it indicates it is taking up a client role
             // In case of actpass and passive, the other peer is taking up a server role and is waiting for incoming connection
@@ -1442,8 +1451,13 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
                 // Ignore the return value, we have candidates we don't support yet like TURN
                 iceAgentAddRemoteCandidate(pKvsPeerConnection->pIceAgent, pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue);
             } else if (STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "fingerprint") == 0) {
-                STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint,
-                        pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue + 8, CERTIFICATE_FINGERPRINT_LENGTH);
+                // Only sha-256 — see the matching session-level fingerprint loop above for the rationale.
+                if (STRNCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, DTLS_FINGERPRINT_SHA256_PREFIX,
+                            DTLS_FINGERPRINT_SHA256_PREFIX_LEN) == 0) {
+                    STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint,
+                            pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue + DTLS_FINGERPRINT_SHA256_PREFIX_LEN,
+                            CERTIFICATE_FINGERPRINT_LENGTH);
+                }
             } else if (pKvsPeerConnection->isOffer &&
                        STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "setup") == 0) {
                 pKvsPeerConnection->dtlsIsServer = STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, "active") == 0;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -630,8 +630,8 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     }
 
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "fingerprint");
-    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "sha-256 ");
-    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue + 8, pCertificateFingerprint);
+    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, DTLS_FINGERPRINT_SHA256_PREFIX);
+    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue + DTLS_FINGERPRINT_SHA256_PREFIX_LEN, pCertificateFingerprint);
     attributeCount++;
 
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "setup");
@@ -947,8 +947,8 @@ STATUS populateSessionDescriptionDataChannel(PKvsPeerConnection pKvsPeerConnecti
     }
 
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "fingerprint");
-    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, "sha-256 ");
-    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue + 8, pCertificateFingerprint);
+    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue, DTLS_FINGERPRINT_SHA256_PREFIX);
+    STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue + DTLS_FINGERPRINT_SHA256_PREFIX_LEN, pCertificateFingerprint);
     attributeCount++;
 
     STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "setup");

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -3331,6 +3331,59 @@ a=rtpmap:96 VP8/90000
                     [](PCHAR sdp) { runSetRemoteDescriptionAndAssertSha256Picked(sdp, (PCHAR) sha256FingerprintHex); });
 }
 
+// If the peer advertises only non-sha256 fingerprints (sha-384/sha-512), the
+// filter must reject all of them and `setRemoteDescription` must fail with
+// `STATUS_SESSION_DESCRIPTION_MISSING_CERTIFICATE_FINGERPRINT` rather than
+// silently storing an empty fingerprint string and deferring the failure to
+// the DTLS handshake. This guards against the inverse of the sha-256 selection
+// bug — a regression that, say, defaults to the last seen line on no-match.
+static void runSetRemoteDescriptionAndAssertMissingFingerprint(PCHAR sdp)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    RtcConfiguration rtcConfiguration;
+    RtcSessionDescriptionInit rtcSessionDescriptionInit;
+
+    MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+
+    EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
+
+    STRCPY(rtcSessionDescriptionInit.sdp, sdp);
+    rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
+    EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit),
+              STATUS_SESSION_DESCRIPTION_MISSING_CERTIFICATE_FINGERPRINT);
+
+    closePeerConnection(pRtcPeerConnection);
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(SdpApiTest, setRemoteDescription_FailsWhenNoSha256FingerprintProvided)
+{
+    auto offer = std::string(R"(v=0
+o=- 7732543171158289043 1565379274 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 1
+a=msid-semantic: WMS
+m=video 16485 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 205.251.233.176
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+)") + sha384FingerprintLine + "\n" + sha512FingerprintLine + R"(
+a=setup:actpass
+a=mid:1
+a=recvonly
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 VP8/90000
+)";
+
+    assertLFAndCRLF((PCHAR) offer.c_str(), offer.size(),
+                    [](PCHAR sdp) { runSetRemoteDescriptionAndAssertMissingFingerprint(sdp); });
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -3238,6 +3238,99 @@ a=sendrecv
     });
 }
 
+// All DTLS certificate fingerprints emitted and validated by this SDK use
+// SHA-256 (see `dtlsCertificateFingerprint`), so `setRemoteDescription`
+// must keep the sha-256 hex regardless of how many other algorithms the
+// peer advertises. Modern peers (e.g. aiortc, current Chromium) emit
+// `a=fingerprint:` lines for sha-256, sha-384 and sha-512 in that order.
+// Without filtering on the algorithm prefix the last line wins, and DTLS
+// verification later fails with `STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED`.
+const auto sha256FingerprintHex =
+    "51:04:F9:20:45:5C:9D:85:AF:D7:AF:FB:2B:F8:DB:24:66:7B:6A:E3:E3:EF:EC:72:93:6E:01:B8:C9:53:A6:31";
+const auto sha384FingerprintLine = "a=fingerprint:sha-384 "
+                                   "9C:0E:6F:3D:3F:60:36:91:71:51:8B:18:1A:5A:13:5C:0E:1F:34:0B:5C:9D:01:7A:0F:71:60:C5:8B:0C:79"
+                                   ":80:3A:F2:1E:C0:18:99:60:8E:25:7C:5C:0F:46:5C:F1:55";
+const auto sha512FingerprintLine = "a=fingerprint:sha-512 "
+                                   "1C:84:39:E0:24:8B:F8:1F:9B:7E:84:1A:9F:24:43:60:7B:0F:A6:1C:0C:34:6E:C5:BF:67:3F:D6:80:35:5C"
+                                   ":F0:9D:0F:F0:D9:5A:55:6F:5F:80:9D:71:9F:62:F0:51:1E:1F:60:09:B6:51:1C:1D:CE:91:0F:25:8E:11:A4:B5:84";
+
+static void runSetRemoteDescriptionAndAssertSha256Picked(PCHAR sdp, PCHAR expectedSha256Hex)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    RtcConfiguration rtcConfiguration;
+    RtcSessionDescriptionInit rtcSessionDescriptionInit;
+
+    MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+
+    EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
+
+    STRCPY(rtcSessionDescriptionInit.sdp, sdp);
+    rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
+    EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+
+    EXPECT_STREQ(((PKvsPeerConnection) pRtcPeerConnection)->remoteCertificateFingerprint, expectedSha256Hex);
+
+    closePeerConnection(pRtcPeerConnection);
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(SdpApiTest, setRemoteDescription_PicksSha256WhenSha256IsFirstFingerprintLine)
+{
+    auto offer = std::string(R"(v=0
+o=- 7732543171158289043 1565379274 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 1
+a=msid-semantic: WMS
+m=video 16485 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 205.251.233.176
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+a=fingerprint:sha-256 )") + sha256FingerprintHex + "\n" + sha384FingerprintLine + "\n" + sha512FingerprintLine + R"(
+a=setup:actpass
+a=mid:1
+a=recvonly
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 VP8/90000
+)";
+
+    assertLFAndCRLF((PCHAR) offer.c_str(), offer.size(),
+                    [](PCHAR sdp) { runSetRemoteDescriptionAndAssertSha256Picked(sdp, (PCHAR) sha256FingerprintHex); });
+}
+
+// Same selection logic, but the sha-256 line is *last* in the list —
+// guards against a bug that selects by position rather than by hash name.
+TEST_F(SdpApiTest, setRemoteDescription_PicksSha256WhenSha256IsLastFingerprintLine)
+{
+    auto offer = std::string(R"(v=0
+o=- 7732543171158289043 1565379274 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 1
+a=msid-semantic: WMS
+m=video 16485 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 205.251.233.176
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+)") + sha512FingerprintLine + "\n" + sha384FingerprintLine + "\na=fingerprint:sha-256 " + sha256FingerprintHex + R"(
+a=setup:actpass
+a=mid:1
+a=recvonly
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 VP8/90000
+)";
+
+    assertLFAndCRLF((PCHAR) offer.c_str(), offer.size(),
+                    [](PCHAR sdp) { runSetRemoteDescriptionAndAssertSha256Picked(sdp, (PCHAR) sha256FingerprintHex); });
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- `setRemoteDescription` now selects the **sha-256** `a=fingerprint:` line out of the (possibly multiple) lines a peer advertises, both at session level and per m-line. Other algorithms are silently skipped.
- The literal `"sha-256 "` and the magic `+ 8` offset that previously appeared in four places are factored out as `DTLS_FINGERPRINT_SHA256_PREFIX` / `..._PREFIX_LEN` in `src/source/Crypto/Dtls.h`.
- Two new `SdpApiTest` cases (`...PicksSha256WhenSha256IsFirstFingerprintLine`, `...IsLastFingerprintLine`) exercise the multi-fingerprint selection through `assertLFAndCRLF`.

*Why was it changed?*
- Modern WebRTC stacks (e.g. [aiortc](https://github.com/aiortc/aiortc), current Chromium) emit `a=fingerprint:` for **sha-256, sha-384, and sha-512** in that order. RFC 8122 §5 explicitly allows multiple lines and the receiver selecting one of them.
- The pre-existing parser at `PeerConnection.c:setRemoteDescription` unconditionally `STRNCPY`'d each line over `pKvsPeerConnection->remoteCertificateFingerprint`, so the *last* line (sha-512) won.
- `dtlsSessionVerifyRemoteCertificateFingerprint` later compares against a SHA-256 digest produced by `dtlsCertificateFingerprint` (uses `MBEDTLS_MD_SHA256` in `Dtls_mbedtls.c` and `EVP_sha256()` in `Dtls_openssl.c`), so the sha-512 hex never matches and DTLS aborts with `STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED (0x59000003)`. Downstream this surfaces as `allocateSrtp(): 0x59000003` and no media flows.

*How was it changed?*
- `src/source/PeerConnection/PeerConnection.c::setRemoteDescription`: both the session-level and the media-level `a=fingerprint:` branches now `STRNCMP` the value against `DTLS_FINGERPRINT_SHA256_PREFIX` first; only on a match do they `STRNCPY` the digest into `remoteCertificateFingerprint`. Other algorithms are silently skipped (RFC 8122 §5 permits this).
- `src/source/PeerConnection/SessionDescription.c::populateSingleMediaSection` and `populateSessionDescriptionDataChannel`: use the same constants for the emission side, replacing the magic `+ 8` offset.
- `src/source/Crypto/Dtls.h`: introduce `DTLS_FINGERPRINT_SHA256_HASH_NAME`, `DTLS_FINGERPRINT_SHA256_PREFIX`, `DTLS_FINGERPRINT_SHA256_PREFIX_LEN` next to the existing `GENERATED_CERTIFICATE_NAME` / `KEYING_EXTRACTOR_LABEL` constants. The hash algorithm choice is dictated by `dtlsCertificateFingerprint` so this is the natural home.

*What testing was done for the changes?*
- Two new `SdpApiTest` cases cover both orderings (sha-256 first and sha-256 last) through `assertLFAndCRLF` so LF and CRLF SDPs are both exercised. Pre-fix they hit `EXPECT_STREQ` failure with the sha-512 hex; post-fix they pass.
- Locally rebuilt `kvsWebrtcClient` (mbedtls + openssl backends) — clean.
- `clang-format --dry-run --Werror` is clean on every file the patch touches (a couple of unrelated pre-existing violations remain in `tst/SdpApiTest.cpp`; not introduced or affected by this change).
- Reproduced the original failure end-to-end against an aiortc viewer (master is the SDK in master role, viewer is `aiortc==1.14`); after this patch DTLS handshake completes, SRTP keys, and RTP packets flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.