### PR TITLE
Add forceTurn CI profiling job

### DIFF
--- a/.github/workflows/profile-stats.yml
+++ b/.github/workflows/profile-stats.yml
@@ -14,11 +14,20 @@ on:
 jobs:
   profile-stats:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            forceTurn: false
+          - name: forceTurn
+            forceTurn: true
     env:
       AWS_KVS_LOG_LEVEL: 5
       MIN_COUNT: 4
       LOG_FILE_LIMIT: 50
       ITERATIONS: 50
+      KVS_ICE_TRANSPORT_POLICY: ${{ matrix.forceTurn && 'relay' || 'all' }}
 
     permissions:
       id-token: write
@@ -57,7 +66,7 @@ jobs:
 
       - name: Setup Signaling Channel
         run: |
-          CHANNEL_NAME="profile-test-channel-${{ github.run_id }}"
+          CHANNEL_NAME="profile-test-channel-${{ matrix.name }}-${{ github.run_id }}"
           aws kinesisvideo create-signaling-channel --channel-name $CHANNEL_NAME
           echo "CHANNEL_NAME=$CHANNEL_NAME" >> $GITHUB_ENV
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add forceTurn CI profiling job

*Why was it changed?*
- The current profiling job added in the 1.16.0 release (#2212) currently runs master and viewer on the same machine. This means that it will always choose host-host.
- Adding this feature allows us to capture metrics for relay connections for each PR

*How was it changed?*
- Add the matrix which sets the env for the sample (#2203) to `relay` or `all`

*What testing was done for the changes?*
- CI/CD should confirm the numbers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
