### PR TITLE
PeerConnection: always use DEFAULT_H264_FMTP for our SDP fmtp

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -2167,6 +2167,23 @@ PUBLIC_API STATUS transceiverOnBandwidthEstimation(PRtcRtpTransceiver, UINT64, R
 PUBLIC_API STATUS transceiverOnPictureLoss(PRtcRtpTransceiver, UINT64, RtcOnPictureLoss);
 
 /**
+ * @brief Override the H264 fmtp string advertised in SDP offers and answers for this transceiver.
+ *
+ * By default the SDK advertises a Baseline-profile fmtp (DEFAULT_H264_FMTP). Use this to pin a
+ * different fmtp (for example, a different profile-level-id) when the local encoder/decoder
+ * requires it. Pass NULL or an empty string to clear the override and fall back to the default.
+ *
+ * Only applied to H264 (RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE);
+ * ignored for other codecs.
+ *
+ * @param[in] PRtcRtpTransceiver Transceiver returned from addTransceiver()
+ * @param[in] PCHAR Null-terminated fmtp string (without the "a=fmtp:<pt> " prefix), or NULL to clear
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS transceiverSetFmtp(PRtcRtpTransceiver, PCHAR);
+
+/**
  * @brief Frees the previously created transceiver object
  *
  * This method is currently a no-op as Transceivers are freed when freePeerConnection is called

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -215,6 +215,28 @@ CleanUp:
     return retStatus;
 }
 
+STATUS transceiverSetFmtp(PRtcRtpTransceiver pRtcRtpTransceiver, PCHAR fmtp)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pRtcRtpTransceiver;
+
+    CHK(pKvsRtpTransceiver != NULL, STATUS_NULL_ARG);
+
+    if (fmtp == NULL || fmtp[0] == '\0') {
+        pKvsRtpTransceiver->fmtpOverride[0] = '\0';
+    } else {
+        CHK(STRLEN(fmtp) <= MAX_SDP_ATTRIBUTE_VALUE_LENGTH, STATUS_INVALID_ARG_LEN);
+        STRNCPY(pKvsRtpTransceiver->fmtpOverride, fmtp, MAX_SDP_ATTRIBUTE_VALUE_LENGTH);
+        pKvsRtpTransceiver->fmtpOverride[MAX_SDP_ATTRIBUTE_VALUE_LENGTH] = '\0';
+    }
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS transceiverOnPictureLoss(PRtcRtpTransceiver pRtcRtpTransceiver, UINT64 customData, RtcOnPictureLoss onPictureLoss)
 {
     ENTERS();

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -84,6 +84,9 @@ typedef struct {
     RtcInboundRtpStreamStats inboundStats;
 
     BOOL twccEnabled; // whether TWCC was negotiated for this transceiver's m-line
+
+    // Caller-supplied fmtp override (H264 only). Empty string means "use the default".
+    CHAR fmtpOverride[MAX_SDP_ATTRIBUTE_VALUE_LENGTH + 1];
 } KvsRtpTransceiver, *PKvsRtpTransceiver;
 
 STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION, PKvsPeerConnection, UINT32, UINT32, PRtcMediaStreamTrack, PJitterBuffer, RTC_CODEC,

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -724,9 +724,16 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
 
     if (pRtcMediaStreamTrack->codec == RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE) {
         // TODO: Need additional condition for a signaling channel with an ENABLED media storage configuration
-        if (pKvsPeerConnection->isOffer) {
-            currentFmtp = DEFAULT_H264_FMTP;
-        }
+        //
+        // Advertise our own fmtp on both offer and answer. The previous
+        // answer-path behavior echoed the peer's fmtp, which on Baseline-only
+        // decoders (e.g. tinyh264 on ESP32-P4/S3) caused the SDK to accept
+        // High/Main offers and then fail to decode the resulting stream.
+        // Per RFC 6184 §8.2.2 profile-level-id and packetization-mode are
+        // symmetric parameters; advertising them ourselves correctly reflects
+        // what we will actually send. transceiverSetFmtp() lets callers pin
+        // a different fmtp when their codec needs it.
+        currentFmtp = pKvsRtpTransceiver->fmtpOverride[0] != '\0' ? pKvsRtpTransceiver->fmtpOverride : DEFAULT_H264_FMTP;
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtpmap");
         amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                                  SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " H264/90000", payloadType);
@@ -745,13 +752,13 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 rtcp-fb nack-pli value could not be written");
         attributeCount++;
 
-        // TODO: If level asymmetry is allowed, consider sending back DEFAULT_H264_FMTP instead of the received fmtp value.
         if (currentFmtp != NULL) {
             STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "fmtp");
             amountWritten =
                 SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
                          SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " %s", payloadType, currentFmtp);
             CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full H264 fmtp value could not be written");
+            DLOGI("H264 fmtp advertised in %s: pt=%" PRId64 " %s", pKvsPeerConnection->isOffer ? "offer" : "answer", payloadType, currentFmtp);
             attributeCount++;
         }
 

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -647,7 +647,8 @@ a=rtpmap:102 H264/90000
         EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
         EXPECT_EQ(TRUE, canTrickleIceCandidates(pRtcPeerConnection).value);
         EXPECT_EQ(createAnswer(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
-        EXPECT_PRED_FORMAT2(testing::IsNotSubstring, "fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
+        // SDK now advertises its own H264 fmtp on offer and answer regardless of what the peer sent.
+        EXPECT_PRED_FORMAT2(testing::IsSubstring, "fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
                             rtcSessionDescriptionInit.sdp);
 
         closePeerConnection(pRtcPeerConnection);
@@ -2069,7 +2070,7 @@ a=mid:2
 a=sctp-port:5000
 a=max-message-size:262144
 )",
-    "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e015",
+    "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
 };
 
 SdpMatch offer_1v1a1d_Chrome_Linux = SdpMatch{
@@ -2478,7 +2479,7 @@ a=setup:actpass
 a=sctp-port:5000
 a=max-message-size:1073741823
 )",
-    "profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1",
+    "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
 };
 
 SdpMatch offer_1v1a1d_Firefox_Mac = SdpMatch{
@@ -2571,7 +2572,7 @@ a=setup:actpass
 a=sctp-port:5000
 a=max-message-size:1073741823
 )",
-    "profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1",
+    "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
 };
 
 SdpMatch offer_1v1a1d_Chromium_Linux = SdpMatch{


### PR DESCRIPTION
## Problem

The override of `currentFmtp` to `DEFAULT_H264_FMTP` was gated on `isOffer`. When **answering**, the SDK echoed back whatever H.264 fmtp the peer offered — including the peer's `profile-level-id` — even though the SDK only ever encodes Baseline.

For platforms whose decoder cannot handle every profile (e.g. the tinyh264 software decoder on ESP32-P4 / ESP32-S3, which is Baseline-only), this meant a browser offering High or Main profile would negotiate successfully but then send a stream the device could not decode, producing endless `profile_idc is error` / ACCESS UNIT BOUNDARY CHECK failures.

There is a long-standing TODO in `PeerConnection.c` flagging exactly this case.

## Fix

Always advertise our own fmtp on both offer and answer, defaulting to `DEFAULT_H264_FMTP`. Add a `transceiverSetFmtp(PRtcRtpTransceiver, PCHAR)` public API so applications whose codec needs a different `profile-level-id` (or different fmtp parameters) can pin one per transceiver; the override falls back to `DEFAULT_H264_FMTP` when unset or cleared.

Per RFC 6184 §8.2.2 `profile-level-id` and `packetization-mode` are symmetric parameters — the fmtp we advertise should reflect what we will actually send, not what the peer happened to support. Echoing the peer's High/Main fmtp from the answer path was misadvertising the SDK's real capability. Codec *selection* still uses the matched remote fmtp via `getH264FmtpScore`; only the answer-side advertised fmtp changes.

## Behavior change

- **Peers that already offer `42e01f` (Baseline)**: no change.
- **Peers that offered only High / Main**: now receive a Baseline answer. If they cannot produce Baseline, they will drop video rather than send an undecodable stream — which is the correct WebRTC behavior on a profile mismatch.
- **Tests**: `TestPayloadNoFmtp` now expects DEFAULT fmtp in the answer; `SdpMatch` fixtures for Chrome_Android (was `42e015`) and Firefox Linux/Mac (different attr ordering) updated to the canonical DEFAULT string.

## Validated on

ESP32-P4 with tinyh264 software decoder, against Chrome / Firefox initiating a WebRTC call with High / Main profile in the offer.