### PR TITLE
Bumped libmbedtls to v3.6.6

### DIFF
--- a/CMake/Dependencies/libmbedtls-CMakeLists.txt
+++ b/CMake/Dependencies/libmbedtls-CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 if (BUILD_OLD_MBEDTLS_VERSION)
   SET(MBEDTLS_GIT_TAG "v2.28.8")
 else()
-  SET(MBEDTLS_GIT_TAG "v3.6.3")
+  SET(MBEDTLS_GIT_TAG "v3.6.6")
 endif()
 
 if (BUILD_STATIC_LIBS)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $env:Path += ';C:\webrtc\open-source\bin;C:\tools\pthreads-w32-2-9-1-release\Pre
 ### Dependency requirements
 
 These would be applicable if the SDK is being linked with system dependencies instead of building from source by the SDK.
-`libmbedtls`: `>= 2.25.0 & < 3.x.x`
+`libmbedtls`: `>= 2.25.0 & < 4.x.x`
 `libopenssl`: `= 1.1.1x`
 `libsrtp2` : `<= 2.5.0`
 `libusrsctp` : `<= 0.9.5.0`


### PR DESCRIPTION
*Issue #, if available:*
- Unterminated string initialization error now thrown by default in GCC 15 and Clang 21 causing compilation errors when running CMake with `-DUSE_MBEDTLS=ON`
```
/Users/jcyan/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/open-source/libmbedtls/build/src/project_libmbedtls/library/ssl_tls13_keys.c:44:5: error: initializer-string for character array is too long, array size is 8 but initializer has size 9 (including the null terminating character); did you mean to use the 'nonstring' attribute? [-Werror,-Wunterminated-string-initialization]
   44 |     MBEDTLS_SSL_TLS1_3_LABEL_LIST
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/jcyan/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/open-source/libmbedtls/build/src/project_libmbedtls/library/ssl_tls13_keys.h:14:40: note: expanded from macro 'MBEDTLS_SSL_TLS1_3_LABEL_LIST'
   14 |     MBEDTLS_SSL_TLS1_3_LABEL(finished, "finished") \
      |                                        ^~~~~~~~~~
``` 
- mbedtls v3.6.4 Release notes mention silencing this warning: https://github.com/Mbed-TLS/mbedtls/issues/9944 
- https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.4

- Chrome 146+ changed DTLS implementation, splitting DTLS ClientHello into two fragments (Client Hello Defragmentation), causing PeerConnection to fail when running JS Master <-> C Viewer:
``` 
2026-05-14 22:41:05.149 WARN    kvsMbedtlsDebugCallback(): [mbedtls] /Users/jcyan/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/open-source/libmbedtls/build/src/project_libmbedtls/library/ssl_tls12_server.c:1100 ClientHello fragmentation not supported
2026-05-14 22:41:05.149 INFO    kvsMbedtlsDebugCallback(): [mbedtls] /Users/jcyan/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/open-source/libmbedtls/build/src/project_libmbedtls/library/ssl_tls.c:4678 <= handshake
2026-05-14 22:41:05.149 WARN    kvsMbedtlsDebugCallback(): [mbedtls] /Users/jcyan/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/open-source/libmbedtls/build/src/project_libmbedtls/library/ssl_msg.c:5971 mbedtls_ssl_handshake() returned -28800 (-0x7080)
2026-05-14 22:41:05.149 WARN    dtlsSessionProcessPacket(): mbedtls_ssl_read failed with SSL - The requested feature is not available
```
- Support backported in v3.6.6: https://github.com/Mbed-TLS/mbedtls/pull/10623


*What was changed?*
- Bumped libmbedtls from v3.6.3 to v3.6.6
- Updated dependency requirements in README

*Why was it changed?*
- To fix build issues and support Chrome DTLS changes.

*How was it changed?*
- Updated libmbedtls CMake
- Updated README

*What testing was done for the changes?*
- Local testing of Chrome JS Master <-> C Viewer
- CI/CD should pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.