### PR TITLE
fix(esp_port): mempool static fix + signaling cache v2 + esp_video bump

### DIFF
--- a/esp_port/components/kvs_signaling/src/SignalingESP.c
+++ b/esp_port/components/kvs_signaling/src/SignalingESP.c
@@ -10,7 +10,16 @@
 
 /* NVS-based caching configuration */
 #define SIGNALING_NVS_NAMESPACE      "kvs_signaling"
-#define SIGNALING_CACHE_VERSION      "v1"   // 2 chars for future compatibility
+/* SIGNALING_CACHE_VERSION must be bumped any time SignalingFileCacheEntry's
+ * binary layout changes (in FileCache.h). The version is the prefix of the
+ * NVS key, so bumping it orphans old-layout blobs and forces fresh entries.
+ *
+ * Bumped to v2: SignalingFileCacheEntry gained controlPlaneUrl[] and
+ * useDualStackEndpoints[] (upstream commit 795a60d4f7, on
+ * beta-reference-esp-port via Release v1.16.0 b6396850a4). Old v1 blobs
+ * lack those fields, so reading them with the new struct shifts every
+ * field after `region` and produces garbage WSS / HTTPS endpoints. */
+#define SIGNALING_CACHE_VERSION      "v2"   // 2 chars for future compatibility
 #define MAX_NVS_KEY_LEN              16     // NVS key limit: 15 chars + NULL terminator
 
 /**

--- a/esp_port/components/media_stream/idf_component.yml
+++ b/esp_port/components/media_stream/idf_component.yml
@@ -5,7 +5,7 @@ dependencies:
       - if: "target not in [esp32p4]"
 
   espressif/esp_video:
-    version: "~1.4.0"
+    version: "~2.0.0"
     rules:
       - if: "target in [esp32p4]"
 

--- a/esp_port/components/network_coprocessor/mempool.c
+++ b/esp_port/components/network_coprocessor/mempool.c
@@ -1,21 +1,21 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright 2015-2022 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+/*
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #include "mempool.h"
 #include "esp_log.h"
+#include "sdkconfig.h"
+
+struct hosted_mempool {
+	struct os_mempool *pool;
+	uint8_t *heap;
+	uint8_t static_heap;
+	size_t num_blocks;
+	size_t block_size;
+	struct mempool_ops_t *ops;
+};
 
 const char *TAG = "HS_MP";
 
@@ -53,17 +53,22 @@ struct hosted_mempool * hosted_mempool_create(void *pre_allocated_mem,
 		}
 	}
 
-	new = (struct hosted_mempool*)MEM_ALLOC(sizeof(struct hosted_mempool));
-	pool = (struct os_mempool *)MEM_ALLOC(sizeof(struct os_mempool));
+	new = (struct hosted_mempool*)CALLOC(1, sizeof(struct hosted_mempool));
+	pool = (struct os_mempool *)CALLOC(1, sizeof(struct os_mempool));
 
 	if(!new || !pool) {
 		goto free_buffs;
 	}
 
+	new->ops = os_mempool_get_ops();
+	if (!new->ops) {
+		goto free_buffs;
+	}
+
 	snprintf(str, MEMPOOL_NAME_STR_SIZE, "hosted_%p", pool);
 
-	if (os_mempool_init(pool, num_blocks, block_size, heap, str)) {
-		ESP_LOGE(TAG, "os_mempool_init failed\n");
+	if (new->ops->mempool_init(pool, num_blocks, block_size, heap, str)) {
+		ESP_LOGE(TAG, "mempool_init failed\n");
 		goto free_buffs;
 	}
 
@@ -101,6 +106,7 @@ void hosted_mempool_destroy(struct hosted_mempool *mempool)
 	ESP_LOGI(MEM_TAG, "Destroy mempool %p num_blk[%lu] blk_size:[%lu]", mempool->pool, mempool->num_blocks, mempool->block_size);
 #endif
 
+	mempool->ops->mempool_unregister(mempool->pool);
 	FREE(mempool->pool);
 
 	if (!mempool->static_heap)
@@ -116,8 +122,10 @@ void * hosted_mempool_alloc(struct hosted_mempool *mempool,
 	void *mem = NULL;
 
 #ifdef CONFIG_ESP_CACHE_MALLOC
-	if (!mempool)
+	if (!mempool) {
+		ESP_LOGE(TAG, "mempool %p is NULL", mempool);
 		return NULL;
+	}
 
 #if MYNEWT_VAL(OS_MEMPOOL_CHECK)
 	assert(mempool->heap);
@@ -130,30 +138,36 @@ void * hosted_mempool_alloc(struct hosted_mempool *mempool,
 	}
 #endif
 
-	mem = os_memblock_get(mempool->pool);
+	mem = mempool->ops->memblock_get(mempool->pool);
 #else
 	mem = MEM_ALLOC(MEMPOOL_ALIGNED(nbytes));
 #endif
 	if (mem && need_memset)
 		memset(mem, 0, nbytes);
 
+	if (!mem) {
+		ESP_LOGE(TAG, "mempool %p alloc failed nbytes[%u]", mempool, nbytes);
+	}
 	return mem;
 }
 
 int hosted_mempool_free(struct hosted_mempool *mempool, void *mem)
 {
-	if (!mem)
+	if (!mem) {
 		return 0;
+	}
 #ifdef CONFIG_ESP_CACHE_MALLOC
-	if (!mempool)
+	if (!mempool) {
+		ESP_LOGE(TAG, "%s: mempool %p is NULL", __func__, mempool);
 		return MEMPOOL_FAIL;
+	}
 
 #if MYNEWT_VAL(OS_MEMPOOL_CHECK)
 	assert(mempool->heap);
 	assert(mempool->pool);
 #endif
 
-	return os_memblock_put(mempool->pool, mem);
+	return mempool->ops->memblock_put(mempool->pool, mem);
 #else
 	FREE(mem);
 	return 0;

--- a/esp_port/components/network_coprocessor/mempool.h
+++ b/esp_port/components/network_coprocessor/mempool.h
@@ -1,18 +1,8 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright 2015-2022 Espressif Systems (Shanghai) PTE LTD
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
+/*
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #ifndef __MEMPOOL_H__
 #define __MEMPOOL_H__
@@ -20,23 +10,18 @@
 #include <string.h>
 #include <stdio.h>
 #include <sys/queue.h>
+#include "esp_idf_version.h"
 #include <freertos/FreeRTOS.h>
 #include <freertos/portmacro.h>
 
 #ifdef CONFIG_ESP_CACHE_MALLOC
 #include "mempool_ll.h"
-struct hosted_mempool {
-	struct os_mempool *pool;
-	uint8_t *heap;
-	uint8_t static_heap;
-	size_t num_blocks;
-	size_t block_size;
-};
 #endif
 
 #define MEM_DUMP(s) \
-    printf("%s free:%lu min-free:%lu lfb-def:%u lfb-8bit:%u\n\n", s, \
+    printf("%s free:%lu min-free:%lu lfb-dma:%u lfb-def:%u lfb-8bit:%u\n", s, \
                   esp_get_free_heap_size(), esp_get_minimum_free_heap_size(), \
+                  heap_caps_get_largest_free_block(MALLOC_CAP_DMA),\
                   heap_caps_get_largest_free_block(MALLOC_CAP_DEFAULT),\
                   heap_caps_get_largest_free_block(MALLOC_CAP_8BIT))
 
@@ -45,7 +30,7 @@ struct hosted_mempool {
 
 #define CALLOC(x,y)                      calloc(x,y)
 #define MALLOC(x)                        malloc(x)
-#define MEM_ALLOC(x)                     heap_caps_malloc(x, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL)
+#define MEM_ALLOC(x)                     heap_caps_malloc((x), MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT)
 #define FREE(x) do {                     \
 	if (x) {                             \
 		free(x);                         \
@@ -55,7 +40,7 @@ struct hosted_mempool {
 
 #define MEMPOOL_NAME_STR_SIZE            32
 
-#define MEMPOOL_ALIGNMENT_BYTES          64
+#define MEMPOOL_ALIGNMENT_BYTES          4
 #define MEMPOOL_ALIGNMENT_MASK           (MEMPOOL_ALIGNMENT_BYTES-1)
 #define IS_MEMPOOL_ALIGNED(VAL)          (!((VAL)& MEMPOOL_ALIGNMENT_MASK))
 #define MEMPOOL_ALIGNED(VAL)             ((VAL) + MEMPOOL_ALIGNMENT_BYTES - \

--- a/esp_port/components/network_coprocessor/mempool_ll.c
+++ b/esp_port/components/network_coprocessor/mempool_ll.c
@@ -1,4 +1,10 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: 2015-2022 The Apache Software Foundation (ASF)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * SPDX-FileContributor: 2019-2026 Espressif Systems (Shanghai) CO LTD
+ */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,6 +22,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ */
+/*
+ * NOTICE: File has been changed from original implementation.
  */
 
 #include <string.h>
@@ -66,7 +76,7 @@ os_mempool_poison_check(void *start, int sz)
 #define os_mempool_poison_check(start, sz)
 #endif
 
-os_error_t
+static os_error_t
 os_mempool_init(struct os_mempool *mp, uint16_t blocks, uint32_t block_size,
                 void *membuf, const char *name)
 {
@@ -124,117 +134,13 @@ os_mempool_init(struct os_mempool *mp, uint16_t blocks, uint32_t block_size,
 	return OS_OK;
 }
 
-os_error_t
-os_mempool_ext_init(struct os_mempool_ext *mpe, uint16_t blocks,
-                    uint32_t block_size, void *membuf, const char *name)
+static void
+os_mempool_unregister(struct os_mempool *mp)
 {
-	int rc;
-
-	rc = os_mempool_init(&mpe->mpe_mp, blocks, block_size, membuf, name);
-	if (rc != 0) {
-		return rc;
-	}
-
-	mpe->mpe_mp.mp_flags = OS_MEMPOOL_F_EXT;
-	mpe->mpe_put_cb = NULL;
-	mpe->mpe_put_arg = NULL;
-
-	return 0;
+	STAILQ_REMOVE(&g_os_hosted_mempool_list, mp, os_mempool, mp_list);
 }
 
-os_error_t
-os_mempool_clear(struct os_mempool *mp)
-{
-	struct os_memblock *block_ptr;
-	int true_block_size;
-	uint8_t *block_addr;
-	uint16_t blocks;
-
-	if (!mp) {
-		return OS_INVALID_PARM;
-	}
-
-	true_block_size = OS_MEM_TRUE_BLOCK_SIZE(mp->mp_block_size);
-
-	/* cleanup the memory pool structure */
-	mp->mp_num_free = mp->mp_num_blocks;
-	mp->mp_min_free = mp->mp_num_blocks;
-	os_mempool_poison((void *)mp->mp_membuf_addr, true_block_size);
-	SLIST_FIRST(mp) = (void *)mp->mp_membuf_addr;
-
-	/* Chain the memory blocks to the free list */
-	block_addr = (uint8_t *)mp->mp_membuf_addr;
-	block_ptr = (struct os_memblock *)block_addr;
-	blocks = mp->mp_num_blocks;
-
-	while (blocks > 1) {
-		block_addr += true_block_size;
-		os_mempool_poison(block_addr, true_block_size);
-		SLIST_NEXT(block_ptr, mb_next) = (struct os_memblock *)block_addr;
-		block_ptr = (struct os_memblock *)block_addr;
-		--blocks;
-	}
-
-	/* Last one in the list should be NULL */
-	SLIST_NEXT(block_ptr, mb_next) = NULL;
-
-	return OS_OK;
-}
-
-os_error_t
-os_mempool_ext_clear(struct os_mempool_ext *mpe)
-{
-	mpe->mpe_mp.mp_flags = 0;
-	mpe->mpe_put_cb = NULL;
-	mpe->mpe_put_arg = NULL;
-
-	return os_mempool_clear(&mpe->mpe_mp);
-}
-
-bool
-os_mempool_is_sane(const struct os_mempool *mp)
-{
-	struct os_memblock *block;
-
-	/* Verify that each block in the free list belongs to the mempool. */
-	SLIST_FOREACH(block, mp, mb_next) {
-		if (!os_memblock_from(mp, block)) {
-			return false;
-		}
-		os_mempool_poison_check(block, OS_MEMPOOL_TRUE_BLOCK_SIZE(mp));
-	}
-
-	return true;
-}
-
-int
-os_memblock_from(const struct os_mempool *mp, const void *block_addr)
-{
-	uintptr_t true_block_size;
-	uintptr_t baddr_ptr;
-	uintptr_t end;
-
-	_Static_assert(sizeof block_addr == sizeof baddr_ptr,
-			"Pointer to void must be native word size.");
-
-	baddr_ptr = (uintptr_t)block_addr;
-	true_block_size = OS_MEMPOOL_TRUE_BLOCK_SIZE(mp);
-	end = mp->mp_membuf_addr + (mp->mp_num_blocks * true_block_size);
-
-	/* Check that the block is in the memory buffer range. */
-	if ((baddr_ptr < mp->mp_membuf_addr) || (baddr_ptr >= end)) {
-		return 0;
-	}
-
-	/* All freed blocks should be on true block size boundaries! */
-	if (((baddr_ptr - mp->mp_membuf_addr) % true_block_size) != 0) {
-		return 0;
-	}
-
-	return 1;
-}
-
-void *
+static void *
 os_memblock_get(struct os_mempool *mp)
 {
 	struct os_memblock *block;
@@ -267,7 +173,7 @@ os_memblock_get(struct os_mempool *mp)
 	return (void *)block;
 }
 
-os_error_t
+static os_error_t
 os_memblock_put_from_cb(struct os_mempool *mp, void *block_addr)
 {
 	struct os_memblock *block;
@@ -290,7 +196,7 @@ os_memblock_put_from_cb(struct os_mempool *mp, void *block_addr)
 	return OS_OK;
 }
 
-os_error_t
+static os_error_t
 os_memblock_put(struct os_mempool *mp, void *block_addr)
 {
 	struct os_mempool_ext *mpe;
@@ -331,7 +237,139 @@ os_memblock_put(struct os_mempool *mp, void *block_addr)
 	return os_memblock_put_from_cb(mp, block_addr);
 }
 
-struct os_mempool *
+/*
+ * The remaining mynewt mempool API entries below are carried over from the
+ * upstream esp-hosted-mcu mempool implementation (commit c8e59587). They
+ * are not exposed through mempool_ops_t (see os_mempool_get_ops() below)
+ * and have no callers on the hosted-networking path, so they are kept
+ * compiled-out behind semantic flags rather than a bare #if 0. The names
+ * say why each block is disabled:
+ *
+ *   MYNEWT_VAL(OS_MEMPOOL_CHECK)        - sanity-check helpers that pair
+ *                                          with the assert() in
+ *                                          os_memblock_put().
+ *   MYNEWT_VAL(OS_MEMPOOL_EXTENDED_API) - clear / extended-pool /
+ *                                          info-walk surface that this
+ *                                          path does not use.
+ *
+ * Neither flag is defined in this build, so today both blocks compile to
+ * nothing - same effective behaviour as the original upstream #if 0, but
+ * grep-friendly and ready to be turned on individually if ever needed.
+ */
+#if MYNEWT_VAL(OS_MEMPOOL_CHECK)
+static int
+os_memblock_from(const struct os_mempool *mp, const void *block_addr)
+{
+	uintptr_t true_block_size;
+	uintptr_t baddr_ptr;
+	uintptr_t end;
+
+	_Static_assert(sizeof block_addr == sizeof baddr_ptr,
+			"Pointer to void must be native word size.");
+
+	baddr_ptr = (uintptr_t)block_addr;
+	true_block_size = OS_MEMPOOL_TRUE_BLOCK_SIZE(mp);
+	end = mp->mp_membuf_addr + (mp->mp_num_blocks * true_block_size);
+
+	/* Check that the block is in the memory buffer range. */
+	if ((baddr_ptr < mp->mp_membuf_addr) || (baddr_ptr >= end)) {
+		return 0;
+	}
+
+	/* All freed blocks should be on true block size boundaries! */
+	if (((baddr_ptr - mp->mp_membuf_addr) % true_block_size) != 0) {
+		return 0;
+	}
+
+	return 1;
+}
+
+static bool
+os_mempool_is_sane(const struct os_mempool *mp)
+{
+	struct os_memblock *block;
+
+	/* Verify that each block in the free list belongs to the mempool. */
+	SLIST_FOREACH(block, mp, mb_next) {
+		if (!os_memblock_from(mp, block)) {
+			return false;
+		}
+		os_mempool_poison_check(block, OS_MEMPOOL_TRUE_BLOCK_SIZE(mp));
+	}
+
+	return true;
+}
+#endif /* MYNEWT_VAL(OS_MEMPOOL_CHECK) */
+
+#if MYNEWT_VAL(OS_MEMPOOL_EXTENDED_API)
+static os_error_t
+os_mempool_clear(struct os_mempool *mp)
+{
+	struct os_memblock *block_ptr;
+	int true_block_size;
+	uint8_t *block_addr;
+	uint16_t blocks;
+
+	if (!mp) {
+		return OS_INVALID_PARM;
+	}
+
+	true_block_size = OS_MEM_TRUE_BLOCK_SIZE(mp->mp_block_size);
+
+	/* cleanup the memory pool structure */
+	mp->mp_num_free = mp->mp_num_blocks;
+	mp->mp_min_free = mp->mp_num_blocks;
+	os_mempool_poison((void *)mp->mp_membuf_addr, true_block_size);
+	SLIST_FIRST(mp) = (void *)mp->mp_membuf_addr;
+
+	/* Chain the memory blocks to the free list */
+	block_addr = (uint8_t *)mp->mp_membuf_addr;
+	block_ptr = (struct os_memblock *)block_addr;
+	blocks = mp->mp_num_blocks;
+
+	while (blocks > 1) {
+		block_addr += true_block_size;
+		os_mempool_poison(block_addr, true_block_size);
+		SLIST_NEXT(block_ptr, mb_next) = (struct os_memblock *)block_addr;
+		block_ptr = (struct os_memblock *)block_addr;
+		--blocks;
+	}
+
+	/* Last one in the list should be NULL */
+	SLIST_NEXT(block_ptr, mb_next) = NULL;
+
+	return OS_OK;
+}
+
+static os_error_t
+os_mempool_ext_init(struct os_mempool_ext *mpe, uint16_t blocks,
+                    uint32_t block_size, void *membuf, const char *name)
+{
+	int rc;
+
+	rc = os_mempool_init(&mpe->mpe_mp, blocks, block_size, membuf, name);
+	if (rc != 0) {
+		return rc;
+	}
+
+	mpe->mpe_mp.mp_flags = OS_MEMPOOL_F_EXT;
+	mpe->mpe_put_cb = NULL;
+	mpe->mpe_put_arg = NULL;
+
+	return 0;
+}
+
+static os_error_t
+os_mempool_ext_clear(struct os_mempool_ext *mpe)
+{
+	mpe->mpe_mp.mp_flags = 0;
+	mpe->mpe_put_cb = NULL;
+	mpe->mpe_put_arg = NULL;
+
+	return os_mempool_clear(&mpe->mpe_mp);
+}
+
+static struct os_mempool *
 os_mempool_info_get_next(struct os_mempool *mp, struct os_mempool_info *omi)
 {
 	struct os_mempool *cur;
@@ -355,6 +393,18 @@ os_mempool_info_get_next(struct os_mempool *mp, struct os_mempool_info *omi)
 
 	return (cur);
 }
+#endif /* MYNEWT_VAL(OS_MEMPOOL_EXTENDED_API) */
 
+static struct mempool_ops_t opts = {
+	.mempool_init = os_mempool_init,
+	.mempool_unregister = os_mempool_unregister,
+	.memblock_get = os_memblock_get,
+	.memblock_put = os_memblock_put,
+};
+
+struct mempool_ops_t * os_mempool_get_ops(void)
+{
+	return &opts;
+}
 
 #endif

--- a/esp_port/components/network_coprocessor/mempool_ll.h
+++ b/esp_port/components/network_coprocessor/mempool_ll.h
@@ -1,4 +1,10 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * SPDX-FileCopyrightText: 2015-2022 The Apache Software Foundation (ASF)
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * SPDX-FileContributor: 2019-2026 Espressif Systems (Shanghai) CO LTD
+ */
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,6 +22,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ */
+/*
+ * NOTICE: File has been changed from original implementation.
  */
 
 /**
@@ -63,33 +73,9 @@ extern "C" {
         )
 #define OS_ALIGNMENT 4
 
-#if 0
-extern portMUX_TYPE hosted_port_mutex;
-#endif
 extern SemaphoreHandle_t hosted_port_mutex;
-//critical section
-#if 0
-static inline uint32_t
-hosted_mp_enter_critical(void)
-{
-    portENTER_CRITICAL(&hosted_port_mutex);
-    return 0;
-}
-
-static inline void
-hosted_mp_exit_critical(uint32_t ctx)
-{
-    portEXIT_CRITICAL(&hosted_port_mutex);
-
-}
-#endif
 
 typedef uint32_t os_sr_t;
-
-#if 0
-#define OS_ENTER_CRITICAL(_sr) (_sr = hosted_mp_enter_critical())
-#define OS_EXIT_CRITICAL(_sr) (hosted_mp_exit_critical(_sr))
-#endif
 
 #define OS_INIT_CRITICAL() (hosted_port_mutex = xSemaphoreCreateMutex())
 #define OS_ENTER_CRITICAL() (xSemaphoreTake((hosted_port_mutex), portMAX_DELAY))
@@ -113,7 +99,6 @@ enum os_error {
 
 typedef enum os_error os_error_t;
 
-
 /**
  * A memory block structure. This simply contains a pointer to the free list
  * chain and is only used when the block is on the free list. When the block
@@ -123,11 +108,6 @@ typedef enum os_error os_error_t;
 struct os_memblock {
     SLIST_ENTRY(os_memblock) mb_next;
 };
-
-/* XXX: Change this structure so that we keep the first address in the pool? */
-/* XXX: add memory debug structure and associated code */
-/* XXX: Change how I coded the SLIST_HEAD here. It should be named:
-   SLIST_HEAD(,os_memblock) mp_head; */
 
 /**
  * Memory pool
@@ -150,6 +130,7 @@ struct os_mempool {
     /** Name for memory block */
     const char *name;
 };
+
 
 /**
  * Indicates an extended mempool.  Address can be safely cast to
@@ -207,19 +188,6 @@ struct os_mempool_info {
     char omi_name[OS_MEMPOOL_INFO_NAME_LEN];
 };
 
-/**
- * Get information about the next system memory pool.
- *
- * @param mempool The current memory pool, or NULL if starting iteration.
- * @param info    A pointer to the structure to return memory pool information
- *                into.
- *
- * @return The next memory pool in the list to get information about, or NULL
- *         when at the last memory pool.
- */
-struct os_mempool *os_mempool_info_get_next(struct os_mempool *,
-        struct os_mempool_info *);
-
 /*
  * To calculate size of the memory buffer needed for the pool. NOTE: This size
  * is NOT in bytes! The size is the number of os_membuf_t elements required for
@@ -237,113 +205,20 @@ typedef uint64_t os_membuf_t;
 #define OS_MEMPOOL_BYTES(n,blksize)     \
     (sizeof (os_membuf_t) * OS_MEMPOOL_SIZE((n), (blksize)))
 
-/**
- * Initialize a memory pool.
- *
- * @param mp            Pointer to a pointer to a mempool
- * @param blocks        The number of blocks in the pool
- * @param blocks_size   The size of the block, in bytes.
- * @param membuf        Pointer to memory to contain blocks.
- * @param name          Name of the pool.
- *
- * @return os_error_t
- */
-os_error_t os_mempool_init(struct os_mempool *mp, uint16_t blocks,
-                           uint32_t block_size, void *membuf, const char *name);
+struct mempool_ops_t {
+	os_error_t (*mempool_init)(struct os_mempool *mp, uint16_t blocks, uint32_t block_size, void *membuf, const char *name);
+	void       (*mempool_unregister)(struct os_mempool *mp);
+	void *     (*memblock_get)(struct os_mempool *mp);
+	os_error_t (*memblock_put)(struct os_mempool *mp, void *block_addr);
+};
 
-/**
- * Initializes an extended memory pool.  Extended attributes (e.g., callbacks)
- * are not specified when this function is called; they are assigned manually
- * after initialization.
- *
- * @param mpe           The extended memory pool to initialize.
- * @param blocks        The number of blocks in the pool.
- * @param block_size    The size of each block, in bytes.
- * @param membuf        Pointer to memory to contain blocks.
- * @param name          Name of the pool.
- *
- * @return os_error_t
- */
-os_error_t os_mempool_ext_init(struct os_mempool_ext *mpe, uint16_t blocks,
-                               uint32_t block_size, void *membuf, const char *name);
-
-/**
- * Clears a memory pool.
- *
- * @param mp            The mempool to clear.
- *
- * @return os_error_t
- */
-os_error_t os_mempool_clear(struct os_mempool *mp);
-
-/**
- * Clears an extended memory pool.
- *
- * @param mpe            The extended memory pool to clear.
- *
- * @return os_error_t
- */
-os_error_t os_mempool_ext_clear(struct os_mempool_ext *mpe);
-
-/**
- * Performs an integrity check of the specified mempool.  This function
- * attempts to detect memory corruption in the specified memory pool.
- *
- * @param mp                    The mempool to check.
- *
- * @return                      true if the memory pool passes the integrity
- *                                  check;
- *                              false if the memory pool is corrupt.
- */
-bool os_mempool_is_sane(const struct os_mempool *mp);
-
-/**
- * Checks if a memory block was allocated from the specified mempool.
- *
- * @param mp                    The mempool to check as parent.
- * @param block_addr            The memory block to check as child.
- *
- * @return                      0 if the block does not belong to the mempool;
- *                              1 if the block does belong to the mempool.
- */
-int os_memblock_from(const struct os_mempool *mp, const void *block_addr);
-
-/**
- * Get a memory block from a memory pool
- *
- * @param mp Pointer to the memory pool
- *
- * @return void* Pointer to block if available; NULL otherwise
- */
-void *os_memblock_get(struct os_mempool *mp);
-
-/**
- * Puts the memory block back into the pool, ignoring the put callback, if any.
- * This function should only be called from a put callback to free a block
- * without causing infinite recursion.
- *
- * @param mp Pointer to memory pool
- * @param block_addr Pointer to memory block
- *
- * @return os_error_t
- */
-os_error_t os_memblock_put_from_cb(struct os_mempool *mp, void *block_addr);
-
-/**
- * Puts the memory block back into the pool
- *
- * @param mp Pointer to memory pool
- * @param block_addr Pointer to memory block
- *
- * @return os_error_t
- */
-os_error_t os_memblock_put(struct os_mempool *mp, void *block_addr);
+struct mempool_ops_t * os_mempool_get_ops(void);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif // CONFIG_ESP_CACHE_MALLOC
 
 #endif  /* _OS_MEMPOOL_H_ */
 


### PR DESCRIPTION
## Summary

Three independent fixes in `esp_port/`:

### 1. `network_coprocessor/`: mempool / NimBLE link conflict (`dc83686500`)

Backport of upstream [esp-hosted-mcu c8e59587](https://github.com/espressif/esp-hosted-mcu/commit/c8e59587).

- Mark all `os_mempool_*` / `os_memblock_*` functions in `mempool_ll.c` as `static` so they no longer collide with NimBLE's identical symbols when BT NimBLE is enabled (e.g. RainMaker BLE provisioning on the C6 in `split_mode/rmaker_split_camera`).
- Add a `struct mempool_ops_t` ops table and an `os_mempool_get_ops()` accessor; route `hosted_mempool_*` calls through the ops table so the implementation can be swapped without re-exporting the LL symbols.
- Move per-pool metadata struct allocations to plain `calloc()` (default heap, SPIRAM-eligible where available); data buffers continue to use `heap_caps_malloc` with `INTERNAL | DMA | 8BIT`.

Without this fix, building any image that links *both* `network_coprocessor` and IDF's `bt` (NimBLE) fails at link time with multiple-definition errors on `os_memblock_put`, `os_memblock_put_from_cb`, `os_mempool_info_get_next`. The same fix is already in `espressif/esp-hosted-mcu` upstream (commit c8e59587 + follow-up 4b420272).

### 2. `kvs_signaling/SignalingESP.c`: bump `SIGNALING_CACHE_VERSION` v1 → v2 (`2eb8bda92c`)

Keeps the ESP-port NVS cache version in sync with `src/source/Signaling/FileCache.h`'s `DEFAULT_CACHE_FILE_PATH` bump.

`SignalingFileCacheEntry`'s binary layout gained two new fields between `region` and `httpsEndpoint` upstream — `controlPlaneUrl` and `useDualStackEndpoints` — in commit [`795a60d4f7`](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/commit/795a60d4f7) ("Signaling Cache Improvements"), landed on `beta-reference-esp-port` via `b6396850a4` ("Release v1.16.0", 2026-02-17). The upstream file-cache path bumped its filename suffix at the same time (`./.SignalingCache_v0` → `./.SignalingCache_v1`), but the ESP-port equivalent `SIGNALING_CACHE_VERSION` constant — which forms the prefix of the NVS key — was left at `"v1"`.

Devices flashed with both layouts under the same `v1` key read stale-shape blobs into the new struct: every field after `region` is shifted by `sizeof(controlPlaneUrl) + sizeof(useDualStackEndpoints)`, so `channelEndpointWss` / `channelEndpointHttps` / `storageStreamArn` / `channelEndpointWebrtc` come out as garbage. `channelArn` still reads correctly because it sits before the inserted fields.

**Symptom**: `signAwsRequestInfoQueryParam` returns `STATUS_INVALID_ARG (0x2)`, bubbled up from `getRequestHost()` failing because the corrupted WSS URL has no `://`.

Bumping the cache version orphans old blobs (they remain under the v1 NVS key but are simply never read again) and forces fresh entries under v2, written with the current layout.

### 3. `media_stream`: bump `esp_video` constraint `~1.4.0` → `~2.0.0` (`cb4244f583`)

Pulls upstream [`f5cd4bd1`](https://github.com/espressif/esp-video-components/commit/f5cd4bd1) ("Fix the WBG stop issue after starting the WBG module twice", first in `esp_video` v2.0.0). Without it, repeated camera start/stop cycles leave WBG in an inconsistent state — `isp_stop_wbg` skips the actual `esp_isp_wbg_disable()` call when red/blue balance gain ≠ 1.0 — and the next `VIDIOC_STREAMON` returns `EBUSY` (errno 16). Compatible with `esp32_p4_function_ev_board` ^5.1.0 (resolves to 5.2.3, which itself requires `esp_video ~2.0`).

## Test plan

- [x] `webrtc_classic` example builds clean on ESP32-P4 + C6 transport (default `CONFIG_ESP_CACHE_MALLOC=y`)
- [x] `rmaker_split_camera` (esp-rainmaker) builds for ESP32-C6 with BT NimBLE enabled — link errors gone
- [x] On a device previously running pre-`v1.16.0` firmware, signaling progresses past `CONNECTING` (state 8) without `signAwsRequestInfoQueryParam` failing 0x2
- [x] Camera survives multiple consecutive start/stop cycles — no `wbg isn't enabled yet` errors, no `VIDIOC_STREAMON … EBUSY`
- [x] `network_adapter` example regression check