### PR TITLE
Update libwebsockets to fix FD leak

### DIFF
--- a/CMake/Dependencies/libwebsockets-CMakeLists.txt
+++ b/CMake/Dependencies/libwebsockets-CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 ExternalProject_Add(project_libwebsockets
     GIT_REPOSITORY    https://github.com/warmcat/libwebsockets.git
-    GIT_TAG           v4.3.5
+    GIT_TAG           v4.3.10
     GIT_PROGRESS      TRUE
     GIT_SHALLOW       TRUE
     PREFIX            ${CMAKE_CURRENT_BINARY_DIR}/build


### PR DESCRIPTION
*Issue #, if available:*
2263

*What was changed?*
Update libwebsockets to latest stable (4.3.10)

*Why was it changed?*
Fix file descriptor leak by incorporating fix in libwebsockets
Specifically this commit:
https://github.com/warmcat/libwebsockets/commit/b9c3ed4cd1032e9b14cda733a753aad868b5382b

*How was it changed?*
Updated libwebsockets-CMakeLists.txt with appropriate GIT_TAG

*What testing was done for the changes?*
Run default kvsWebrtcClientMaster sample. Without the change it leaks 1 file descriptor every 2 hours (the lws ICE TTL reconnect). Can be verified with:
> ls -l /proc/<proc>/fd | wc -l.
With the updated libwebsockets change leak stops.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.