### PR TITLE
Support track-specific TWCC for Firefox compatibility

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1490,6 +1490,7 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
                        STRSTR(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, TWCC_EXT_URL) != NULL) {
                 remoteHasTwccExtmap = TRUE;
                 remoteTwccExtId = parseExtId(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue);
+                pKvsPeerConnection->remoteTwccOfferedPerMedia[i] = TRUE;
             } else if (STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "rtcp-fb") == 0 &&
                        STRSTR(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, TWCC_SDP_ATTR) != NULL) {
                 remoteHasTwccRtcpFb = TRUE;

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -150,6 +150,7 @@ typedef struct {
     // congestion control
     // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
     UINT16 twccExtId;
+    BOOL remoteTwccOfferedPerMedia[MAX_SDP_SESSION_MEDIA_COUNT]; // tracks which remote m-lines offered TWCC extmap
     MUTEX twccLock;
     PTwccManager pTwccManager;
     RtcOnSenderBandwidthEstimation onSenderBandwidthEstimation;

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -363,7 +363,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     bufferAfterEncrypt = (pKvsRtpTransceiver->sender.payloadType == pKvsRtpTransceiver->sender.rtxPayloadType);
     for (i = 0; i < pPayloadArray->payloadSubLenSize; i++) {
         pRtpPacket = pPacketList + i;
-        if (pKvsRtpTransceiver->pKvsPeerConnection->twccExtId != 0) {
+        if (pKvsRtpTransceiver->twccEnabled) {
             pRtpPacket->header.extension = TRUE;
             pRtpPacket->header.extensionProfile = TWCC_EXT_PROFILE;
             pRtpPacket->header.extensionLength = SIZEOF(UINT32);
@@ -394,7 +394,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             framesDiscardedOnSend = 1;
             SAFE_MEMFREE(rawPacket);
             continue;
-        } else if (sendStatus == STATUS_SUCCESS && pKvsRtpTransceiver->pKvsPeerConnection->twccExtId != 0) {
+        } else if (sendStatus == STATUS_SUCCESS && pKvsRtpTransceiver->twccEnabled) {
             pRtpPacket->sentTime = GETTIME();
             twccManagerOnPacketSent(pKvsPeerConnection, pRtpPacket);
         }

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -82,6 +82,8 @@ typedef struct {
     RtcOutboundRtpStreamStats outboundStats;
     RtcRemoteInboundRtpStreamStats remoteInboundStats;
     RtcInboundRtpStreamStats inboundStats;
+
+    BOOL twccEnabled; // whether TWCC was negotiated for this transceiver's m-line
 } KvsRtpTransceiver, *PKvsRtpTransceiver;
 
 STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION, PKvsPeerConnection, UINT32, UINT32, PRtcMediaStreamTrack, PJitterBuffer, RTC_CODEC,

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -485,6 +485,11 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     CHK(pKvsRtpTransceiver != NULL, STATUS_NULL_ARG);
     CHK(pKvsPeerConnection->isOffer || pRemoteSessionDescription != NULL, STATUS_NULL_ARG);
 
+    // Set per-transceiver TWCC flag based on whether this m-line negotiated TWCC
+    if (pKvsPeerConnection->twccExtId != 0) {
+        pKvsRtpTransceiver->twccEnabled = pKvsPeerConnection->remoteTwccOfferedPerMedia[mediaSectionId];
+    }
+
     PRtcMediaStreamTrack pRtcMediaStreamTrack = &(pKvsRtpTransceiver->sender.track);
 
     MEMSET(remoteSdpAttributeValue, 0, MAX_SDP_ATTRIBUTE_VALUE_LENGTH);
@@ -896,7 +901,7 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full rtcp-fb goog-remb could not be written");
     attributeCount++;
 
-    if (pKvsPeerConnection->twccExtId != 0) {
+    if (pKvsPeerConnection->twccExtId != 0 && pKvsPeerConnection->remoteTwccOfferedPerMedia[mediaSectionId]) {
         STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "rtcp-fb");
         amountWritten =
             SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -1458,6 +1458,84 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersForcedTURNWithDelayedDyna
     deinitializeSignalingClient();
 }
 
+// Verify that writeFrame only adds TWCC header extension on transceivers with twccEnabled=TRUE
+TEST_F(PeerConnectionFunctionalityTest, twccHeaderOnlyOnEnabledTransceivers)
+{
+    auto const frameBufferSize = 200000;
+
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack, offerAudioTrack, answerAudioTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver, offerAudioTransceiver, answerAudioTransceiver;
+    SIZE_T seenVideo = 0;
+    Frame videoFrame, audioFrame;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+    MEMSET(&audioFrame, 0x00, SIZEOF(Frame));
+
+    videoFrame.frameData = (PBYTE) MEMALLOC(frameBufferSize);
+    videoFrame.size = TEST_VIDEO_FRAME_SIZE;
+    MEMSET(videoFrame.frameData, 0x11, videoFrame.size);
+
+    audioFrame.frameData = (PBYTE) MEMALLOC(frameBufferSize);
+    audioFrame.size = 160; // small audio frame
+    MEMSET(audioFrame.frameData, 0x22, audioFrame.size);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(offerPc, &offerAudioTrack, &offerAudioTransceiver, RTC_CODEC_OPUS, MEDIA_STREAM_TRACK_KIND_AUDIO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerAudioTrack, &answerAudioTransceiver, RTC_CODEC_OPUS, MEDIA_STREAM_TRACK_KIND_AUDIO);
+
+    auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
+        UNUSED_PARAM(pFrame);
+        ATOMIC_STORE((PSIZE_T) customData, 1);
+    };
+    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &seenVideo, onFrameHandler), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // After connection, simulate Firefox scenario: disable TWCC on audio transceiver
+    PKvsRtpTransceiver pKvsOfferAudioTransceiver = (PKvsRtpTransceiver) offerAudioTransceiver;
+    PKvsRtpTransceiver pKvsOfferVideoTransceiver = (PKvsRtpTransceiver) offerVideoTransceiver;
+    pKvsOfferAudioTransceiver->twccEnabled = FALSE;
+    pKvsOfferVideoTransceiver->twccEnabled = TRUE;
+
+    PKvsPeerConnection pKvsOfferPc = (PKvsPeerConnection) offerPc;
+    SIZE_T twccSeqBefore = ATOMIC_LOAD(&pKvsOfferPc->transportWideSequenceNumber);
+
+    // Send audio frames - should NOT increment transportWideSequenceNumber
+    for (int i = 0; i < 5; i++) {
+        writeFrame(offerAudioTransceiver, &audioFrame);
+        audioFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 50);
+    }
+
+    SIZE_T twccSeqAfterAudio = ATOMIC_LOAD(&pKvsOfferPc->transportWideSequenceNumber);
+    EXPECT_EQ(twccSeqBefore, twccSeqAfterAudio);
+
+    // Send video frames - SHOULD increment transportWideSequenceNumber
+    for (int i = 0; i < 3; i++) {
+        writeFrame(offerVideoTransceiver, &videoFrame);
+        videoFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 25);
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    }
+
+    SIZE_T twccSeqAfterVideo = ATOMIC_LOAD(&pKvsOfferPc->transportWideSequenceNumber);
+    EXPECT_LT(twccSeqAfterAudio, twccSeqAfterVideo);
+
+    MEMFREE(videoFrame.frameData);
+    MEMFREE(audioFrame.frameData);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -3762,6 +3762,220 @@ a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
     });
 }
 
+// Check: When remote offer has TWCC on video m-line only (like Firefox), the answer includes TWCC only on video, not audio
+TEST_F(SdpApiTest, whenRemoteOfferHasTwccOnVideoOnly_thenAnswerIncludesTwccOnVideoOnly)
+{
+    // Firefox-style offer: audio + video, TWCC extmap only on video m-line
+    CHAR remoteSessionDescription[] = R"(v=0
+o=mozilla...THIS_IS_SDPARTA-99.0 1594401690149404988 0 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE 0 1
+a=ice-options:trickle
+a=msid-semantic: WMS *
+m=audio 9 UDP/TLS/RTP/SAVPF 109
+c=IN IP4 0.0.0.0
+a=recvonly
+a=ice-ufrag:6ca5a4b1
+a=ice-pwd:e19ac94391e12f14994bdaaa7b4fc812
+a=fingerprint:sha-256 59:DE:2A:3C:0B:B9:68:EB:D9:7E:40:60:5C:90:E7:1D:2E:C1:B1:9A:FF:88:B7:D7:38:10:98:8B:F2:9C:5C:42
+a=setup:actpass
+a=mid:0
+a=rtcp-mux
+a=rtpmap:109 opus/48000/2
+a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1
+m=video 9 UDP/TLS/RTP/SAVPF 126
+c=IN IP4 0.0.0.0
+a=recvonly
+a=ice-ufrag:6ca5a4b1
+a=ice-pwd:e19ac94391e12f14994bdaaa7b4fc812
+a=fingerprint:sha-256 59:DE:2A:3C:0B:B9:68:EB:D9:7E:40:60:5C:90:E7:1D:2E:C1:B1:9A:FF:88:B7:D7:38:10:98:8B:F2:9C:5C:42
+a=setup:actpass
+a=mid:1
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:126 H264/90000
+a=fmtp:126 profile-level-id=42e01f;level-asymmetry-allowed=1;packetization-mode=1
+a=rtcp-fb:126 nack
+a=rtcp-fb:126 nack pli
+a=rtcp-fb:126 transport-cc
+a=extmap:7 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+)";
+
+    assertLFAndCRLF(remoteSessionDescription, ARRAY_SIZE(remoteSessionDescription) - 1, [](PCHAR sdp) {
+        PRtcPeerConnection pRtcPeerConnection = NULL;
+        PRtcRtpTransceiver pAudioTransceiver = NULL;
+        PRtcRtpTransceiver pVideoTransceiver = NULL;
+        RtcConfiguration rtcConfiguration;
+        RtcMediaStreamTrack audioTrack, videoTrack;
+        RtcRtpTransceiverInit rtcRtpTransceiverInit;
+        RtcSessionDescriptionInit rtcSessionDescriptionInit;
+
+        MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
+        MEMSET(&audioTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+        MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
+
+        EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
+        EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_OPUS), STATUS_SUCCESS);
+        EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);
+
+        rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;
+
+        audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
+        audioTrack.codec = RTC_CODEC_OPUS;
+        STRCPY(audioTrack.streamId, "myKvsVideoStream");
+        STRCPY(audioTrack.trackId, "myAudioTrack");
+        EXPECT_EQ(addTransceiver(pRtcPeerConnection, &audioTrack, &rtcRtpTransceiverInit, &pAudioTransceiver), STATUS_SUCCESS);
+
+        videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        videoTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+        STRCPY(videoTrack.streamId, "myKvsVideoStream");
+        STRCPY(videoTrack.trackId, "myVideoTrack");
+        EXPECT_EQ(addTransceiver(pRtcPeerConnection, &videoTrack, &rtcRtpTransceiverInit, &pVideoTransceiver), STATUS_SUCCESS);
+
+        STRCPY(rtcSessionDescriptionInit.sdp, sdp);
+        rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
+        EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+        EXPECT_EQ(createAnswer(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+
+        std::string answerSdp(rtcSessionDescriptionInit.sdp);
+
+        // Split the answer SDP into audio (m=audio) and video (m=video) sections
+        auto audioPos = answerSdp.find("m=audio");
+        auto videoPos = answerSdp.find("m=video");
+        ASSERT_NE(audioPos, std::string::npos);
+        ASSERT_NE(videoPos, std::string::npos);
+
+        std::string audioSection = answerSdp.substr(audioPos, videoPos - audioPos);
+        std::string videoSection = answerSdp.substr(videoPos);
+
+        // Audio section must NOT contain TWCC extmap or transport-cc
+        EXPECT_EQ(audioSection.find(TWCC_EXT_URL), std::string::npos);
+        EXPECT_EQ(audioSection.find("transport-cc"), std::string::npos);
+
+        // Video section MUST contain TWCC extmap and transport-cc
+        EXPECT_NE(videoSection.find(TWCC_EXT_URL), std::string::npos);
+        EXPECT_NE(videoSection.find("transport-cc"), std::string::npos);
+
+        // Verify per-transceiver twccEnabled flags
+        PKvsRtpTransceiver pKvsAudioTransceiver = (PKvsRtpTransceiver) pAudioTransceiver;
+        PKvsRtpTransceiver pKvsVideoTransceiver = (PKvsRtpTransceiver) pVideoTransceiver;
+        EXPECT_FALSE(pKvsAudioTransceiver->twccEnabled);
+        EXPECT_TRUE(pKvsVideoTransceiver->twccEnabled);
+
+        closePeerConnection(pRtcPeerConnection);
+        freePeerConnection(&pRtcPeerConnection);
+    });
+}
+
+// Check: When remote offer has TWCC on both audio and video, the answer includes TWCC on both
+TEST_F(SdpApiTest, whenRemoteOfferHasTwccOnBothMlines_thenAnswerIncludesTwccOnBoth)
+{
+    CHAR remoteSessionDescription[] = R"(v=0
+o=- 7732334361409071710 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0 1
+a=msid-semantic: WMS
+m=audio 9 UDP/TLS/RTP/SAVPF 109
+c=IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+a=fingerprint:sha-256 51:04:F9:20:45:5C:9D:85:AF:D7:AF:FB:2B:F8:DB:24:66:7B:6A:E3:E3:EF:EC:72:93:6E:01:B8:C9:53:A6:31
+a=setup:actpass
+a=mid:0
+a=recvonly
+a=rtcp-mux
+a=rtpmap:109 opus/48000/2
+a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1
+a=rtcp-fb:109 transport-cc
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+m=video 9 UDP/TLS/RTP/SAVPF 96
+c=IN IP4 0.0.0.0
+a=ice-ufrag:9YRc
+a=ice-pwd:/ELMEiczRSsx2OEi2ynq+TbZ
+a=ice-options:trickle
+a=fingerprint:sha-256 51:04:F9:20:45:5C:9D:85:AF:D7:AF:FB:2B:F8:DB:24:66:7B:6A:E3:E3:EF:EC:72:93:6E:01:B8:C9:53:A6:31
+a=setup:actpass
+a=mid:1
+a=recvonly
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 H264/90000
+a=fmtp:96 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=rtcp-fb:96 transport-cc
+a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+)";
+
+    assertLFAndCRLF(remoteSessionDescription, ARRAY_SIZE(remoteSessionDescription) - 1, [](PCHAR sdp) {
+        PRtcPeerConnection pRtcPeerConnection = NULL;
+        PRtcRtpTransceiver pAudioTransceiver = NULL;
+        PRtcRtpTransceiver pVideoTransceiver = NULL;
+        RtcConfiguration rtcConfiguration;
+        RtcMediaStreamTrack audioTrack, videoTrack;
+        RtcRtpTransceiverInit rtcRtpTransceiverInit;
+        RtcSessionDescriptionInit rtcSessionDescriptionInit;
+
+        MEMSET(&rtcConfiguration, 0x00, SIZEOF(RtcConfiguration));
+        MEMSET(&audioTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        MEMSET(&rtcSessionDescriptionInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+        MEMSET(&rtcRtpTransceiverInit, 0x00, SIZEOF(RtcRtpTransceiverInit));
+
+        EXPECT_EQ(createPeerConnection(&rtcConfiguration, &pRtcPeerConnection), STATUS_SUCCESS);
+        EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_OPUS), STATUS_SUCCESS);
+        EXPECT_EQ(addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE), STATUS_SUCCESS);
+
+        rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;
+
+        audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
+        audioTrack.codec = RTC_CODEC_OPUS;
+        STRCPY(audioTrack.streamId, "myKvsVideoStream");
+        STRCPY(audioTrack.trackId, "myAudioTrack");
+        EXPECT_EQ(addTransceiver(pRtcPeerConnection, &audioTrack, &rtcRtpTransceiverInit, &pAudioTransceiver), STATUS_SUCCESS);
+
+        videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        videoTrack.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+        STRCPY(videoTrack.streamId, "myKvsVideoStream");
+        STRCPY(videoTrack.trackId, "myVideoTrack");
+        EXPECT_EQ(addTransceiver(pRtcPeerConnection, &videoTrack, &rtcRtpTransceiverInit, &pVideoTransceiver), STATUS_SUCCESS);
+
+        STRCPY(rtcSessionDescriptionInit.sdp, sdp);
+        rtcSessionDescriptionInit.type = SDP_TYPE_OFFER;
+        EXPECT_EQ(setRemoteDescription(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+        EXPECT_EQ(createAnswer(pRtcPeerConnection, &rtcSessionDescriptionInit), STATUS_SUCCESS);
+
+        std::string answerSdp(rtcSessionDescriptionInit.sdp);
+
+        // Split the answer SDP into audio and video sections
+        auto audioPos = answerSdp.find("m=audio");
+        auto videoPos = answerSdp.find("m=video");
+        ASSERT_NE(audioPos, std::string::npos);
+        ASSERT_NE(videoPos, std::string::npos);
+
+        std::string audioSection = answerSdp.substr(audioPos, videoPos - audioPos);
+        std::string videoSection = answerSdp.substr(videoPos);
+
+        // Both sections MUST contain TWCC extmap and transport-cc
+        EXPECT_NE(audioSection.find(TWCC_EXT_URL), std::string::npos);
+        EXPECT_NE(audioSection.find("transport-cc"), std::string::npos);
+        EXPECT_NE(videoSection.find(TWCC_EXT_URL), std::string::npos);
+        EXPECT_NE(videoSection.find("transport-cc"), std::string::npos);
+
+        // Verify per-transceiver twccEnabled flags
+        PKvsRtpTransceiver pKvsAudioTransceiver = (PKvsRtpTransceiver) pAudioTransceiver;
+        PKvsRtpTransceiver pKvsVideoTransceiver = (PKvsRtpTransceiver) pVideoTransceiver;
+        EXPECT_TRUE(pKvsAudioTransceiver->twccEnabled);
+        EXPECT_TRUE(pKvsVideoTransceiver->twccEnabled);
+
+        closePeerConnection(pRtcPeerConnection);
+        freePeerConnection(&pRtcPeerConnection);
+    });
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*

Adding support for TWCC to be enabled for certain tracks

**Before**
- When TWCC was negotiated, the SDK enabled TWCC for all tracks. (Added `a=extmap:<id> <twcc-url>` and `a=rtcp-fb:<pt> transport-cc` to every m-line in the answer, regardless of whether the remote offer included TWCC on that specific m-line)
- The TWCC transport-wide sequence number header extension was added to every outgoing RTP packet on all transceivers, as long as TWCC was globally enabled on the peer connection (`twccExtId != 0`).

**After**
- The SDK now only includes TWCC `extmap` and `rtcp-fb transport-cc` on m-lines where the corresponding remote offer m-line actually advertised them.
- The TWCC header extension is now only added to outgoing RTP packets on transceivers where TWCC was actually negotiated for that specific m-line (`pKvsRtpTransceiver->twccEnabled`).

*Why was it changed?*
- Firefox's offer only includes the TWCC `extmap` on the video `m-line` (not audio). In the current implementation, C SDK was adding it to all m-lines in the answer. This caused Firefox to reject the answer with:

```
InvalidAccessError: Answer has extmap http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01 at level 0 that was not present in offer.
```

- Note: It is odd that Firefox only offers TWCC on video and not audio, since TWCC should be transport-wide, operating on a single shared sequence number space across all media on the same transport (BUNDLE). However, browsers are free to offer extensions selectively per m-line, and the answerer must respect that per the SDP offer/answer model regardless of the semantic scope of the extension.

*How was it changed?*
- Store which m-line has TWCC enabled during parsing.
- Adjust `writeFrame` to only add TWCC seqNum to the packet and increment the twccSeqNum index when writing frames on tracks with TWCC enabled.

- The per-m-line info is stored in two places (`remoteTwccOfferedPerMedia` on the peer connection and `twccEnabled` on the transceiver) because they are needed at different stages: `remoteTwccOfferedPerMedia` is populated during `setRemoteDescription` when we know the m-line index but transceivers haven't been matched to m-lines yet. `twccEnabled` is set later in `populateSingleMediaSection` when the transceiver-to-m-line mapping is established. At RTP send time in `writeFrame`, we only have access to the transceiver, not the m-line index, so the transceiver-level flag is needed there.

*What testing was done for the changes?*
- Manual testing with Firefox viewer connecting to C SDK master
- Manual testing with Chrome, Safari, Edge, Android and iOS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
