### PR TITLE
Support null out parameter in createSocketConnection

### DIFF
--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -44,10 +44,6 @@ STATUS createSocketConnection(KVS_IP_FAMILY_TYPE familyType, KVS_SOCKET_PROTOCOL
     pSocketConnection->dataAvailableCallbackCustomData = customData;
     pSocketConnection->dataAvailableCallbackFn = dataAvailableFn;
 
-CleanUp:
-
-    CHK_LOG_ERR(retStatus);
-
     if (pBindAddr) {
         getIpAddrStr(pBindAddr, ipAddr, ARRAY_SIZE(ipAddr));
         DLOGD("create socket id: %d, with ip: %s:%u. family:%d", pSocketConnection->localSocket, ipAddr, (UINT16) getInt16(pBindAddr->port),
@@ -59,6 +55,10 @@ CleanUp:
         getIpAddrStr(pPeerIpAddr, ipAddr, ARRAY_SIZE(ipAddr));
         DLOGD("tcp socket connected with ip: %s:%u. family:%d", ipAddr, (UINT16) getInt16(pPeerIpAddr->port), pPeerIpAddr->family);
     }
+
+CleanUp:
+
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_FAILED(retStatus) && pSocketConnection != NULL) {
         freeSocketConnection(&pSocketConnection);

--- a/tst/IceApiTest.cpp
+++ b/tst/IceApiTest.cpp
@@ -97,6 +97,12 @@ TEST_F(IceApiTest, IceUtilApiTest)
     EXPECT_EQ(STATUS_SUCCESS, freeStunPacket(&pStunPacket));
     EXPECT_EQ(STATUS_SUCCESS, freeTransactionIdStore(&pTransactionIdStore));
 }
+TEST_F(IceApiTest, createSocketConnectionNullArgument)
+{
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createSocketConnection(KVS_IP_FAMILY_TYPE_IPV4, KVS_SOCKET_PROTOCOL_UDP, NULL, NULL, 0, NULL, 0, NULL));
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Support null parameter: `ppSocketConnection` in the `createSocketConnection` constructor.

*Why was it changed?*
- When `createSocketConnection()` is called with a NULL `ppSocketConnection` out parameter, the `CHK` macro correctly jumps to `CleanUp` but the logging code inside the `CleanUp` unconditionally dereferences `pSocketConnection`, which is NULL at that point.
- The logging in the `CleanUp` was introduced in https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/commit/51f4d993871c0693e1dc53f9b23f3c073123ee33

*How was it changed?*
- Moved debug logging statements from after the `CleanUp:` label to before the `CleanUp:` label
- Added unit test to check the behavior

*What testing was done for the changes?*
- The newly added test fails before this change, and passes after the change.

```
./tst/webrtc_client_test --gtest_filter="*createSocketConnectionNullArgument*"
Note: Google Test filter = *createSocketConnectionNullArgument*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from IceApiTest
[ RUN      ] IceApiTest.createSocketConnectionNullArgument
2026-05-07 01:40:51.647 INFO    initKvsWebRtc(): Initializing WebRTC library...
2026-05-07 01:40:51.652 INFO    initKvsWebRtc(): SDK version: ed713f9900f4cf9e5987456aef08938fdf2fa49b
2026-05-07 01:40:51.654 ERROR   createSocketConnection(): operation returned status code: 0x00000001
2026-05-07 01:40:51.654 INFO    TearDown(): 
Tearing down test: IceApiTest

[       OK ] IceApiTest.createSocketConnectionNullArgument (410 ms)
[----------] 1 test from IceApiTest (410 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (410 ms total)
[  PASSED  ] 1 test.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
