### PR TITLE
Samples: Optimize getenv calls by caching the value

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -830,8 +830,8 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
     }
 
     if (!IS_NULL_OR_EMPTY_STRING((pMaxLogFiles = GETENV(MAX_NUM_LOG_FILES_ENV_VAR)))) {
-        CHK_STATUS_ERR(STRTOUI32(pMaxLogFiles, NULL, 10, &numLogFiles), STATUS_INVALID_ARG,
-                       "Failed to parse max number of log files: %s", pMaxLogFiles);
+        CHK_STATUS_ERR(STRTOUI32(pMaxLogFiles, NULL, 10, &numLogFiles), STATUS_INVALID_ARG, "Failed to parse max number of log files: %s",
+                       pMaxLogFiles);
         CHK_ERR(CHECK_IN_RANGE(numLogFiles, 1, 100), STATUS_INVALID_ARG, "MaxLogFiles must be in range: [1, 100], was: %d", numLogFiles);
     }
 

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -802,6 +802,7 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
 {
     STATUS retStatus = STATUS_SUCCESS;
     PCHAR pAccessKey, pSecretKey, pSessionToken, pLogFilesDir = (PCHAR) FILE_LOGGER_LOG_FILE_DIRECTORY_PATH;
+    PCHAR pMaxLogFiles, pLogFileDir;
     PSampleConfiguration pSampleConfiguration = NULL;
     UINT32 numLogFiles = DEFAULT_MAX_NUMBER_OF_LOG_FILES;
 
@@ -828,14 +829,14 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
         pSessionToken = NULL;
     }
 
-    if (!IS_NULL_OR_EMPTY_STRING(GETENV(MAX_NUM_LOG_FILES_ENV_VAR))) {
-        CHK_STATUS_ERR(STRTOUI32(GETENV(MAX_NUM_LOG_FILES_ENV_VAR), NULL, 10, &numLogFiles), STATUS_INVALID_ARG,
-                       "Failed to parse max number of log files: %s", GETENV(MAX_NUM_LOG_FILES_ENV_VAR));
+    if (!IS_NULL_OR_EMPTY_STRING((pMaxLogFiles = GETENV(MAX_NUM_LOG_FILES_ENV_VAR)))) {
+        CHK_STATUS_ERR(STRTOUI32(pMaxLogFiles, NULL, 10, &numLogFiles), STATUS_INVALID_ARG,
+                       "Failed to parse max number of log files: %s", pMaxLogFiles);
         CHK_ERR(CHECK_IN_RANGE(numLogFiles, 1, 100), STATUS_INVALID_ARG, "MaxLogFiles must be in range: [1, 100], was: %d", numLogFiles);
     }
 
-    if (!IS_NULL_OR_EMPTY_STRING(GETENV(LOG_FILE_DIR))) {
-        pLogFilesDir = GETENV(LOG_FILE_DIR);
+    if (!IS_NULL_OR_EMPTY_STRING((pLogFileDir = GETENV(LOG_FILE_DIR)))) {
+        pLogFilesDir = pLogFileDir;
     }
 
     // If the env is set, we generate normal log files apart from filtered profile log files


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Samples: Cache `GETENV()` results in local variables instead of calling `GETENV()` multiple times for the same environment variable.

*Why was it changed?*
- The code was calling `GETENV()` up to multiple times for the same variable (once in the condition, then again inside the block). Caching the result avoids redundant lookups.

*How was it changed?*
- Added local variables `pMaxLogFiles` and `pLogFileDir` to store the `GETENV()` result once.
- Reused the cached value in the NULL check and subsequent usage within the block.

*What testing was done for the changes?*
- CI/CD to verify the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
