### PR TITLE
TWCC API and sample integration

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -705,6 +705,29 @@ STATUS sampleOnPeerCongestionFeedback(UINT64 customData, PCongestionCtx pCongest
     BOOL lossClear = pSampleStreamingSession->twccMetadata.averagePacketLoss <= 2.0;
     BOOL delayClear = delayTrendMs < -0.1;
 
+    /*
+     * Multiplicative decrease factors (combined, take the minimum):
+     *
+     *   averagePacketLoss (EMA) | lossFactor
+     *   ------------------------+-----------
+     *   > 10.0%                 | 0.70
+     *   > 5.0% and <= 10.0%     | 0.85
+     *   <= 5.0%                 | 1.00
+     *
+     *   delayTrendMs (smoothed) | delayFactor
+     *   ------------------------+------------
+     *   > 5.0                   | 0.50
+     *   > 1.0 and <= 5.0        | 0.70
+     *   > 0.5 and <= 1.0        | 0.95
+     *   <= 0.5                  | 1.00
+     *
+     *   Additive increase (when not congested):
+     *   condition                | video step          | audio step
+     *   -------------------------+---------------------+---------------------
+     *   lossClear AND delayClear | +MAX_VIDEO/40       | +MAX_AUDIO/20
+     *   lossClear OR delayClear  | +MAX_VIDEO/80       | +MAX_AUDIO/20
+     *   both neutral             | hold                | hold
+     */
     DOUBLE factor = 1.0;
     if (lossCongested || delayCongested) {
         // Multiplicative decrease
@@ -725,10 +748,10 @@ STATUS sampleOnPeerCongestionFeedback(UINT64 customData, PCongestionCtx pCongest
         factor = MIN(lossFactor, delayFactor);
     } else if (lossClear && delayClear) {
         // Additive increase: fixed step relative to max
-        videoBitrate = MIN(videoBitrate + MAX_VIDEO_BITRATE_KBPS / 50, MAX_VIDEO_BITRATE_KBPS);
+        videoBitrate = MIN(videoBitrate + MAX_VIDEO_BITRATE_KBPS / 40, MAX_VIDEO_BITRATE_KBPS);
         factor = 0; // signal that we used additive increase
     } else if (lossClear || delayClear) {
-        videoBitrate = MIN(videoBitrate + MAX_VIDEO_BITRATE_KBPS / 100, MAX_VIDEO_BITRATE_KBPS);
+        videoBitrate = MIN(videoBitrate + MAX_VIDEO_BITRATE_KBPS / 80, MAX_VIDEO_BITRATE_KBPS);
         factor = 0;
     }
     // else: both neutral -> hold (factor = 1.0, no change)
@@ -738,7 +761,13 @@ STATUS sampleOnPeerCongestionFeedback(UINT64 customData, PCongestionCtx pCongest
     } else {
         videoBitrate = (UINT64) MAX(videoBitrate, MIN_VIDEO_BITRATE_KBPS);
     }
-    audioBitrate = (UINT64) MAX(MIN(audioBitrate * (factor > 0 ? factor : 1.0), MAX_AUDIO_BITRATE_BPS), MIN_AUDIO_BITRATE_BPS);
+    if (factor > 0) {
+        audioBitrate = (UINT64) MAX(MIN(audioBitrate * factor, MAX_AUDIO_BITRATE_BPS), MIN_AUDIO_BITRATE_BPS);
+    } else {
+        // Additive increase for audio
+        audioBitrate = MIN(audioBitrate + MAX_AUDIO_BITRATE_BPS / 20, MAX_AUDIO_BITRATE_BPS);
+        audioBitrate = (UINT64) MAX(audioBitrate, MIN_AUDIO_BITRATE_BPS);
+    }
 
     pSampleStreamingSession->twccMetadata.newVideoBitrate = videoBitrate;
     pSampleStreamingSession->twccMetadata.newAudioBitrate = audioBitrate;

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -559,8 +559,8 @@ STATUS createSampleStreamingSession(PSampleConfiguration pSampleConfiguration, P
 
     // twcc bandwidth estimation
     if (pSampleConfiguration->enableTwcc) {
-        CHK_STATUS(peerConnectionOnSenderBandwidthEstimation(pSampleStreamingSession->pPeerConnection, (UINT64) pSampleStreamingSession,
-                                                             sampleSenderBandwidthEstimationHandler));
+        CHK_STATUS(setOnPeerCongestionFeedbackFn(pSampleStreamingSession->pPeerConnection, (UINT64) pSampleStreamingSession,
+                                                 sampleOnPeerCongestionFeedback));
     }
     pSampleStreamingSession->startUpLatency = 0;
 CleanUp:
@@ -668,61 +668,89 @@ VOID sampleBandwidthEstimationHandler(UINT64 customData, DOUBLE maximumBitrate)
     DLOGV("received bitrate suggestion: %f", maximumBitrate);
 }
 
-// Sample callback for TWCC. Average packet is calculated with exponential moving average (EMA). If average packet lost is <= 5%,
-// the current bitrate is increased by 5%. If more than 5%, the current bitrate
-// is reduced by percent lost. Bitrate update is allowed every second and is increased/decreased upto the limits
-VOID sampleSenderBandwidthEstimationHandler(UINT64 customData, UINT32 txBytes, UINT32 rxBytes, UINT32 txPacketsCnt, UINT32 rxPacketsCnt,
-                                            UINT64 duration)
+// Congestion feedback callback: SDK invokes this when TWCC feedback arrives.
+// Combines loss-based and delay-based signals to adjust encoder bitrate.
+STATUS sampleOnPeerCongestionFeedback(UINT64 customData, PCongestionCtx pCongestionCtx)
 {
-    UNUSED_PARAM(duration);
-    UINT64 videoBitrate, audioBitrate;
-    UINT64 currentTimeMs, timeDiff;
-    UINT32 lostPacketsCnt = txPacketsCnt - rxPacketsCnt;
-    DOUBLE percentLost = (DOUBLE) ((txPacketsCnt > 0) ? (lostPacketsCnt * 100 / txPacketsCnt) : 0.0);
-    SampleStreamingSession* pSampleStreamingSession = (SampleStreamingSession*) customData;
-
-    if (pSampleStreamingSession == NULL) {
-        DLOGW("Invalid streaming session (NULL object)");
-        return;
+    PSampleStreamingSession pSampleStreamingSession = (PSampleStreamingSession) customData;
+    if (pSampleStreamingSession == NULL || pCongestionCtx == NULL) {
+        return STATUS_NULL_ARG;
     }
 
-    // Calculate packet loss
+    UINT64 videoBitrate, audioBitrate;
+    UINT64 currentTimeMs, timeDiff;
+    UINT32 txPacketsCnt = pCongestionCtx->txPackets;
+    UINT32 rxPacketsCnt = pCongestionCtx->rxPackets;
+    UINT32 lostPacketsCnt = txPacketsCnt > rxPacketsCnt ? txPacketsCnt - rxPacketsCnt : 0;
+    DOUBLE percentLost = (DOUBLE) ((txPacketsCnt > 0) ? (lostPacketsCnt * 100 / txPacketsCnt) : 0.0);
+    DOUBLE delayTrendMs = pCongestionCtx->congestionState.delayTrend;
+
+    // Calculate packet loss (EMA smoothed)
     pSampleStreamingSession->twccMetadata.averagePacketLoss =
         EMA_ACCUMULATOR_GET_NEXT(pSampleStreamingSession->twccMetadata.averagePacketLoss, ((DOUBLE) percentLost));
 
     currentTimeMs = GETTIME();
     timeDiff = currentTimeMs - pSampleStreamingSession->twccMetadata.lastAdjustmentTimeMs;
     if (timeDiff < TWCC_BITRATE_ADJUSTMENT_INTERVAL_MS) {
-        // Too soon for another adjustment
-        return;
+        return STATUS_SUCCESS;
     }
 
     MUTEX_LOCK(pSampleStreamingSession->twccMetadata.updateLock);
     videoBitrate = pSampleStreamingSession->twccMetadata.currentVideoBitrate;
     audioBitrate = pSampleStreamingSession->twccMetadata.currentAudioBitrate;
 
-    if (pSampleStreamingSession->twccMetadata.averagePacketLoss <= 5) {
-        // increase encoder bitrate by 5 percent with a cap at MAX_BITRATE
-        videoBitrate = (UINT64) MIN(videoBitrate * 1.05, MAX_VIDEO_BITRATE_KBPS);
-        // increase encoder bitrate by 5 percent with a cap at MAX_BITRATE
-        audioBitrate = (UINT64) MIN(audioBitrate * 1.05, MAX_AUDIO_BITRATE_BPS);
-    } else {
-        // decrease encoder bitrate by average packet loss percent, with a cap at MIN_BITRATE
-        videoBitrate = (UINT64) MAX(videoBitrate * (1.0 - pSampleStreamingSession->twccMetadata.averagePacketLoss / 100.0), MIN_VIDEO_BITRATE_KBPS);
-        // decrease encoder bitrate by average packet loss percent, with a cap at MIN_BITRATE
-        audioBitrate = (UINT64) MAX(audioBitrate * (1.0 - pSampleStreamingSession->twccMetadata.averagePacketLoss / 100.0), MIN_AUDIO_BITRATE_BPS);
-    }
+    // Combine loss-based and delay-based signals for bandwidth decision
+    BOOL lossCongested = pSampleStreamingSession->twccMetadata.averagePacketLoss > 5.0;
+    BOOL delayCongested = delayTrendMs > 0.5;
+    BOOL lossClear = pSampleStreamingSession->twccMetadata.averagePacketLoss <= 2.0;
+    BOOL delayClear = delayTrendMs < -0.1;
 
-    // Update the session with the new bitrate and adjustment time
+    DOUBLE factor = 1.0;
+    if (lossCongested || delayCongested) {
+        // Multiplicative decrease
+        DOUBLE lossFactor = 1.0;
+        DOUBLE delayFactor = 1.0;
+        if (pSampleStreamingSession->twccMetadata.averagePacketLoss > 10.0) {
+            lossFactor = 0.7;
+        } else if (lossCongested) {
+            lossFactor = 0.85;
+        }
+        if (delayTrendMs > 5.0) {
+            delayFactor = 0.5;
+        } else if (delayTrendMs > 1.0) {
+            delayFactor = 0.7;
+        } else if (delayCongested) {
+            delayFactor = 0.95;
+        }
+        factor = MIN(lossFactor, delayFactor);
+    } else if (lossClear && delayClear) {
+        // Additive increase: fixed step relative to max
+        videoBitrate = MIN(videoBitrate + MAX_VIDEO_BITRATE_KBPS / 50, MAX_VIDEO_BITRATE_KBPS);
+        factor = 0; // signal that we used additive increase
+    } else if (lossClear || delayClear) {
+        videoBitrate = MIN(videoBitrate + MAX_VIDEO_BITRATE_KBPS / 100, MAX_VIDEO_BITRATE_KBPS);
+        factor = 0;
+    }
+    // else: both neutral -> hold (factor = 1.0, no change)
+
+    if (factor > 0) {
+        videoBitrate = (UINT64) MAX(MIN(videoBitrate * factor, MAX_VIDEO_BITRATE_KBPS), MIN_VIDEO_BITRATE_KBPS);
+    } else {
+        videoBitrate = (UINT64) MAX(videoBitrate, MIN_VIDEO_BITRATE_KBPS);
+    }
+    audioBitrate = (UINT64) MAX(MIN(audioBitrate * (factor > 0 ? factor : 1.0), MAX_AUDIO_BITRATE_BPS), MIN_AUDIO_BITRATE_BPS);
+
     pSampleStreamingSession->twccMetadata.newVideoBitrate = videoBitrate;
     pSampleStreamingSession->twccMetadata.newAudioBitrate = audioBitrate;
     MUTEX_UNLOCK(pSampleStreamingSession->twccMetadata.updateLock);
 
     pSampleStreamingSession->twccMetadata.lastAdjustmentTimeMs = currentTimeMs;
 
-    DLOGI("Adjustment made: average packet loss = %.2f%%, timediff: %llu ms", pSampleStreamingSession->twccMetadata.averagePacketLoss, timeDiff);
-    DLOGI("Suggested video bitrate %u kbps, suggested audio bitrate: %u bps, sent: %u bytes %u packets received: %u bytes %u packets in %lu msec",
-          videoBitrate, audioBitrate, txBytes, txPacketsCnt, rxBytes, rxPacketsCnt, duration / 10000ULL);
+    DLOGD("BWE: pktLoss=%.2f%% delayTrend=%.4f ms factor=%.2f | video=%llu kbps audio=%llu bps | tx: %u bytes %u pkts, rx: %u bytes %u pkts",
+          pSampleStreamingSession->twccMetadata.averagePacketLoss, delayTrendMs, factor, videoBitrate, audioBitrate, pCongestionCtx->txBytes,
+          txPacketsCnt, pCongestionCtx->rxBytes, rxPacketsCnt);
+
+    return STATUS_SUCCESS;
 }
 
 STATUS handleRemoteCandidate(PSampleStreamingSession pSampleStreamingSession, PSignalingMessage pSignalingMessage)

--- a/samples/common/Samples.h
+++ b/samples/common/Samples.h
@@ -108,7 +108,7 @@ extern "C" {
 #define MIN_VIDEO_BITRATE_KBPS              384    // Unit kilobits/sec. Value could change based on codec.
 #define MAX_VIDEO_BITRATE_KBPS              2500   // Unit kilobits/sec. Value could change based on codec.
 #define MIN_AUDIO_BITRATE_BPS               4000   // Unit bits/sec. Value could change based on codec.
-#define MAX_AUDIO_BITRATE_BPS               650000 // Unit bits/sec. Value could change based on codec.
+#define MAX_AUDIO_BITRATE_BPS               128000 // Unit bits/sec. Value could change based on codec.
 
 typedef enum {
     SAMPLE_STREAMING_VIDEO_ONLY,

--- a/samples/common/Samples.h
+++ b/samples/common/Samples.h
@@ -104,11 +104,11 @@ extern "C" {
 #define MAX_SIGNALING_CLIENT_METRICS_MESSAGE_SIZE 736 // strlen(SIGNALING_CLIENT_METRICS_JSON_TEMPLATE) + 20 * 10
 #define MAX_ICE_AGENT_METRICS_MESSAGE_SIZE        113 // strlen(ICE_AGENT_METRICS_JSON_TEMPLATE) + 20 * 2
 
-#define TWCC_BITRATE_ADJUSTMENT_INTERVAL_MS 1000 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND
-#define MIN_VIDEO_BITRATE_KBPS              512     // Unit kilobits/sec. Value could change based on codec.
-#define MAX_VIDEO_BITRATE_KBPS              2048000 // Unit kilobits/sec. Value could change based on codec.
-#define MIN_AUDIO_BITRATE_BPS               4000    // Unit bits/sec. Value could change based on codec.
-#define MAX_AUDIO_BITRATE_BPS               650000  // Unit bits/sec. Value could change based on codec.
+#define TWCC_BITRATE_ADJUSTMENT_INTERVAL_MS 250 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND
+#define MIN_VIDEO_BITRATE_KBPS              384    // Unit kilobits/sec. Value could change based on codec.
+#define MAX_VIDEO_BITRATE_KBPS              2500   // Unit kilobits/sec. Value could change based on codec.
+#define MIN_AUDIO_BITRATE_BPS               4000   // Unit bits/sec. Value could change based on codec.
+#define MAX_AUDIO_BITRATE_BPS               650000 // Unit bits/sec. Value could change based on codec.
 
 typedef enum {
     SAMPLE_STREAMING_VIDEO_ONLY,
@@ -296,7 +296,7 @@ VOID sampleVideoFrameHandler(UINT64, PFrame);
 VOID sampleAudioFrameHandler(UINT64, PFrame);
 VOID sampleFrameHandler(UINT64, PFrame);
 VOID sampleBandwidthEstimationHandler(UINT64, DOUBLE);
-VOID sampleSenderBandwidthEstimationHandler(UINT64, UINT32, UINT32, UINT32, UINT32, UINT64);
+STATUS sampleOnPeerCongestionFeedback(UINT64, PCongestionCtx);
 VOID onDataChannel(UINT64, PRtcDataChannel);
 VOID onConnectionStateChange(UINT64, RTC_PEER_CONNECTION_STATE);
 STATUS sessionCleanupWait(PSampleConfiguration);

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1198,6 +1198,66 @@ typedef VOID (*RtcOnBandwidthEstimation)(UINT64, DOUBLE);
 typedef VOID (*RtcOnSenderBandwidthEstimation)(UINT64, UINT32, UINT32, UINT32, UINT32, UINT64);
 
 /**
+ * @brief Per-packet feedback from a TWCC report.
+ *
+ * NOTE: sendTime and recvTime use different unsynchronized clocks
+ * (local sender clock vs. remote receiver clock).
+ * These values are meaningful for computing inter-packet deltas
+ * (e.g., one-way delay variation). Do NOT use them to calculate RTT.
+ */
+typedef struct {
+    UINT16 twccSeqNum; //!< Transport-wide sequence number
+    UINT64 sendTime;   //!< RTP packet send time in hundreds of nanos (local clock)
+    UINT64 recvTime;   //!< RTP packet reported receive time in hundreds of nanos (remote clock, reconstructed)
+    UINT32 packetSize; //!< Size of the packet sent (bytes)
+} TwccFeedback, *PTwccFeedback;
+
+/**
+ * @brief Congestion state output from the trendline estimator.
+ */
+typedef struct {
+    DOUBLE delayTrend; //!< Smoothed slope of accumulated delay variation (ms).
+                       //!<   >0: congestion building
+                       //!<   ~0: stable
+                       //!<   <0: congestion clearing
+} TwccCongestionState, *PTwccCongestionState;
+
+/**
+ * @brief Context provided to the bandwidth controller callback.
+ */
+typedef struct {
+    UINT32 txBytes;                      //!< Bytes sent over the transport
+    UINT32 rxBytes;                      //!< Bytes reported as received
+    UINT32 txPackets;                    //!< Packets sent over the transport
+    UINT32 rxPackets;                    //!< Packets reported as received
+    UINT64 duration;                     //!< Time window for this feedback (hundreds of nanos)
+    TwccCongestionState congestionState; //!< Current congestion state
+} CongestionCtx, *PCongestionCtx;
+
+/**
+ * @brief Called when new TWCC feedback is available from the remote peer.
+ * Updates the current network congestion state with latest data.
+ * The SDK provides a default implementation; set a custom callback to override.
+ *
+ * @param[in] UINT64 customData - User customData
+ * @param[in] PTwccFeedback twccFeedbackList - batch of per-packet feedback
+ * @param[in] UINT32 twccFeedbackListLen - length of the list
+ * @param[in,out] PTwccCongestionState pCongestionState - congestion state to update
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+typedef STATUS (*RtcOnTwccFeedbackReceived)(UINT64, PTwccFeedback, UINT32, PTwccCongestionState);
+
+/**
+ * @brief Called when the SDK has computed congestion context from TWCC feedback.
+ * The application uses this to make bandwidth decisions and adjust encoder parameters.
+ *
+ * @param[in] UINT64 customData - User customData
+ * @param[in] PCongestionCtx congestionContext - latest feedback context
+ */
+typedef STATUS (*RtcOnPeerCongestionFeedback)(UINT64, PCongestionCtx);
+
+/**
  * @brief RtcOnPictureLoss is fired everytime a Picture Loss Indication (PLI)
  * feedback message is received. Receiving such message normally indicates that
  * you sent a video frame which receiver could not decode.
@@ -1855,6 +1915,31 @@ PUBLIC_API STATUS peerConnectionOnIceCandidate(PRtcPeerConnection, UINT64, RtcOn
  * @return STATUS code of the execution. STATUS_SUCCESS on success
  */
 PUBLIC_API STATUS peerConnectionOnSenderBandwidthEstimation(PRtcPeerConnection, UINT64, RtcOnSenderBandwidthEstimation);
+
+/**
+ * @brief Configure a custom TWCC feedback received callback.
+ * When TWCC feedback arrives from the remote peer, this callback is invoked to update the congestion state.
+ * If not set, the SDK uses a default EMA-smoothed least-squares trendline estimator.
+ *
+ * @param[in] PRtcPeerConnection Initialized RtcPeerConnection
+ * @param[in] UINT64 User customData that will be passed along when the callback is called
+ * @param[in] RtcOnTwccFeedbackReceived User callback
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS setOnTwccFeedbackReceived(PRtcPeerConnection, UINT64, RtcOnTwccFeedbackReceived);
+
+/**
+ * @brief Configure a callback invoked when the SDK has congestion context ready for the application.
+ * The application uses this to adjust encoder bitrate or other media parameters.
+ *
+ * @param[in] PRtcPeerConnection Initialized RtcPeerConnection
+ * @param[in] UINT64 User customData that will be passed along when the callback is called
+ * @param[in] RtcOnPeerCongestionFeedback User callback
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS setOnPeerCongestionFeedbackFn(PRtcPeerConnection, UINT64, RtcOnPeerCongestionFeedback);
 
 /**
  * Set a callback for data channel

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -2037,7 +2037,9 @@ STATUS twccManagerOnPacketSent(PKvsPeerConnection pKvsPeerConnection, PRtpPacket
     PTwccRtpPacketInfo pTwccRtpPktInfo = NULL;
 
     CHK(pKvsPeerConnection != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
-    CHK((pKvsPeerConnection->onSenderBandwidthEstimation != NULL || pKvsPeerConnection->onPeerCongestionFeedback != NULL) &&
+    // Skip TWCC tracking if no callback is set to consume the results
+    CHK((pKvsPeerConnection->onSenderBandwidthEstimation != NULL || pKvsPeerConnection->onPeerCongestionFeedback != NULL ||
+         pKvsPeerConnection->onTwccFeedbackReceived != NULL) &&
             pKvsPeerConnection->pTwccManager != NULL,
         STATUS_SUCCESS);
     CHK(TWCC_EXT_PROFILE == pRtpPacket->header.extensionProfile, STATUS_SUCCESS);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -2037,7 +2037,9 @@ STATUS twccManagerOnPacketSent(PKvsPeerConnection pKvsPeerConnection, PRtpPacket
     PTwccRtpPacketInfo pTwccRtpPktInfo = NULL;
 
     CHK(pKvsPeerConnection != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
-    CHK(pKvsPeerConnection->onSenderBandwidthEstimation != NULL && pKvsPeerConnection->pTwccManager != NULL, STATUS_SUCCESS);
+    CHK((pKvsPeerConnection->onSenderBandwidthEstimation != NULL || pKvsPeerConnection->onPeerCongestionFeedback != NULL) &&
+            pKvsPeerConnection->pTwccManager != NULL,
+        STATUS_SUCCESS);
     CHK(TWCC_EXT_PROFILE == pRtpPacket->header.extensionProfile, STATUS_SUCCESS);
 
     MUTEX_LOCK(pKvsPeerConnection->twccLock);
@@ -2139,6 +2141,42 @@ STATUS iceAgentGetMetrics(PRtcPeerConnection pPeerConnection, PKvsIceAgentMetric
         pKvsIceAgentMetrics->version = ICE_AGENT_METRICS_CURRENT_VERSION;
     }
     CHK_STATUS(getIceAgentStats(pKvsPeerConnection->pIceAgent, pKvsIceAgentMetrics));
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS setOnTwccFeedbackReceived(PRtcPeerConnection pPeerConnection, UINT64 customData, RtcOnTwccFeedbackReceived onTwccFbReceived)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
+
+    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    pKvsPeerConnection->onTwccFeedbackReceivedCustomData = customData;
+    pKvsPeerConnection->onTwccFeedbackReceived = onTwccFbReceived;
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS setOnPeerCongestionFeedbackFn(PRtcPeerConnection pPeerConnection, UINT64 customData, RtcOnPeerCongestionFeedback onPeerCongestionFeedback)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
+
+    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    pKvsPeerConnection->onPeerCongestionFeedbackCustomData = customData;
+    pKvsPeerConnection->onPeerCongestionFeedback = onPeerCongestionFeedback;
+
 CleanUp:
     CHK_LOG_ERR(retStatus);
 

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -48,9 +48,16 @@ typedef enum {
     RTC_RTX_CODEC_H265 = 3,
 } RTX_CODEC;
 
+/**
+ * Contains the necessary info for TWCC one-way delay variation calculation.
+ * Between two consecutive seqNum packets 1 and 2:
+ * - Inter-send delta: T2 - T1
+ * - Inter-recv delta: R2 - R1
+ * - One-way delay variation: (R2 - R1) - (T2 - T1)
+ */
 typedef struct {
-    UINT64 localTimeKvs;
-    UINT64 remoteTimeKvs;
+    UINT64 localTimeKvs;  //!< sender send time (T) in hundreds of nanos
+    UINT64 remoteTimeKvs; //!< receiver arrival time (R) in hundreds of nanos (reconstructed)
     UINT32 packetSize;
 } TwccRtpPacketInfo, *PTwccRtpPacketInfo;
 
@@ -59,6 +66,8 @@ typedef struct {
     UINT16 firstSeqNumInRollingWindow;    // To monitor the last deleted packet in the rolling window
     UINT16 lastReportedSeqNum;            // To monitor the last packet's seqNum in the TWCC response
     UINT16 prevReportedBaseSeqNum;        // To monitor the base seqNum in the TWCC response
+    DOUBLE smoothedSlope;                 // EMA-smoothed trendline slope (hundreds-of-nanos units)
+    DOUBLE lastQueueDelay;                // Last computed queue delay (hundreds-of-nanos units)
 } TwccManager, *PTwccManager;
 
 typedef struct {
@@ -145,6 +154,14 @@ typedef struct {
     PTwccManager pTwccManager;
     RtcOnSenderBandwidthEstimation onSenderBandwidthEstimation;
     UINT64 onSenderBandwidthEstimationCustomData;
+
+    // TWCC trendline callback (configurable estimator)
+    RtcOnTwccFeedbackReceived onTwccFeedbackReceived;
+    UINT64 onTwccFeedbackReceivedCustomData;
+
+    // Bandwidth controller callback (application-side)
+    RtcOnPeerCongestionFeedback onPeerCongestionFeedback;
+    UINT64 onPeerCongestionFeedbackCustomData;
 
     UINT64 iceConnectingStartTime;
     KvsPeerConnectionDiagnostics peerConnectionDiagnostics;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -146,6 +146,10 @@ CleanUp:
     return retStatus;
 }
 
+// After this function executes, the twccManager saves the indexes of the packets
+// reported in this feedback.
+// - twccManager.prevReportedBaseSeqNum = base seqNum, first packet in the report
+// - twccManager.lastReportedSeqNum = final seqNum, last packet in the report
 STATUS parseRtcpTwccPacket(PRtcpPacket pRtcpPacket, PTwccManager pTwccManager)
 {
     /*
@@ -484,12 +488,40 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
 
     // Compute trendline
     if (pKvsPeerConnection->onTwccFeedbackReceived != NULL) {
-        // Custom estimator callback
+        // Custom estimator callback, build feedback list from this TWCC report
         TwccCongestionState congestionState;
+        PTwccFeedback pFeedbackList = NULL;
+        UINT32 feedbackCount = 0;
+        UINT16 seqNum;
+        UINT64 twccPktVal = 0;
+        PTwccRtpPacketInfo pPktInfo = NULL;
+        UINT16 reportLen = (UINT16) (pTwccManager->lastReportedSeqNum - pTwccManager->prevReportedBaseSeqNum + 1);
+
         MEMSET(&congestionState, 0, SIZEOF(congestionState));
+        pFeedbackList = (PTwccFeedback) MEMALLOC(reportLen * SIZEOF(TwccFeedback));
+        CHK(pFeedbackList != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+        for (seqNum = pTwccManager->prevReportedBaseSeqNum; seqNum != (UINT16) (pTwccManager->lastReportedSeqNum + 1); seqNum++) {
+            if (STATUS_SUCCEEDED(hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, seqNum, &twccPktVal))) {
+                pPktInfo = (PTwccRtpPacketInfo) twccPktVal;
+                if (pPktInfo != NULL && pPktInfo->remoteTimeKvs != TWCC_PACKET_LOST_TIME && pPktInfo->remoteTimeKvs != TWCC_PACKET_UNITIALIZED_TIME) {
+                    pFeedbackList[feedbackCount].twccSeqNum = seqNum;
+                    pFeedbackList[feedbackCount].sendTime = pPktInfo->localTimeKvs;
+                    pFeedbackList[feedbackCount].recvTime = pPktInfo->remoteTimeKvs;
+                    pFeedbackList[feedbackCount].packetSize = pPktInfo->packetSize;
+                    feedbackCount++;
+                }
+            }
+        }
+
         MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
         locked = FALSE;
-        CHK_STATUS(pKvsPeerConnection->onTwccFeedbackReceived(pKvsPeerConnection->onTwccFeedbackReceivedCustomData, NULL, 0, &congestionState));
+
+        // Invoke custom callback to perform the calculation
+        retStatus = pKvsPeerConnection->onTwccFeedbackReceived(pKvsPeerConnection->onTwccFeedbackReceivedCustomData, pFeedbackList, feedbackCount,
+                                                               &congestionState);
+        SAFE_MEMFREE(pFeedbackList);
+        CHK_STATUS(retStatus);
         MUTEX_LOCK(pKvsPeerConnection->twccLock);
         locked = TRUE;
         delayTrend = congestionState.delayTrend;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -321,17 +321,6 @@ CleanUp:
     return retStatus;
 }
 
-// Computes TWCC congestion signals from the current feedback window [prevReportedBaseSeqNum, lastReportedSeqNum].
-//
-// One-way delay variation measures how packet spacing changes through the network:
-//   For two consecutive packets, if the sender sends them 10ms apart but the receiver gets them 15ms apart,
-//   the extra 5ms means the second packet was delayed longer — likely sitting in a network buffer/queue.
-//   Formally: delayVariation = (receiverArrivalGap - senderSendGap) = (R_i - R_{i-1}) - (T_i - T_{i-1})
-//
-// Outputs (both in milliseconds):
-//   pDelayTrend: EMA-smoothed least-squares slope of accumulated delay variation.
-//                positive = congestion accelerating, negative = congestion clearing, ~0 = stable.
-//   pQueueDelay: sum of per-pair delay variations across the window.
 STATUS computeTwccTrendline(PTwccManager pTwccManager, PDOUBLE pDelayTrend, PDOUBLE pQueueDelay)
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -339,6 +328,7 @@ STATUS computeTwccTrendline(PTwccManager pTwccManager, PDOUBLE pDelayTrend, PDOU
     PTwccRtpPacketInfo pCurr = NULL, pPrev = NULL;
     UINT16 seqNum;
     DOUBLE accumulatedDelay = 0.0;
+    // Accumulators for least-squares: sum(x), sum(y), sum(x*y), sum(x^2)
     DOUBLE sumX = 0.0, sumY = 0.0, sumXY = 0.0, sumX2 = 0.0;
     DOUBLE rawSlope = 0.0;
     UINT32 n = 0;
@@ -355,10 +345,26 @@ STATUS computeTwccTrendline(PTwccManager pTwccManager, PDOUBLE pDelayTrend, PDOU
         }
 
         if (pPrev != NULL) {
+            // d_i = (recvTime_i - recvTime_{i-1}) - (sendTime_i - sendTime_{i-1})
+            // Positive means receiver-side gap grew relative to sender-side gap (queuing delay increased)
             INT64 interRecv = (INT64) (pCurr->remoteTimeKvs - pPrev->remoteTimeKvs);
             INT64 interSend = (INT64) (pCurr->localTimeKvs - pPrev->localTimeKvs);
+            // D_i = D_{i-1} + d_i  (running sum of delay variations)
             accumulatedDelay += (DOUBLE) (interRecv - interSend);
 
+            // Build accumulators for ordinary least-squares (OLS) linear regression.
+            // We are fitting the model: y = slope * x + intercept
+            //   where x_i = sample index (0, 1, 2, ...)
+            //         y_i = accumulated delay D_i at that sample
+            //
+            // The OLS slope formula requires these running sums:
+            //   sumX  = Σ x_i           (sum of all x values)
+            //   sumY  = Σ y_i           (sum of all y values)
+            //   sumXY = Σ (x_i * y_i)   (sum of products, measures correlation)
+            //   sumX2 = Σ (x_i^2)       (sum of squared x, measures x spread)
+            //
+            // These avoid storing all data points in an array. We compute the
+            // slope in O(1) space by maintaining only these four running totals.
             sumX += (DOUBLE) n;
             sumY += accumulatedDelay;
             sumXY += (DOUBLE) n * accumulatedDelay;
@@ -369,6 +375,8 @@ STATUS computeTwccTrendline(PTwccManager pTwccManager, PDOUBLE pDelayTrend, PDOU
         pPrev = pCurr;
     }
 
+    // Least-squares slope: (n*sum(xy) - sum(x)*sum(y)) / (n*sum(x^2) - sum(x)^2)
+    // Need at least 2 points to define a line
     if (n >= 2) {
         DOUBLE denom = (DOUBLE) n * sumX2 - sumX * sumX;
         if (denom != 0.0) {
@@ -376,8 +384,11 @@ STATUS computeTwccTrendline(PTwccManager pTwccManager, PDOUBLE pDelayTrend, PDOU
         }
     }
 
+    // EMA smoothing: S_t = alpha * rawSlope + (1 - alpha) * S_{t-1}
+    // This filters out short-term noise while tracking sustained trends
     pTwccManager->smoothedSlope = TWCC_TRENDLINE_SMOOTHING_FACTOR * rawSlope + (1.0 - TWCC_TRENDLINE_SMOOTHING_FACTOR) * pTwccManager->smoothedSlope;
     pTwccManager->lastQueueDelay = accumulatedDelay;
+    // Convert from internal time units (hundreds of nanoseconds) to milliseconds for output
     *pDelayTrend = pTwccManager->smoothedSlope / (DOUBLE) HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     *pQueueDelay = accumulatedDelay / (DOUBLE) HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
 

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -490,7 +490,11 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
     DOUBLE delayTrend = 0.0, queueDelay = 0.0;
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
-    CHK(pKvsPeerConnection->pTwccManager != NULL, STATUS_SUCCESS);
+    // Skip TWCC parsing if no callback is set to consume the results
+    CHK(pKvsPeerConnection->pTwccManager != NULL &&
+            (pKvsPeerConnection->onSenderBandwidthEstimation != NULL || pKvsPeerConnection->onPeerCongestionFeedback != NULL ||
+             pKvsPeerConnection->onTwccFeedbackReceived != NULL),
+        STATUS_SUCCESS);
 
     MUTEX_LOCK(pKvsPeerConnection->twccLock);
     locked = TRUE;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -317,6 +317,73 @@ CleanUp:
     return retStatus;
 }
 
+// Computes TWCC congestion signals from the current feedback window [prevReportedBaseSeqNum, lastReportedSeqNum].
+//
+// One-way delay variation measures how packet spacing changes through the network:
+//   For two consecutive packets, if the sender sends them 10ms apart but the receiver gets them 15ms apart,
+//   the extra 5ms means the second packet was delayed longer — likely sitting in a network buffer/queue.
+//   Formally: delayVariation = (receiverArrivalGap - senderSendGap) = (R_i - R_{i-1}) - (T_i - T_{i-1})
+//
+// Outputs (both in milliseconds):
+//   pDelayTrend: EMA-smoothed least-squares slope of accumulated delay variation.
+//                positive = congestion accelerating, negative = congestion clearing, ~0 = stable.
+//   pQueueDelay: sum of per-pair delay variations across the window.
+STATUS computeTwccTrendline(PTwccManager pTwccManager, PDOUBLE pDelayTrend, PDOUBLE pQueueDelay)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 twccPktValue = 0;
+    PTwccRtpPacketInfo pCurr = NULL, pPrev = NULL;
+    UINT16 seqNum;
+    DOUBLE accumulatedDelay = 0.0;
+    DOUBLE sumX = 0.0, sumY = 0.0, sumXY = 0.0, sumX2 = 0.0;
+    DOUBLE rawSlope = 0.0;
+    UINT32 n = 0;
+
+    CHK(pTwccManager != NULL && pDelayTrend != NULL && pQueueDelay != NULL, STATUS_NULL_ARG);
+
+    for (seqNum = pTwccManager->prevReportedBaseSeqNum; seqNum != (UINT16) (pTwccManager->lastReportedSeqNum + 1); seqNum++) {
+        if (STATUS_FAILED(hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, seqNum, &twccPktValue))) {
+            continue;
+        }
+        pCurr = (PTwccRtpPacketInfo) twccPktValue;
+        if (pCurr == NULL || pCurr->remoteTimeKvs == TWCC_PACKET_LOST_TIME || pCurr->remoteTimeKvs == TWCC_PACKET_UNITIALIZED_TIME) {
+            continue;
+        }
+
+        if (pPrev != NULL) {
+            INT64 interRecv = (INT64) (pCurr->remoteTimeKvs - pPrev->remoteTimeKvs);
+            INT64 interSend = (INT64) (pCurr->localTimeKvs - pPrev->localTimeKvs);
+            accumulatedDelay += (DOUBLE) (interRecv - interSend);
+
+            sumX += (DOUBLE) n;
+            sumY += accumulatedDelay;
+            sumXY += (DOUBLE) n * accumulatedDelay;
+            sumX2 += (DOUBLE) n * (DOUBLE) n;
+            n++;
+        }
+
+        pPrev = pCurr;
+    }
+
+    if (n >= 2) {
+        DOUBLE denom = (DOUBLE) n * sumX2 - sumX * sumX;
+        if (denom != 0.0) {
+            rawSlope = ((DOUBLE) n * sumXY - sumX * sumY) / denom;
+        }
+    }
+
+    pTwccManager->smoothedSlope = TWCC_TRENDLINE_SMOOTHING_FACTOR * rawSlope + (1.0 - TWCC_TRENDLINE_SMOOTHING_FACTOR) * pTwccManager->smoothedSlope;
+    pTwccManager->lastQueueDelay = accumulatedDelay;
+    *pDelayTrend = pTwccManager->smoothedSlope / (DOUBLE) HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    *pQueueDelay = accumulatedDelay / (DOUBLE) HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+
+    DLOGD("TWCC trendline: delayTrend=%.4f ms queueDelay=%.2f ms (n=%u)", *pDelayTrend, *pQueueDelay, n);
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    return retStatus;
+}
+
 STATUS updateTwccHashTable(PTwccManager pTwccManager, PINT64 duration, PUINT64 receivedBytes, PUINT64 receivedPackets, PUINT64 sentBytes,
                            PUINT64 sentPackets)
 {
@@ -405,22 +472,55 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
     UINT64 sentBytes = 0, receivedBytes = 0;
     UINT64 sentPackets = 0, receivedPackets = 0;
     INT64 duration = 0;
+    DOUBLE delayTrend = 0.0, queueDelay = 0.0;
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
-    CHK(pKvsPeerConnection->pTwccManager != NULL && pKvsPeerConnection->onSenderBandwidthEstimation != NULL, STATUS_SUCCESS);
+    CHK(pKvsPeerConnection->pTwccManager != NULL, STATUS_SUCCESS);
 
     MUTEX_LOCK(pKvsPeerConnection->twccLock);
     locked = TRUE;
     pTwccManager = pKvsPeerConnection->pTwccManager;
     CHK_STATUS(parseRtcpTwccPacket(pRtcpPacket, pTwccManager));
 
+    // Compute trendline
+    if (pKvsPeerConnection->onTwccFeedbackReceived != NULL) {
+        // Custom estimator callback
+        TwccCongestionState congestionState;
+        MEMSET(&congestionState, 0, SIZEOF(congestionState));
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+        locked = FALSE;
+        CHK_STATUS(pKvsPeerConnection->onTwccFeedbackReceived(pKvsPeerConnection->onTwccFeedbackReceivedCustomData, NULL, 0, &congestionState));
+        MUTEX_LOCK(pKvsPeerConnection->twccLock);
+        locked = TRUE;
+        delayTrend = congestionState.delayTrend;
+    } else {
+        // Default trendline estimator
+        CHK_STATUS(computeTwccTrendline(pTwccManager, &delayTrend, &queueDelay));
+    }
+
     updateTwccHashTable(pTwccManager, &duration, &receivedBytes, &receivedPackets, &sentBytes, &sentPackets);
 
     if (duration > 0) {
         MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
         locked = FALSE;
-        pKvsPeerConnection->onSenderBandwidthEstimation(pKvsPeerConnection->onSenderBandwidthEstimationCustomData, sentBytes, receivedBytes,
-                                                        sentPackets, receivedPackets, duration);
+
+        // Invoke the new congestion feedback callback if set
+        if (pKvsPeerConnection->onPeerCongestionFeedback != NULL) {
+            CongestionCtx ctx;
+            ctx.txBytes = (UINT32) sentBytes;
+            ctx.rxBytes = (UINT32) receivedBytes;
+            ctx.txPackets = (UINT32) sentPackets;
+            ctx.rxPackets = (UINT32) receivedPackets;
+            ctx.duration = (UINT64) duration;
+            ctx.congestionState.delayTrend = delayTrend;
+            CHK_LOG_ERR(pKvsPeerConnection->onPeerCongestionFeedback(pKvsPeerConnection->onPeerCongestionFeedbackCustomData, &ctx));
+        }
+
+        // Also invoke the legacy callback for backward compatibility
+        if (pKvsPeerConnection->onSenderBandwidthEstimation != NULL) {
+            pKvsPeerConnection->onSenderBandwidthEstimation(pKvsPeerConnection->onSenderBandwidthEstimationCustomData, sentBytes, receivedBytes,
+                                                            sentPackets, receivedPackets, duration);
+        }
     }
 
 CleanUp:

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -13,6 +13,36 @@ STATUS onRtcpPLIPacket(PRtcpPacket, PKvsPeerConnection);
 STATUS parseRtcpTwccPacket(PRtcpPacket, PTwccManager);
 STATUS onRtcpTwccPacket(PRtcpPacket, PKvsPeerConnection);
 STATUS updateTwccHashTable(PTwccManager, PINT64, PUINT64, PUINT64, PUINT64, PUINT64);
+
+/**
+ * @brief Estimates network congestion trend using least-squares linear regression
+ *        on accumulated one-way delay variations, smoothed with an exponential moving average (EMA).
+ *
+ * Algorithm overview:
+ *   1. For each consecutive packet pair (i-1, i), compute the inter-arrival delay variation:
+ *        d_i = (recvTime_i - recvTime_{i-1}) - (sendTime_i - sendTime_{i-1})
+ *      A positive d_i means the network took longer to deliver packet i than packet i-1.
+ *
+ *   2. Accumulate these variations into a running sum (the "accumulated delay"):
+ *        D_i = D_{i-1} + d_i    (where D_0 = 0)
+ *      This represents the total queuing delay buildup over the observation window.
+ *
+ *   3. Fit a line to the points (x_i, y_i) = (i, D_i) using ordinary least-squares regression.
+ *      The slope formula is:
+ *        rawSlope = (n * sum(x_i * y_i) - sum(x_i) * sum(y_i))
+ *                   / (n * sum(x_i^2) - (sum(x_i))^2)
+ *      A positive slope indicates delay is growing (congestion building up).
+ *      A near-zero slope indicates stable network conditions.
+ *      A negative slope indicates delay is decreasing (congestion clearing).
+ *
+ *   4. Smooth the slope with an EMA to reduce noise:
+ *        smoothedSlope = alpha * rawSlope + (1 - alpha) * prevSmoothedSlope
+ *      where alpha = TWCC_TRENDLINE_SMOOTHING_FACTOR (0.2 by default).
+ *
+ * @param[in]  pTwccManager  TWCC manager containing packet timing history
+ * @param[out] pDelayTrend   Smoothed slope in ms per sample (positive = congestion building)
+ * @param[out] pQueueDelay   Total accumulated delay variation in ms over the window
+ */
 STATUS computeTwccTrendline(PTwccManager, PDOUBLE, PDOUBLE);
 
 // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -52,7 +52,9 @@ STATUS computeTwccTrendline(PTwccManager, PDOUBLE, PDOUBLE);
 #define MILLISECONDS_PER_SECOND      1000LL
 #define TWCC_PACKET_LOST_TIME        ((UINT64) (-1LL))
 #define TWCC_PACKET_UNITIALIZED_TIME 0
-#define TWCC_ESTIMATOR_TIME_WINDOW   (10 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+// Max packet age in the TWCC hash table. If feedback is not received within this
+// window, the entry is evicted. Entries are also evicted once we receive feedback.
+#define TWCC_ESTIMATOR_TIME_WINDOW (4 * HUNDREDS_OF_NANOS_IN_A_SECOND)
 
 // Trendline estimation parameters
 #define TWCC_TRENDLINE_SMOOTHING_FACTOR 0.2

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -13,6 +13,7 @@ STATUS onRtcpPLIPacket(PRtcpPacket, PKvsPeerConnection);
 STATUS parseRtcpTwccPacket(PRtcpPacket, PTwccManager);
 STATUS onRtcpTwccPacket(PRtcpPacket, PKvsPeerConnection);
 STATUS updateTwccHashTable(PTwccManager, PINT64, PUINT64, PUINT64, PUINT64, PUINT64);
+STATUS computeTwccTrendline(PTwccManager, PDOUBLE, PDOUBLE);
 
 // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
 // Deltas are represented as multiples of 250us:
@@ -21,7 +22,10 @@ STATUS updateTwccHashTable(PTwccManager, PINT64, PUINT64, PUINT64, PUINT64, PUIN
 #define MILLISECONDS_PER_SECOND      1000LL
 #define TWCC_PACKET_LOST_TIME        ((UINT64) (-1LL))
 #define TWCC_PACKET_UNITIALIZED_TIME 0
-#define TWCC_ESTIMATOR_TIME_WINDOW   (1 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+#define TWCC_ESTIMATOR_TIME_WINDOW   (10 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
+// Trendline estimation parameters
+#define TWCC_TRENDLINE_SMOOTHING_FACTOR 0.2
 
 typedef enum {
     TWCC_STATUS_SYMBOL_NOTRECEIVED = 0,

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -585,7 +585,7 @@ TEST_F(RtcpFunctionalityTest, computeTwccTrendline_increasingDelay)
 TEST_F(RtcpFunctionalityTest, computeTwccTrendline_decreasingDelay)
 {
     // Simulate packets where receiver gaps are smaller than sender gaps and shrinking (congestion clearing)
-    // Sender sends every 10ms, receiver gaps: 9, 8, 7, 6, 5, 4, 3, 2, 1 ms — all below send interval
+    // Sender sends every 10ms, receiver gaps: 9, 8, 7, 6, 5, 4, 3, 2, 1 ms - all below send interval
     PRtcPeerConnection pRtcPeerConnection = nullptr;
     PKvsPeerConnection pKvsPeerConnection;
     RtcConfiguration config{};
@@ -683,6 +683,269 @@ TEST_F(RtcpFunctionalityTest, setOnTwccFeedbackReceived_basic)
 
     EXPECT_EQ(STATUS_NULL_ARG, setOnTwccFeedbackReceived(NULL, 0, NULL));
     EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, 0, NULL));
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+// Test context for custom TWCC callback
+struct TwccCallbackCtx {
+    UINT32 callCount;
+    UINT32 feedbackCount;
+    PTwccFeedback pCapturedList;
+    DOUBLE delayTrendToReturn;
+};
+
+static STATUS testTwccFeedbackCallback(UINT64 customData, PTwccFeedback pFeedbackList, UINT32 feedbackListLen, PTwccCongestionState pCongestionState)
+{
+    TwccCallbackCtx* pCtx = (TwccCallbackCtx*) customData;
+    pCtx->callCount++;
+    pCtx->feedbackCount = feedbackListLen;
+    // Copy the list so we can inspect it after the call
+    if (feedbackListLen > 0 && pFeedbackList != NULL) {
+        pCtx->pCapturedList = (PTwccFeedback) MEMALLOC(feedbackListLen * SIZEOF(TwccFeedback));
+        MEMCPY(pCtx->pCapturedList, pFeedbackList, feedbackListLen * SIZEOF(TwccFeedback));
+    }
+    pCongestionState->delayTrend = pCtx->delayTrendToReturn;
+    return STATUS_SUCCESS;
+}
+
+static STATUS testCongestionFeedbackHandler(UINT64 customData, PCongestionCtx pCtx)
+{
+    UNUSED_PARAM(customData);
+    UNUSED_PARAM(pCtx);
+    return STATUS_SUCCESS;
+}
+
+// Verifies that the custom callback receives a properly populated TwccFeedback list
+// with per-packet data from the TWCC report.
+TEST_F(RtcpFunctionalityTest, onTwccFeedbackReceived_feedbackListPopulated)
+{
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection = nullptr;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    BYTE payload[256] = {0};
+    UINT32 payloadLen = 256;
+    TwccCallbackCtx ctx{};
+    ctx.delayTrendToReturn = 0.5;
+
+    // Use a known TWCC packet: base=0x0181, 1 received, 0 lost
+    const std::string hex = "4487A9E754B3E6FD01810001147A75A62001C801";
+    hexDecode(const_cast<PCHAR>(hex.data()), hex.size(), payload, &payloadLen);
+
+    rtcpPacket.header.packetLength = payloadLen / 4;
+    rtcpPacket.payload = payload;
+    rtcpPacket.payloadLength = payloadLen;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    // Need congestion callback so twccManagerOnPacketSent stores packets
+    EXPECT_EQ(STATUS_SUCCESS, setOnPeerCongestionFeedbackFn(pRtcPeerConnection, 0, testCongestionFeedbackHandler));
+    // Register custom callback
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &ctx, testTwccFeedbackCallback));
+
+    // Simulate sending the packets so they exist in the hash table
+    UINT16 baseSeqNum = getUnalignedInt16BigEndian(rtcpPacket.payload + 8);
+    UINT16 pktCount = TWCC_PACKET_STATUS_COUNT(rtcpPacket.payload);
+    for (UINT16 i = baseSeqNum; i < baseSeqNum + pktCount; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        UINT16 twsn = i;
+        UINT32 extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), twsn);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        rtpPacket.payloadLength = 100;
+        rtpPacket.payload = payload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    // Process the TWCC feedback packet - this should invoke our callback
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+
+    // Verify callback was invoked with correct data
+    EXPECT_EQ(1u, ctx.callCount);
+    EXPECT_EQ(1u, ctx.feedbackCount);
+    ASSERT_NE(nullptr, ctx.pCapturedList);
+    EXPECT_EQ(baseSeqNum, ctx.pCapturedList[0].twccSeqNum);
+    EXPECT_EQ(100u, ctx.pCapturedList[0].packetSize);
+    EXPECT_NE(0u, ctx.pCapturedList[0].recvTime);
+    EXPECT_NE(TWCC_PACKET_LOST_TIME, ctx.pCapturedList[0].recvTime);
+
+    SAFE_MEMFREE(ctx.pCapturedList);
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+// Verifies that lost packets are excluded from the feedback list
+TEST_F(RtcpFunctionalityTest, onTwccFeedbackReceived_excludesLostPackets)
+{
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection = nullptr;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    BYTE payload[256] = {0};
+    UINT32 payloadLen = 256;
+    TwccCallbackCtx ctx{};
+    ctx.delayTrendToReturn = -0.1;
+
+    // TWCC packet with 1 received, 3 lost (4 total)
+    const std::string hex = "4487A9E754B3E6FD12740004148566AAC1402C00";
+    hexDecode(const_cast<PCHAR>(hex.data()), hex.size(), payload, &payloadLen);
+
+    rtcpPacket.header.packetLength = payloadLen / 4;
+    rtcpPacket.payload = payload;
+    rtcpPacket.payloadLength = payloadLen;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    EXPECT_EQ(STATUS_SUCCESS, setOnPeerCongestionFeedbackFn(pRtcPeerConnection, 0, testCongestionFeedbackHandler));
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &ctx, testTwccFeedbackCallback));
+
+    UINT16 baseSeqNum = getUnalignedInt16BigEndian(rtcpPacket.payload + 8);
+    UINT16 pktCount = TWCC_PACKET_STATUS_COUNT(rtcpPacket.payload);
+    for (UINT16 i = baseSeqNum; i < baseSeqNum + pktCount; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        UINT16 twsn = i;
+        UINT32 extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), twsn);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        rtpPacket.payloadLength = 100;
+        rtpPacket.payload = payload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+
+    // Only received packets should be in the list (1 received, 3 lost)
+    EXPECT_EQ(1u, ctx.callCount);
+    EXPECT_EQ(1u, ctx.feedbackCount);
+    ASSERT_NE(nullptr, ctx.pCapturedList);
+    EXPECT_NE(TWCC_PACKET_LOST_TIME, ctx.pCapturedList[0].recvTime);
+
+    SAFE_MEMFREE(ctx.pCapturedList);
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+// Verifies callback receives multiple received packets
+TEST_F(RtcpFunctionalityTest, onTwccFeedbackReceived_multipleReceivedPackets)
+{
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection = nullptr;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    BYTE payload[256] = {0};
+    UINT32 payloadLen = 256;
+    TwccCallbackCtx ctx{};
+    ctx.delayTrendToReturn = 0.0;
+
+    // TWCC packet with 3 received, 0 lost
+    const std::string hex = "4487A9E754B3E6FD000C000314797A052003E40004000003";
+    hexDecode(const_cast<PCHAR>(hex.data()), hex.size(), payload, &payloadLen);
+
+    rtcpPacket.header.packetLength = payloadLen / 4;
+    rtcpPacket.payload = payload;
+    rtcpPacket.payloadLength = payloadLen;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    EXPECT_EQ(STATUS_SUCCESS, setOnPeerCongestionFeedbackFn(pRtcPeerConnection, 0, testCongestionFeedbackHandler));
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &ctx, testTwccFeedbackCallback));
+
+    UINT16 baseSeqNum = getUnalignedInt16BigEndian(rtcpPacket.payload + 8);
+    UINT16 pktCount = TWCC_PACKET_STATUS_COUNT(rtcpPacket.payload);
+    for (UINT16 i = baseSeqNum; i < baseSeqNum + pktCount; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        UINT16 twsn = i;
+        UINT32 extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), twsn);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        rtpPacket.payloadLength = 100;
+        rtpPacket.payload = payload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+
+    // All 3 packets received
+    EXPECT_EQ(1u, ctx.callCount);
+    EXPECT_EQ(3u, ctx.feedbackCount);
+    ASSERT_NE(nullptr, ctx.pCapturedList);
+
+    // Verify sequence numbers are in order
+    for (UINT32 i = 0; i < ctx.feedbackCount; i++) {
+        EXPECT_EQ((UINT16)(baseSeqNum + i), ctx.pCapturedList[i].twccSeqNum);
+        EXPECT_EQ(100u, ctx.pCapturedList[i].packetSize);
+        EXPECT_NE(0u, ctx.pCapturedList[i].recvTime);
+        EXPECT_NE(TWCC_PACKET_LOST_TIME, ctx.pCapturedList[i].recvTime);
+    }
+
+    SAFE_MEMFREE(ctx.pCapturedList);
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+static STATUS testTwccFeedbackCallbackError(UINT64 customData, PTwccFeedback pFeedbackList, UINT32 feedbackListLen, PTwccCongestionState pCongestionState)
+{
+    UNUSED_PARAM(pFeedbackList);
+    UNUSED_PARAM(feedbackListLen);
+    UNUSED_PARAM(pCongestionState);
+    TwccCallbackCtx* pCtx = (TwccCallbackCtx*) customData;
+    pCtx->callCount++;
+    return STATUS_INVALID_OPERATION;
+}
+
+// Verifies no deadlock when custom callback returns an error
+TEST_F(RtcpFunctionalityTest, onTwccFeedbackReceived_callbackErrorNoDeadlock)
+{
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection = nullptr;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    BYTE payload[256] = {0};
+    UINT32 payloadLen = 256;
+    TwccCallbackCtx ctx{};
+
+    const std::string hex = "4487A9E754B3E6FD01810001147A75A62001C801";
+    hexDecode(const_cast<PCHAR>(hex.data()), hex.size(), payload, &payloadLen);
+
+    rtcpPacket.header.packetLength = payloadLen / 4;
+    rtcpPacket.payload = payload;
+    rtcpPacket.payloadLength = payloadLen;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    EXPECT_EQ(STATUS_SUCCESS, setOnPeerCongestionFeedbackFn(pRtcPeerConnection, 0, testCongestionFeedbackHandler));
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &ctx, testTwccFeedbackCallbackError));
+
+    UINT16 baseSeqNum = getUnalignedInt16BigEndian(rtcpPacket.payload + 8);
+    UINT16 pktCount = TWCC_PACKET_STATUS_COUNT(rtcpPacket.payload);
+    for (UINT16 i = baseSeqNum; i < baseSeqNum + pktCount; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        UINT16 twsn = i;
+        UINT32 extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), twsn);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        rtpPacket.payloadLength = 100;
+        rtpPacket.payload = payload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    // Callback returns error - should propagate without deadlock
+    EXPECT_EQ(STATUS_INVALID_OPERATION, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+    EXPECT_EQ(1u, ctx.callCount);
+
+    // Verify mutex is not held - we can still lock/unlock it
+    MUTEX_LOCK(pKvsPeerConnection->twccLock);
+    MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
 
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -528,8 +528,8 @@ TEST_F(RtcpFunctionalityTest, computeTwccTrendline_stableNetwork)
     // Insert 10 packets with uniform 10ms send and receive spacing (no delay variation)
     for (UINT16 i = 0; i < 10; i++) {
         PTwccRtpPacketInfo pInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
-        pInfo->localTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
-        pInfo->remoteTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND; // same spacing
+        pInfo->localTimeKvs = (1000 + i * 10) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        pInfo->remoteTimeKvs = (1000 + i * 10) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND; // same spacing
         pInfo->packetSize = 1200;
         hashTablePut(pTwccManager->pTwccRtpPktInfosHashTable, i, (UINT64) pInfo);
     }
@@ -542,12 +542,7 @@ TEST_F(RtcpFunctionalityTest, computeTwccTrendline_stableNetwork)
     EXPECT_NEAR(0.0, delayTrend, 0.001);
     EXPECT_NEAR(0.0, queueDelay, 0.001);
 
-    // Cleanup hash table entries
-    for (UINT16 i = 0; i < 10; i++) {
-        UINT64 val;
-        hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, i, &val);
-        MEMFREE((PVOID) val);
-    }
+    // freePeerConnection will clean up hash table entries via freeHashEntry
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
@@ -565,7 +560,7 @@ TEST_F(RtcpFunctionalityTest, computeTwccTrendline_increasingDelay)
     PTwccManager pTwccManager = pKvsPeerConnection->pTwccManager;
 
     // Sender sends every 10ms, but receiver gets them with increasing gaps (10, 11, 12, 13... ms)
-    UINT64 recvTime = 0;
+    UINT64 recvTime = 1000 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     for (UINT16 i = 0; i < 10; i++) {
         PTwccRtpPacketInfo pInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
         pInfo->localTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
@@ -584,17 +579,13 @@ TEST_F(RtcpFunctionalityTest, computeTwccTrendline_increasingDelay)
     // Queue delay should be positive (accumulated delay variation)
     EXPECT_GT(queueDelay, 0.0);
 
-    for (UINT16 i = 0; i < 10; i++) {
-        UINT64 val;
-        hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, i, &val);
-        MEMFREE((PVOID) val);
-    }
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
 TEST_F(RtcpFunctionalityTest, computeTwccTrendline_decreasingDelay)
 {
-    // Simulate packets where receiver gaps shrink (congestion clearing)
+    // Simulate packets where receiver gaps are smaller than sender gaps and shrinking (congestion clearing)
+    // Sender sends every 10ms, receiver gaps: 9, 8, 7, 6, 5, 4, 3, 2, 1 ms — all below send interval
     PRtcPeerConnection pRtcPeerConnection = nullptr;
     PKvsPeerConnection pKvsPeerConnection;
     RtcConfiguration config{};
@@ -605,15 +596,14 @@ TEST_F(RtcpFunctionalityTest, computeTwccTrendline_decreasingDelay)
 
     PTwccManager pTwccManager = pKvsPeerConnection->pTwccManager;
 
-    // Sender sends every 10ms, receiver gaps shrink (15, 14, 13, 12, 11, 10, 9, 8, 7, 6 ms)
-    UINT64 recvTime = 0;
+    UINT64 recvTime = 1000 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     for (UINT16 i = 0; i < 10; i++) {
         PTwccRtpPacketInfo pInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
         pInfo->localTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
         pInfo->remoteTimeKvs = recvTime;
         pInfo->packetSize = 1200;
         hashTablePut(pTwccManager->pTwccRtpPktInfosHashTable, i, (UINT64) pInfo);
-        recvTime += (15 - i) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND; // shrinking gaps
+        recvTime += (9 - i) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND; // gaps smaller than send interval and shrinking
     }
     pTwccManager->prevReportedBaseSeqNum = 0;
     pTwccManager->lastReportedSeqNum = 9;
@@ -623,11 +613,6 @@ TEST_F(RtcpFunctionalityTest, computeTwccTrendline_decreasingDelay)
     // Delay trend should be negative (congestion clearing)
     EXPECT_LT(delayTrend, 0.0);
 
-    for (UINT16 i = 0; i < 10; i++) {
-        UINT64 val;
-        hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, i, &val);
-        MEMFREE((PVOID) val);
-    }
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
@@ -664,11 +649,6 @@ TEST_F(RtcpFunctionalityTest, computeTwccTrendline_skipsLostPackets)
     // Should still compute without crashing; stable network so ~0
     EXPECT_NEAR(0.0, queueDelay, 0.5);
 
-    for (UINT16 i = 0; i < 5; i++) {
-        UINT64 val;
-        hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, i, &val);
-        MEMFREE((PVOID) val);
-    }
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -509,6 +509,204 @@ TEST_F(RtcpFunctionalityTest, updateTwccHashTableIntPromotionCase) {
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+// ---- TWCC Trendline and API Tests ----
+
+TEST_F(RtcpFunctionalityTest, computeTwccTrendline_stableNetwork)
+{
+    // Simulate packets sent and received with constant spacing (no congestion)
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection;
+    RtcConfiguration config{};
+    DOUBLE delayTrend = 0.0, queueDelay = 0.0;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    PTwccManager pTwccManager = pKvsPeerConnection->pTwccManager;
+    ASSERT_NE(nullptr, pTwccManager);
+
+    // Insert 10 packets with uniform 10ms send and receive spacing (no delay variation)
+    for (UINT16 i = 0; i < 10; i++) {
+        PTwccRtpPacketInfo pInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
+        pInfo->localTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        pInfo->remoteTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND; // same spacing
+        pInfo->packetSize = 1200;
+        hashTablePut(pTwccManager->pTwccRtpPktInfosHashTable, i, (UINT64) pInfo);
+    }
+    pTwccManager->prevReportedBaseSeqNum = 0;
+    pTwccManager->lastReportedSeqNum = 9;
+
+    EXPECT_EQ(STATUS_SUCCESS, computeTwccTrendline(pTwccManager, &delayTrend, &queueDelay));
+
+    // With uniform spacing, delay variation should be ~0
+    EXPECT_NEAR(0.0, delayTrend, 0.001);
+    EXPECT_NEAR(0.0, queueDelay, 0.001);
+
+    // Cleanup hash table entries
+    for (UINT16 i = 0; i < 10; i++) {
+        UINT64 val;
+        hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, i, &val);
+        MEMFREE((PVOID) val);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, computeTwccTrendline_increasingDelay)
+{
+    // Simulate packets where receiver gaps grow (congestion building)
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection;
+    RtcConfiguration config{};
+    DOUBLE delayTrend = 0.0, queueDelay = 0.0;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    PTwccManager pTwccManager = pKvsPeerConnection->pTwccManager;
+
+    // Sender sends every 10ms, but receiver gets them with increasing gaps (10, 11, 12, 13... ms)
+    UINT64 recvTime = 0;
+    for (UINT16 i = 0; i < 10; i++) {
+        PTwccRtpPacketInfo pInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
+        pInfo->localTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        pInfo->remoteTimeKvs = recvTime;
+        pInfo->packetSize = 1200;
+        hashTablePut(pTwccManager->pTwccRtpPktInfosHashTable, i, (UINT64) pInfo);
+        recvTime += (10 + i) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND; // growing gaps
+    }
+    pTwccManager->prevReportedBaseSeqNum = 0;
+    pTwccManager->lastReportedSeqNum = 9;
+
+    EXPECT_EQ(STATUS_SUCCESS, computeTwccTrendline(pTwccManager, &delayTrend, &queueDelay));
+
+    // Delay trend should be positive (congestion building)
+    EXPECT_GT(delayTrend, 0.0);
+    // Queue delay should be positive (accumulated delay variation)
+    EXPECT_GT(queueDelay, 0.0);
+
+    for (UINT16 i = 0; i < 10; i++) {
+        UINT64 val;
+        hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, i, &val);
+        MEMFREE((PVOID) val);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, computeTwccTrendline_decreasingDelay)
+{
+    // Simulate packets where receiver gaps shrink (congestion clearing)
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection;
+    RtcConfiguration config{};
+    DOUBLE delayTrend = 0.0, queueDelay = 0.0;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    PTwccManager pTwccManager = pKvsPeerConnection->pTwccManager;
+
+    // Sender sends every 10ms, receiver gaps shrink (15, 14, 13, 12, 11, 10, 9, 8, 7, 6 ms)
+    UINT64 recvTime = 0;
+    for (UINT16 i = 0; i < 10; i++) {
+        PTwccRtpPacketInfo pInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
+        pInfo->localTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        pInfo->remoteTimeKvs = recvTime;
+        pInfo->packetSize = 1200;
+        hashTablePut(pTwccManager->pTwccRtpPktInfosHashTable, i, (UINT64) pInfo);
+        recvTime += (15 - i) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND; // shrinking gaps
+    }
+    pTwccManager->prevReportedBaseSeqNum = 0;
+    pTwccManager->lastReportedSeqNum = 9;
+
+    EXPECT_EQ(STATUS_SUCCESS, computeTwccTrendline(pTwccManager, &delayTrend, &queueDelay));
+
+    // Delay trend should be negative (congestion clearing)
+    EXPECT_LT(delayTrend, 0.0);
+
+    for (UINT16 i = 0; i < 10; i++) {
+        UINT64 val;
+        hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, i, &val);
+        MEMFREE((PVOID) val);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, computeTwccTrendline_skipsLostPackets)
+{
+    // Verify that lost packets (remoteTimeKvs == TWCC_PACKET_LOST_TIME) are skipped
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection;
+    RtcConfiguration config{};
+    DOUBLE delayTrend = 0.0, queueDelay = 0.0;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    PTwccManager pTwccManager = pKvsPeerConnection->pTwccManager;
+
+    // 5 packets, middle one is lost
+    for (UINT16 i = 0; i < 5; i++) {
+        PTwccRtpPacketInfo pInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
+        pInfo->localTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        if (i == 2) {
+            pInfo->remoteTimeKvs = TWCC_PACKET_LOST_TIME;
+        } else {
+            pInfo->remoteTimeKvs = i * 10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        }
+        pInfo->packetSize = 1200;
+        hashTablePut(pTwccManager->pTwccRtpPktInfosHashTable, i, (UINT64) pInfo);
+    }
+    pTwccManager->prevReportedBaseSeqNum = 0;
+    pTwccManager->lastReportedSeqNum = 4;
+
+    EXPECT_EQ(STATUS_SUCCESS, computeTwccTrendline(pTwccManager, &delayTrend, &queueDelay));
+
+    // Should still compute without crashing; stable network so ~0
+    EXPECT_NEAR(0.0, queueDelay, 0.5);
+
+    for (UINT16 i = 0; i < 5; i++) {
+        UINT64 val;
+        hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, i, &val);
+        MEMFREE((PVOID) val);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, computeTwccTrendline_nullArgs)
+{
+    DOUBLE delayTrend, queueDelay;
+    EXPECT_EQ(STATUS_NULL_ARG, computeTwccTrendline(NULL, &delayTrend, &queueDelay));
+}
+
+TEST_F(RtcpFunctionalityTest, setOnPeerCongestionFeedbackFn_basic)
+{
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    RtcConfiguration config{};
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+
+    // Null peer connection
+    EXPECT_EQ(STATUS_NULL_ARG, setOnPeerCongestionFeedbackFn(NULL, 0, NULL));
+
+    // Setting NULL callback is valid (disables)
+    EXPECT_EQ(STATUS_SUCCESS, setOnPeerCongestionFeedbackFn(pRtcPeerConnection, 0, NULL));
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, setOnTwccFeedbackReceived_basic)
+{
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    RtcConfiguration config{};
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+
+    EXPECT_EQ(STATUS_NULL_ARG, setOnTwccFeedbackReceived(NULL, 0, NULL));
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, 0, NULL));
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added TWCC congestion control API with push-based callbacks for trendline estimation and bandwidth control
  - `computeTwccTrendline()`: default EMA-smoothed linear regression over accumulated one-way delay variation
  - `setOnTwccFeedbackReceived()`: **pluggable trendline estimator**
  -  `setOnPeerCongestionFeedbackFn()`: **bandwidth controller callback**
- Added public structs: TwccFeedback, TwccCongestionState, CongestionCtx
- Updated GStreamer sample to use the new onPeerCongestionFeedback callback for adaptive bitrate (combined loss + delay signals with multiplicative decrease / additive increase)
- Legacy `peerConnectionOnSenderBandwidthEstimation` callback remains functional for backward compatibility

*Why was it changed?*
- The SDK previously had no mechanism for applications to receive delay-based congestion signals to adapt encoder bitrate
- The existing `peerConnectionOnSenderBandwidthEstimation` callback only provided raw packet counts without one-way delay variation or analysis
- This enables self-resilient streaming by detecting over-use/under-use conditions, allowing applications to trade off quality for latency based on available bandwidth

*How was it changed?*
- `Rtcp.c`: Added `computeTwccTrendline()` which computes least-squares slope over accumulated delay variation with EMA smoothing. Modified onRtcpTwccPacket() to run the trendline (default or custom via onTwccFeedbackReceived), build `CongestionCtx`, and invoke `onPeerCongestionFeedback`.
- `PeerConnection.h`: Extended TwccManager with smoothedSlope and lastQueueDelay. Added callback fields to `KvsPeerConnection` (SDK-internal struct)
- `PeerConnection.c`: Implemented `setOnTwccFeedbackReceived()`, `setOnPeerCongestionFeedbackFn()`. Updated `twccManagerOnPacketSent` to proceed if either legacy or new callback is set
- `Include.h`: Added `TwccFeedback`, `TwccCongestionState`, `CongestionCtx` structs and callback typedefs (`RtcOnTwccFeedbackReceived`, `RtcOnPeerCongestionFeedback`)
- `Samples.h` / `Common.c`: Replaced legacy `sampleSenderBandwidthEstimationHandler` with `sampleOnPeerCongestionFeedback`. Implements multiplicative decrease / additive increase combining 
packet loss and delay trend signals

*What testing was done for the changes?*
- Added unit tests for `computeTwccTrendline`: stable network (zero trend), increasing delay (positive trend), decreasing delay (negative trend), lost packet handling, null args
- Added unit tests for `setOnTwccFeedbackReceived` and `setOnPeerCongestionFeedbackFn` API null checks
- End-to-end validation with GStreamer master sample and JS SDK viewer: confirmed bitrate ramps to 2500 kbps during good network, drops to 384 kbps on congestion, and recovers via additive increase

Example log (in order top to bottom), note the `video=X kbps` section:
| Network description | Screenshot |
|-------|-------|
| Network is good | <img width="1422" height="64" alt="image" src="https://github.com/user-attachments/assets/e3f9b7b3-d1ce-4be8-8300-38cf8b2bcba2" /> |
| Network becomes bad | <img width="1402" height="70" alt="image" src="https://github.com/user-attachments/assets/59b4dfc2-7fc6-4833-b272-11b7580dcf56" /> |
| Network recovering 1 | <img width="1387" height="60" alt="image" src="https://github.com/user-attachments/assets/d2597196-ef33-46fc-8749-258ad241f526" /> | 
| Network recovering 2 |  <img width="1409" height="75" alt="image" src="https://github.com/user-attachments/assets/a0494dee-3a28-43f6-817c-bdfaaf93a5d1" /> | 
| Recovered | <img width="1409" height="58" alt="image" src="https://github.com/user-attachments/assets/0411e1ba-37a0-4f1e-8ca3-c3b2134a5bcb" /> |



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
