### PR TITLE
Adjust valgrind condition to check definite leaks

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -230,4 +230,7 @@ jobs:
             echo "No memory leaks detected."
           else
             echo "Memory leaks detected."
+            cat valgrind-master.txt
+            cat valgrind-viewer.txt
+            exit 1
           fi

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -226,11 +226,17 @@ jobs:
           fi
 
           # Check for memory leaks in Valgrind output files
-          if grep "All heap blocks were freed -- no leaks are possible" valgrind-master.txt && grep "All heap blocks were freed -- no leaks are possible" valgrind-viewer.txt; then
-            echo "No memory leaks detected."
-          else
-            echo "Memory leaks detected."
+          LEAK_FOUND=0
+          for LOG_FILE in valgrind-master.txt valgrind-viewer.txt; do
+            if grep -qE "definitely lost: [^0]" "$LOG_FILE" || grep -qE "indirectly lost: [^0]" "$LOG_FILE"; then
+              echo "❌ Valgrind found definitely or indirectly lost memory in $LOG_FILE"
+              grep -E "(definitely|indirectly) lost:" "$LOG_FILE"
+              LEAK_FOUND=1
+            fi
+          done
+          if [ $LEAK_FOUND -ne 0 ]; then
             cat valgrind-master.txt
             cat valgrind-viewer.txt
             exit 1
           fi
+          echo "✅ No definite or indirect memory leaks detected."


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fail valgrind-check job if memory leaks are detected

*Why was it changed?*
- Currently the check passes even if leaks are detected, we want to know if there are memory leaks. 

*How was it changed?*
- Add `exit 1` in the else branch where leaks are detected.

*What testing was done for the changes?*
- Test CI run fails with results of memory leak (https://github.com/vabhasin/amazon-kinesis-video-streams-webrtc-sdk-c/actions/runs/25755362540/job/75642270587)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
