### PR TITLE
Support null arguments to writeFrame

### DIFF
--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -429,35 +429,38 @@ CleanUp:
     if (locked) {
         MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
     }
-    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
-    pKvsRtpTransceiver->outboundStats.totalEncodedBytesTarget += pFrame->size;
-    pKvsRtpTransceiver->outboundStats.framesEncoded += frames;
-    pKvsRtpTransceiver->outboundStats.keyFramesEncoded += keyframes;
-    if (fps > 0.0) {
-        pKvsRtpTransceiver->outboundStats.framesPerSecond = fps;
-    }
-    pKvsRtpTransceiver->sender.lastKnownFrameCountTime = now;
-    pKvsRtpTransceiver->sender.lastKnownFrameCount = pKvsRtpTransceiver->outboundStats.framesEncoded;
-    pKvsRtpTransceiver->outboundStats.sent.bytesSent += bytesSent;
-    pKvsRtpTransceiver->outboundStats.sent.packetsSent += packetsSent;
-    if (lastPacketSentTimestamp > 0) {
-        pKvsRtpTransceiver->outboundStats.lastPacketSentTimestamp = lastPacketSentTimestamp;
-    }
-    pKvsRtpTransceiver->outboundStats.headerBytesSent += headerBytesSent;
-    pKvsRtpTransceiver->outboundStats.framesSent += framesSent;
-    if (pKvsRtpTransceiver->outboundStats.framesPerSecond > 0.0) {
-        if (pFrame->size >=
-            pKvsRtpTransceiver->outboundStats.targetBitrate / pKvsRtpTransceiver->outboundStats.framesPerSecond * HUGE_FRAME_MULTIPLIER) {
-            pKvsRtpTransceiver->outboundStats.hugeFramesSent++;
-        }
-    }
-    // iceAgentSendPacket tries to send packet immediately, explicitly settings totalPacketSendDelay to 0
-    pKvsRtpTransceiver->outboundStats.totalPacketSendDelay = 0;
 
-    pKvsRtpTransceiver->outboundStats.framesDiscardedOnSend += framesDiscardedOnSend;
-    pKvsRtpTransceiver->outboundStats.packetsDiscardedOnSend += packetsDiscardedOnSend;
-    pKvsRtpTransceiver->outboundStats.bytesDiscardedOnSend += bytesDiscardedOnSend;
-    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+    if (pKvsRtpTransceiver != NULL && pFrame != NULL) {
+        MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+        pKvsRtpTransceiver->outboundStats.totalEncodedBytesTarget += pFrame->size;
+        pKvsRtpTransceiver->outboundStats.framesEncoded += frames;
+        pKvsRtpTransceiver->outboundStats.keyFramesEncoded += keyframes;
+        if (fps > 0.0) {
+            pKvsRtpTransceiver->outboundStats.framesPerSecond = fps;
+        }
+        pKvsRtpTransceiver->sender.lastKnownFrameCountTime = now;
+        pKvsRtpTransceiver->sender.lastKnownFrameCount = pKvsRtpTransceiver->outboundStats.framesEncoded;
+        pKvsRtpTransceiver->outboundStats.sent.bytesSent += bytesSent;
+        pKvsRtpTransceiver->outboundStats.sent.packetsSent += packetsSent;
+        if (lastPacketSentTimestamp > 0) {
+            pKvsRtpTransceiver->outboundStats.lastPacketSentTimestamp = lastPacketSentTimestamp;
+        }
+        pKvsRtpTransceiver->outboundStats.headerBytesSent += headerBytesSent;
+        pKvsRtpTransceiver->outboundStats.framesSent += framesSent;
+        if (pKvsRtpTransceiver->outboundStats.framesPerSecond > 0.0) {
+            if (pFrame->size >=
+                pKvsRtpTransceiver->outboundStats.targetBitrate / pKvsRtpTransceiver->outboundStats.framesPerSecond * HUGE_FRAME_MULTIPLIER) {
+                pKvsRtpTransceiver->outboundStats.hugeFramesSent++;
+            }
+        }
+        // iceAgentSendPacket tries to send packet immediately, explicitly settings totalPacketSendDelay to 0
+        pKvsRtpTransceiver->outboundStats.totalPacketSendDelay = 0;
+
+        pKvsRtpTransceiver->outboundStats.framesDiscardedOnSend += framesDiscardedOnSend;
+        pKvsRtpTransceiver->outboundStats.packetsDiscardedOnSend += packetsDiscardedOnSend;
+        pKvsRtpTransceiver->outboundStats.bytesDiscardedOnSend += bytesDiscardedOnSend;
+        MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+    }
 
     SAFE_MEMFREE(rawPacket);
     SAFE_MEMFREE(pPacketList);

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -646,6 +646,19 @@ TEST_F(RtpFunctionalityTest, twccPayload)
     EXPECT_EQ(0, ptr[3]);
 }
 
+TEST_F(RtpFunctionalityTest, writeFrameNullArgs)
+{
+    Frame frame;
+    RtcRtpTransceiver transceiver;
+
+    MEMSET(&frame, 0x00, SIZEOF(Frame));
+    MEMSET(&transceiver, 0x00, SIZEOF(RtcRtpTransceiver));
+
+    EXPECT_EQ(STATUS_NULL_ARG, writeFrame(NULL, &frame));
+    EXPECT_EQ(STATUS_NULL_ARG, writeFrame(&transceiver, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, writeFrame(NULL, NULL));
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
-  Added a NULL guard around the stats-update block in the CleanUp section of writeFrame()
-  Added new test to confirm the behavior

*Why was it changed?*
- When writeFrame is called with a NULL `pFrame` or NULL `pRtcRtpTransceiver`, the `CHK` macro correctly jumps to `CleanUp` but the cleanup code unconditionally dereferences both pointers.

*How was it changed?*
- Wrapped the stats-update block with a condition so it is safely skipped on NULL argument paths
  - Note: the git diff (changes) splits it up into multiple sections. All that was changed was indenting the existing code section one to the right after adding the guard.
- Added a test that passes NULL for each argument and verifies STATUS_NULL_ARG is returned

*What testing was done for the changes?*
- After: Run the new unit test with the guard change, passed locally.
- Before: Reverted the guard change and confirmed the new test failure.

```sh
./tst/webrtc_client_test --gtest_filter="*writeFrameNullArgs*"
Note: Google Test filter = *writeFrameNullArgs*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from RtpFunctionalityTest
[ RUN      ] RtpFunctionalityTest.writeFrameNullArgs
2026-05-06 22:45:49.036 INFO    initKvsWebRtc(): Initializing WebRTC library...
2026-05-06 22:45:49.037 INFO    initKvsWebRtc(): SDK version: 9eebcc45e207e3054437da2858b1954cb87d234a
2026-05-06 22:45:49.038 ERROR   writeFrame(): operation returned status code: 0x00000001
2026-05-06 22:45:49.038 ERROR   writeFrame(): operation returned status code: 0x00000001
2026-05-06 22:45:49.038 ERROR   writeFrame(): operation returned status code: 0x00000001
2026-05-06 22:45:49.038 INFO    TearDown(): 
Tearing down test: RtpFunctionalityTest

[       OK ] RtpFunctionalityTest.writeFrameNullArgs (404 ms)
[----------] 1 test from RtpFunctionalityTest (404 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (404 ms total)
[  PASSED  ] 1 test.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
