### PR TITLE
fix(sdp): add attribute name length check for parity with other SDP field parsers

### DIFF
--- a/src/source/Sdp/Deserialize.c
+++ b/src/source/Sdp/Deserialize.c
@@ -29,7 +29,7 @@ STATUS parseSessionAttributes(PSessionDescription pSessionDescription, PCHAR pch
                 MIN(MAX_SDP_ATTRIBUTE_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
     } else {
         STRNCPY(pSessionDescription->sdpAttributes[pSessionDescription->sessionAttributesCount].attributeName, pch + SDP_ATTRIBUTE_LENGTH,
-                (search - (pch + SDP_ATTRIBUTE_LENGTH)));
+                MIN(MAX_SDP_ATTRIBUTE_NAME_LENGTH, (search - (pch + SDP_ATTRIBUTE_LENGTH))));
         STRNCPY(pSessionDescription->sdpAttributes[pSessionDescription->sessionAttributesCount].attributeValue, search + 1,
                 MIN(MAX_SDP_ATTRIBUTE_VALUE_LENGTH, lineLen - (search - pch + 1)));
     }
@@ -58,7 +58,7 @@ STATUS parseMediaAttributes(PSessionDescription pSessionDescription, PCHAR pch, 
                 pch + SDP_ATTRIBUTE_LENGTH, MIN(MAX_SDP_ATTRIBUTE_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
     } else {
         STRNCPY(pSessionDescription->mediaDescriptions[pSessionDescription->mediaCount - 1].sdpAttributes[currentMediaAttributesCount].attributeName,
-                pch + SDP_ATTRIBUTE_LENGTH, (search - (pch + SDP_ATTRIBUTE_LENGTH)));
+                pch + SDP_ATTRIBUTE_LENGTH, MIN(MAX_SDP_ATTRIBUTE_NAME_LENGTH, (search - (pch + SDP_ATTRIBUTE_LENGTH))));
         STRNCPY(pSessionDescription->mediaDescriptions[pSessionDescription->mediaCount - 1].sdpAttributes[currentMediaAttributesCount].attributeValue,
                 search + 1, MIN(MAX_SDP_ATTRIBUTE_VALUE_LENGTH, lineLen - (search - pch + 1)));
     }

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -2882,6 +2882,51 @@ TEST_F(SdpApiTest, addTransceiverUnknownCodecId_returnsStatusNotImplemented)
     freePeerConnection(&offerPc);
 }
 
+// Attribute name and value on colon path must be truncated to their max lengths
+TEST_F(SdpApiTest, deserializeSessionDescription_AttributeKeyValuesTruncated)
+{
+    // Try constructing 1 longer than max
+    std::string longName(MAX_SDP_ATTRIBUTE_NAME_LENGTH + 1, 'A');
+    std::string longValue(MAX_SDP_ATTRIBUTE_VALUE_LENGTH + 1, 'V');
+
+    std::string sessionSdp = "v=0\n"
+                             "o=- 1 1 IN IP4 127.0.0.1\n"
+                             "s=test\n"
+                             "t=0 0\n"
+                             "a=" + longName + ":" + longValue + "\n";
+    std::string mediaSdp =
+        "v=0\n"
+        "o=- 1 1 IN IP4 127.0.0.1\n"
+        "s=test\n"
+        "t=0 0\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 96\n"
+        "a=" + longName + ":" + longValue + "\n";
+
+    assertLFAndCRLF((PCHAR) sessionSdp.c_str(), (INT32) sessionSdp.size(), [&](PCHAR sdp) {
+        SessionDescription sessionDescription;
+        MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+        EXPECT_EQ(deserializeSessionDescription(&sessionDescription, sdp), STATUS_SUCCESS);
+        EXPECT_EQ(sessionDescription.sessionAttributesCount, 1);
+        EXPECT_EQ(STRLEN(sessionDescription.sdpAttributes[0].attributeName), MAX_SDP_ATTRIBUTE_NAME_LENGTH);
+        EXPECT_EQ(STRNCMP(sessionDescription.sdpAttributes[0].attributeName, longName.c_str(), MAX_SDP_ATTRIBUTE_NAME_LENGTH), 0);
+        EXPECT_EQ(STRLEN(sessionDescription.sdpAttributes[0].attributeValue), MAX_SDP_ATTRIBUTE_VALUE_LENGTH);
+        EXPECT_EQ(STRNCMP(sessionDescription.sdpAttributes[0].attributeValue, longValue.c_str(), MAX_SDP_ATTRIBUTE_VALUE_LENGTH), 0);
+    });
+
+    assertLFAndCRLF((PCHAR) mediaSdp.c_str(), (INT32) mediaSdp.size(), [&](PCHAR sdp) {
+        SessionDescription sessionDescription;
+        MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+        EXPECT_EQ(deserializeSessionDescription(&sessionDescription, sdp), STATUS_SUCCESS);
+        EXPECT_EQ(sessionDescription.mediaCount, 1);
+        EXPECT_EQ(sessionDescription.mediaDescriptions[0].mediaAttributesCount, 1);
+        EXPECT_EQ(STRLEN(sessionDescription.mediaDescriptions[0].sdpAttributes[0].attributeName), MAX_SDP_ATTRIBUTE_NAME_LENGTH);
+        EXPECT_EQ(STRNCMP(sessionDescription.mediaDescriptions[0].sdpAttributes[0].attributeName, longName.c_str(), MAX_SDP_ATTRIBUTE_NAME_LENGTH), 0);
+        EXPECT_EQ(STRLEN(sessionDescription.mediaDescriptions[0].sdpAttributes[0].attributeValue), MAX_SDP_ATTRIBUTE_VALUE_LENGTH);
+        EXPECT_EQ(STRNCMP(sessionDescription.mediaDescriptions[0].sdpAttributes[0].attributeValue, longValue.c_str(), MAX_SDP_ATTRIBUTE_VALUE_LENGTH),
+                  0);
+    });
+}
+
 class IntersectTransceiverDirectionE2ETest : public SdpApiTest,
     public ::testing::WithParamInterface<std::tuple<RTC_RTP_TRANSCEIVER_DIRECTION, RTC_RTP_TRANSCEIVER_DIRECTION, 
                                                       RTC_RTP_TRANSCEIVER_DIRECTION, RTC_RTP_TRANSCEIVER_DIRECTION,


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add MIN() to truncate the length of the SDP attribute name.

*Why was it changed?*
- MIN is already there in the surrounding code, keeping it consistent.

*How was it changed?*
- Add MIN to match the surrounding code
- Add new unit test to confirm the behavior

*What testing was done for the changes?*
- Run new tests to confirm the behavior
- The test failed before the change and passed after the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
