### PR TITLE
Remove redundant THREAD_JOIN in connectionListenerFunctionalityTest

### DIFF
--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -207,8 +207,6 @@ TEST_F(IceFunctionalityTest, connectionListenerFunctionalityTest)
     EXPECT_TRUE(IS_VALID_TID_VALUE(threadId));
     ATOMIC_STORE_BOOL(&pConnectionListener->terminate, TRUE);
 
-    THREAD_JOIN(threadId, NULL);
-
     EXPECT_EQ(STATUS_SUCCESS, freeConnectionListener(&pConnectionListener));
 
     EXPECT_EQ(STATUS_SUCCESS, freeSocketConnection(&pSocketConnection));


### PR DESCRIPTION
*Issue #, if available:*
- Address Sanitizer on Mac throwing this error for connectionListenerFunctionalityTest
```
jcyan@14147d976462 build % ./tst/webrtc_client_test --gtest_filter='IceFunctionalityTest.*'                                                         
Note: Google Test filter = IceFunctionalityTest.*
[==========] Running 11 tests from 1 test suite.                                                                                                                                                                                                                                                                          
[----------] Global test environment set-up.
[----------] 11 tests from IceFunctionalityTest
[ RUN      ] IceFunctionalityTest.sortIceCandidatePairsTest
2026-05-13 23:36:37.765 INFO    initKvsWebRtc(): Initializing WebRTC library...
2026-05-13 23:36:37.770 INFO    initKvsWebRtc(): SDK version: b6396850a47bfc07d421663519b4b4b119084a28
2026-05-13 23:36:37.772 INFO    TearDown(): 
Tearing down test: IceFunctionalityTest

[       OK ] IceFunctionalityTest.sortIceCandidatePairsTest (409 ms)
[ RUN      ] IceFunctionalityTest.connectionListenerFunctionalityTest
2026-05-13 23:36:38.175 INFO    SetUp(): 
Setting up test: IceFunctionalityTest

2026-05-13 23:36:38.175 INFO    initKvsWebRtc(): Initializing WebRTC library...
2026-05-13 23:36:38.177 INFO    initKvsWebRtc(): SDK version: b6396850a47bfc07d421663519b4b4b119084a28
2026-05-13 23:36:38.331 DEBUG   createSocketConnection(): create socket id: 5, with ip: 0000:0000:0000:0000:0000:0000:0000:0001:60817. family:2
2026-05-13 23:36:38.428 DEBUG   createSocketConnection(): create socket id: 6, with ip: 127.0.0.1:61990. family:1
2026-05-13 23:36:38.529 DEBUG   createSocketConnection(): create socket id: 7, with ip: 127.0.0.1:53400. family:1
2026-05-13 23:36:38.568 DEBUG   createSocketConnection(): create socket id: 8, with ip: 0000:0000:0000:0000:0000:0000:0000:0001:51386. family:2
2026-05-13 23:36:38.604 DEBUG   createSocketConnection(): create socket id: 9, with ip: 127.0.0.1:50400. family:1
2026-05-13 23:36:38.646 DEBUG   createSocketConnection(): create socket id: 10, with ip: 0000:0000:0000:0000:0000:0000:0000:0001:52530. family:2
2026-05-13 23:36:38.840 DEBUG   createSocketConnection(): create socket id: 11, with ip: 0000:0000:0000:0000:0000:0000:0000:0001:56528. family:2
2026-05-13 23:36:38.902 DEBUG   createSocketConnection(): create socket id: 12, with ip: 0000:0000:0000:0000:0000:0000:0000:0001:54413. family:2
2026-05-13 23:36:39.174 DEBUG   createSocketConnection(): create socket id: 13, with ip: 0000:0000:0000:0000:0000:0000:0000:0001:56664. family:2
2026-05-13 23:36:39.238 DEBUG   createSocketConnection(): create socket id: 14, with ip: 0000:0000:0000:0000:0000:0000:0000:0001:52340. family:2
2026-05-13 23:36:39.238 DEBUG   createSocketConnection(): create socket id: 15, with ip: 127.0.0.1:52584. family:1
2026-05-13 23:36:39.238 DEBUG   socketConnectionClosed(): Close socket 15
==5719==ERROR: AddressSanitizer: Joining already joined thread, aborting.
zsh: abort      ./tst/webrtc_client_test --gtest_filter='IceFunctionalityTest.*'
```
*What was changed?*
  - Removed the redundant `THREAD_JOIN(threadId, NULL)` call in `IceFunctionalityTest.connectionListenerFunctionalityTest` that ran just before `freeConnectionListener()`.

*Why was it changed?*
  - Both the test and `freeConnectionListener()` were calling `THREAD_JOIN` on the same `receiveDataRoutine` TID, resulting in a double `pthread_join` on the same thread handle.
  - `pthread_join` is a one-shot operation. Per POSIX, on a successful call the implementation blocks until the target thread terminates, delivers its exit status to the caller, and reaps the thread (frees its stack, kernel data structures, TCB, etc.). After the first successful join, the TID no longer refers to
  a joinable thread — it has been consumed, and may even be recycled to refer to a different thread.
  - A second `pthread_join` on the same TID is therefore undefined behavior. POSIX explicitly states: *"The behavior is undefined if the value specified by the thread argument to pthread_join() does not refer to a joinable thread."* (see [pthread_join — POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_join.html), also documented in the Linux man page [pthread_join(3)](https://man7.org/linux/man-pages/man3/pthread_join.3.html)).

*How was it changed?*
- Removed the `THREAD_JOIN(threadId, NULL)` in the test.

*What testing was done for the changes?*
  - Ran `./tst/webrtc_client_test --gtest_filter='IceFunctionalityTest.*'` successfully with no issues on Mac.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
