### PR TITLE
Update constants used for certain SDP fields

### DIFF
--- a/src/source/Sdp/Deserialize.c
+++ b/src/source/Sdp/Deserialize.c
@@ -106,7 +106,7 @@ STATUS deserializeSessionDescription(PSessionDescription pSessionDescription, PC
             // SDP Session Name
             if (0 == STRNCMP(curr, SDP_SESSION_NAME_MARKER, (ARRAY_SIZE(SDP_SESSION_NAME_MARKER) - 1))) {
                 STRNCPY(pSessionDescription->sessionName, (curr + SDP_ATTRIBUTE_LENGTH),
-                        MIN(MAX_SDP_MEDIA_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
+                        MIN(MAX_SDP_SESSION_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
             }
 
             // SDP Session Name
@@ -117,19 +117,19 @@ STATUS deserializeSessionDescription(PSessionDescription pSessionDescription, PC
 
             // SDP URI
             if (0 == STRNCMP(curr, SDP_URI_MARKER, (ARRAY_SIZE(SDP_URI_MARKER) - 1))) {
-                STRNCPY(pSessionDescription->uri, (curr + SDP_ATTRIBUTE_LENGTH), MIN(MAX_SDP_MEDIA_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
+                STRNCPY(pSessionDescription->uri, (curr + SDP_ATTRIBUTE_LENGTH), MIN(MAX_SDP_SESSION_URI_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
             }
 
             // SDP Email Address
             if (0 == STRNCMP(curr, SDP_EMAIL_ADDRESS_MARKER, (ARRAY_SIZE(SDP_EMAIL_ADDRESS_MARKER) - 1))) {
                 STRNCPY(pSessionDescription->emailAddress, (curr + SDP_ATTRIBUTE_LENGTH),
-                        MIN(MAX_SDP_MEDIA_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
+                        MIN(MAX_SDP_SESSION_EMAIL_ADDRESS_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
             }
 
             // SDP Phone number
             if (0 == STRNCMP(curr, SDP_PHONE_NUMBER_MARKER, (ARRAY_SIZE(SDP_PHONE_NUMBER_MARKER) - 1))) {
                 STRNCPY(pSessionDescription->phoneNumber, (curr + SDP_ATTRIBUTE_LENGTH),
-                        MIN(MAX_SDP_MEDIA_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
+                        MIN(MAX_SDP_SESSION_PHONE_NUMBER_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));
             }
 
             if (0 == STRNCMP(curr, SDP_VERSION_MARKER, (ARRAY_SIZE(SDP_VERSION_MARKER) - 1))) {

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -129,6 +129,50 @@ a=candidate:842163049 1 udp 1677729535 54.240.196.188 15632 typ srflx raddr 10.1
     });
 }
 
+TEST_F(SdpApiTest, deserializeSessionDescription_SessionNameTruncatedAtMaxLength)
+{
+    std::string longName(MAX_SDP_SESSION_NAME_LENGTH + 50, 'A');
+    std::string sdpStr = "v=0\ns=" + longName + "\n";
+
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) sdpStr.c_str()));
+    EXPECT_EQ(STRLEN(sessionDescription.sessionName), (UINT32) MAX_SDP_SESSION_NAME_LENGTH);
+}
+
+TEST_F(SdpApiTest, deserializeSessionDescription_UriTruncatedAtMaxLength)
+{
+    std::string longUri(MAX_SDP_SESSION_URI_LENGTH + 50, 'A');
+    std::string sdpStr = "v=0\nu=" + longUri + "\n";
+
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) sdpStr.c_str()));
+    EXPECT_EQ(STRLEN(sessionDescription.uri), (UINT32) MAX_SDP_SESSION_URI_LENGTH);
+}
+
+TEST_F(SdpApiTest, deserializeSessionDescription_EmailAddressTruncatedAtMaxLength)
+{
+    std::string longEmail(MAX_SDP_SESSION_EMAIL_ADDRESS_LENGTH + 50, 'A');
+    std::string sdpStr = "v=0\ne=" + longEmail + "\n";
+
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) sdpStr.c_str()));
+    EXPECT_EQ(STRLEN(sessionDescription.emailAddress), (UINT32) MAX_SDP_SESSION_EMAIL_ADDRESS_LENGTH);
+}
+
+TEST_F(SdpApiTest, deserializeSessionDescription_PhoneNumberTruncatedAtMaxLength)
+{
+    std::string longPhone(MAX_SDP_SESSION_PHONE_NUMBER_LENGTH + 50, 'A');
+    std::string sdpStr = "v=0\np=" + longPhone + "\n";
+
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) sdpStr.c_str()));
+    EXPECT_EQ(STRLEN(sessionDescription.phoneNumber), (UINT32) MAX_SDP_SESSION_PHONE_NUMBER_LENGTH);
+}
+
 auto populate_session_description = [](PSessionDescription pSessionDescription) {
     MEMSET(pSessionDescription, 0x00, SIZEOF(SessionDescription));
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Replace MAX_SDP_MEDIA_NAME_LENGTH with the dedicated constants (MAX_SDP_SESSION_NAME_LENGTH, MAX_SDP_SESSION_URI_LENGTH, MAX_SDP_SESSION_EMAIL_ADDRESS_LENGTH, and MAX_SDP_SESSION_PHONE_NUMBER_LENGTH).

*Why was it changed?*
- The code was using MAX_SDP_MEDIA_NAME_LENGTH for fields that have their own dedicated constants
- Allows future flexibility to tweak individual fields

*How was it changed?*
- Update the constant used for sessionName, uri,  emailAddress, phoneNumber to match, keeping it consistent.

*What testing was done for the changes?*
- Add new unit tests to confirm the behavior
- The new tests pass without the change, and pass after the change. This is expected since the constants are currently all the same (255).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
