### PR TITLE
fix(RtpOpusPayloader): handle empty input cleanly

### DIFF
--- a/src/source/Rtp/Codecs/RtpOpusPayloader.c
+++ b/src/source/Rtp/Codecs/RtpOpusPayloader.c
@@ -14,6 +14,7 @@ STATUS createPayloadForOpus(UINT32 mtu, PBYTE opusFrame, UINT32 opusFrameLength,
 
     CHK(opusFrame != NULL && pPayloadSubLenSize != NULL && pPayloadLength != NULL && (sizeCalculationOnly || pPayloadSubLength != NULL),
         STATUS_NULL_ARG);
+    CHK(opusFrameLength > 0, retStatus);
 
     payloadLength = opusFrameLength;
     payloadSubLenSize = 1;

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -414,6 +414,21 @@ TEST_F(RtpFunctionalityTest, packingUnpackingVerifySameOpusFrame)
     MEMFREE(depayload);
 }
 
+TEST_F(RtpFunctionalityTest, packingEmptyOpusFrameReturnsZeroSubLenSize)
+{
+    BYTE payload[] = {0x00};
+    PayloadArray payloadArray;
+
+    payloadArray.payloadLength = 0;
+    payloadArray.payloadSubLenSize = 0;
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              createPayloadForOpus(DEFAULT_MTU_SIZE_BYTES, (PBYTE) &payload, 0, NULL, &payloadArray.payloadLength, NULL,
+                                   &payloadArray.payloadSubLenSize));
+    EXPECT_EQ(0, payloadArray.payloadLength);
+    EXPECT_EQ(0, payloadArray.payloadSubLenSize);
+}
+
 TEST_F(RtpFunctionalityTest, packingUnpackingVerifySameShortG711Frame)
 {
     BYTE payload[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- `createPayloadForOpus` now early-returns with `payloadLength=0` and `payloadSubLenSize=0` when `opusFrameLength==0`.

*Why was it changed?*
- Previously `payloadSubLenSize=1` was set unconditionally, so on an empty input `writeFrame` would `MEMALLOC(pPacketList)` for one packet, but `constructRtpPackets` would early-return on `payloadLength > 0` without filling it — the for-loop then read uninitialized memory (observed as `MEMALLOC` failing for multi-GB sizes via garbage `RTP_GET_RAW_PACKET_SIZE`, or `srtp_protect → replay_fail` from corrupted seq numbers).
- The H264 payloader already handles empty input via `CHK(remainNalusLength != 0, retStatus)`. This change brings Opus to the same shape.

*How was it changed?*
- One-line `CHK(opusFrameLength > 0, retStatus)` in `createPayloadForOpus`. CleanUp leaves both out-params at their zero initialisers, so writeFrame's loop iterates zero times.

*What testing was done for the changes?*
- New unit test `RtpFunctionalityTest.packingEmptyOpusFrameReturnsZeroSubLenSize` verifies `payloadLength=0` and `payloadSubLenSize=0` for empty input.
- Existing `packingUnpackingVerifySameOpusFrame` continues to pass.
- `scripts/check-clang.sh` clean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.