### PR TITLE
Fix bitwise & vs logical && typo in writeTransceiverDirection cleanup

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1326,7 +1326,7 @@ STATUS writeTransceiverDirection(PCHAR buf, UINT32 len, RTC_RTP_TRANSCEIVER_DIRE
     CHK(amountWouldHaveWritten < len, STATUS_BUFFER_TOO_SMALL);
 
 CleanUp:
-    if (STATUS_FAILED(retStatus) && buf != NULL & len > 0) {
+    if (STATUS_FAILED(retStatus) && buf != NULL && len > 0) {
         buf[0] = '\0';
     }
 


### PR DESCRIPTION
## What

In the cleanup block of `writeTransceiverDirection` (`src/source/PeerConnection/SessionDescription.c`), two boolean sub-expressions are combined with a single bitwise `&` instead of the intended logical `&&`:

```c
CleanUp:
    if (STATUS_FAILED(retStatus) && buf != NULL & len > 0) {
        buf[0] = '\0';
    }
```

## Why

The two operands of the `&` happen to be 0/1 results so runtime behavior matches the intent, but it trips `-Werror=parentheses` on stricter cross-compiles (e.g. ESP-IDF) and is a maintenance hazard.

## Fix

One-character change: `&` → `&&` so the whole condition uses logical AND consistently.

```diff
-    if (STATUS_FAILED(retStatus) && buf != NULL & len > 0) {
+    if (STATUS_FAILED(retStatus) && buf != NULL && len > 0) {
```

Introduced in `beb520b96` (Release v1.17.0).