### PR TITLE
Update constant for media title and session description

### DIFF
--- a/src/source/Sdp/Deserialize.c
+++ b/src/source/Sdp/Deserialize.c
@@ -100,7 +100,7 @@ STATUS deserializeSessionDescription(PSessionDescription pSessionDescription, PC
             // Media Title
             if (0 == STRNCMP(curr, SDP_INFORMATION_MARKER, (ARRAY_SIZE(SDP_INFORMATION_MARKER) - 1))) {
                 STRNCPY(pSessionDescription->mediaDescriptions[pSessionDescription->mediaCount - 1].mediaTitle, (curr + SDP_ATTRIBUTE_LENGTH),
-                        MIN(MAX_SDP_MEDIA_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
+                        MIN(MAX_SDP_MEDIA_TITLE_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
             }
         } else {
             // SDP Session Name
@@ -112,7 +112,7 @@ STATUS deserializeSessionDescription(PSessionDescription pSessionDescription, PC
             // SDP Session Name
             if (0 == STRNCMP(curr, SDP_INFORMATION_MARKER, (ARRAY_SIZE(SDP_INFORMATION_MARKER) - 1))) {
                 STRNCPY(pSessionDescription->sessionInformation, (curr + SDP_ATTRIBUTE_LENGTH),
-                        MIN(MAX_SDP_MEDIA_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
+                        MIN(MAX_SDP_SESSION_INFORMATION_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
             }
 
             // SDP URI

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -1821,6 +1821,28 @@ a=ssrc:1644235696 cname:{36a6a74c-73a4-594b-9bb0-023b4d357280})";
     });
 }
 
+TEST_F(SdpApiTest, deserializeSessionDescription_SessionInformationTruncatedAtMaxLength)
+{
+    std::string longInfo(MAX_SDP_SESSION_INFORMATION_LENGTH + 50, 'A');
+    std::string sdpStr = "v=0\ni=" + longInfo + "\n";
+
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) sdpStr.c_str()));
+    EXPECT_EQ(STRLEN(sessionDescription.sessionInformation), (UINT32) MAX_SDP_SESSION_INFORMATION_LENGTH);
+}
+
+TEST_F(SdpApiTest, deserializeSessionDescription_MediaTitleTruncatedAtMaxLength)
+{
+    std::string longTitle(MAX_SDP_MEDIA_TITLE_LENGTH + 50, 'B');
+    std::string sdpStr = "v=0\nm=video 9 UDP/TLS/RTP/SAVPF 96\ni=" + longTitle + "\n";
+
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) sdpStr.c_str()));
+    EXPECT_EQ(STRLEN(sessionDescription.mediaDescriptions[0].mediaTitle), (UINT32) MAX_SDP_MEDIA_TITLE_LENGTH);
+}
+
 TEST_P(SdpApiTest_SdpMatch, populateSingleMediaSection_TestH264Fmtp)
 {
     PRtcPeerConnection pRtcPeerConnection = NULL;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Updated constant used when deserializing the SDP media title (`i=` line within a media section) and session information (`i=` line at session level)

*Why was it changed?*
- Update the constant to match the SessionDescription field being populated

*How was it changed?*
- Use the constant with the same name

*What testing was done for the changes?*
- Wrote new unit tests to check the updated behavior
- They failed before and passed after

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
