### PR TITLE
GSt Samples: Handle null parameter to on_new_sample

### DIFF
--- a/samples/common/GstMedia.c
+++ b/samples/common/GstMedia.c
@@ -20,9 +20,9 @@ GstFlowReturn on_new_sample(GstElement* sink, gpointer data, UINT64 trackid)
     UINT32 i;
     guint bitrate;
 
-    CHK_ERR(pSampleConfiguration != NULL, STATUS_NULL_ARG, "NULL sample configuration");
-
     info.data = NULL;
+
+    CHK_ERR(pSampleConfiguration != NULL, STATUS_NULL_ARG, "NULL sample configuration");
     sample = gst_app_sink_pull_sample(GST_APP_SINK(sink));
 
     buffer = gst_sample_get_buffer(sample);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Moved `info.data = NULL` initialization above the `CHK_ERR` guard

*Why was it changed?*
- When `on_new_sample` is called with a NULL `pSampleConfiguration`, the CHK_ERR macro correctly jumps to CleanUp but the cleanup code tries to check the `info.data` that hasn't been initialized.

*How was it changed?*
- Swapped the order of initialization `info.data = NULL` and the `CHK_ERR(pSampleConfiguration != NULL, ...)` so initialization always happens first

*What testing was done for the changes?*
- Rebuild completed successfully with no warnings or errors
- CI/CD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
