### PR TITLE
Gst Viewer Sample: Ignore caps for unsupported codecs

### DIFF
--- a/samples/p2p/GstAudioVideoReceiver.c
+++ b/samples/p2p/GstAudioVideoReceiver.c
@@ -103,7 +103,7 @@ PVOID receiveGstreamerAudioVideo(PVOID args)
     GstBus* bus;
     GstMessage* msg;
     GError* error = NULL;
-    GstCaps *audiocaps, *videocaps;
+    GstCaps *audiocaps = NULL, *videocaps = NULL;
     PSampleStreamingSession pSampleStreamingSession = (PSampleStreamingSession) args;
     PSampleConfiguration pSampleConfiguration = pSampleStreamingSession->pSampleConfiguration;
     PCHAR roleType = "Viewer";
@@ -168,15 +168,19 @@ PVOID receiveGstreamerAudioVideo(PVOID args)
     appsrcVideo = gst_bin_get_by_name(GST_BIN(pipeline), "appsrc-video");
     CHK_ERR(appsrcVideo != NULL, STATUS_INTERNAL_ERROR, "[KVS GStreamer %s] Cannot find appsrc video", roleType);
     CHK_STATUS(transceiverOnFrame(pSampleStreamingSession->pVideoRtcRtpTransceiver, (UINT64) appsrcVideo, onGstVideoFrameReady));
-    g_object_set(G_OBJECT(appsrcVideo), "caps", videocaps, NULL);
-    gst_caps_unref(videocaps);
+    if (videocaps != NULL) {
+        g_object_set(G_OBJECT(appsrcVideo), "caps", videocaps, NULL);
+        gst_caps_unref(videocaps);
+    }
 
     if (pSampleConfiguration->mediaType == SAMPLE_STREAMING_AUDIO_VIDEO) {
         appsrcAudio = gst_bin_get_by_name(GST_BIN(pipeline), "appsrc-audio");
         CHK_ERR(appsrcAudio != NULL, STATUS_INTERNAL_ERROR, "[KVS GStreamer %s] Cannot find appsrc audio", roleType);
         CHK_STATUS(transceiverOnFrame(pSampleStreamingSession->pAudioRtcRtpTransceiver, (UINT64) appsrcAudio, onGstAudioFrameReady));
-        g_object_set(G_OBJECT(appsrcAudio), "caps", audiocaps, NULL);
-        gst_caps_unref(audiocaps);
+        if (audiocaps != NULL) {
+            g_object_set(G_OBJECT(appsrcAudio), "caps", audiocaps, NULL);
+            gst_caps_unref(audiocaps);
+        }
     }
 
     CHK_STATUS(streamingSessionOnShutdown(pSampleStreamingSession, (UINT64) pipeline, onSampleStreamingSessionShutdown));


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- When an unsupported codec is selected, the Viewer GStreamer receiver sample now skips setting caps on the appsrc elements

*Why was it changed?*
- If a codec hits the `default:` switch branch, no caps are created. Previously the uninitialized pointers were passed to `g_object_set()` and `gst_caps_unref()`, which is undefined behavior.

*How was it changed?*
- Initialized videocaps and audiocaps to NULL
- Added NULL checks before setting caps on the appsrc elements

*What testing was done for the changes?*
- CI/CD
- Run the `./samples/kvsWebrtcClientViewerGstSample` sample locally with the JS master on Chrome to confirm the frames are received:

```c
2026-05-19 05:32:09.502 VERBOSE onGstVideoFrameReady(): Video frame size: 885, presentationTs: 3200000000
2026-05-19 05:32:09.502 VERBOSE onGstAudioFrameReady(): Audio frame size: 73, presentationTs: 3240000000
2026-05-19 05:32:09.529 VERBOSE onGstVideoFrameReady(): Video frame size: 485, presentationTs: 3240000000
2026-05-19 05:32:09.529 VERBOSE onGstAudioFrameReady(): Audio frame size: 75, presentationTs: 3280000000
2026-05-19 05:32:09.542 VERBOSE onGstAudioFrameReady(): Audio frame size: 81, presentationTs: 3280000000
2026-05-19 05:32:09.557 VERBOSE onGstVideoFrameReady(): Video frame size: 1083, presentationTs: 3280000000
2026-05-19 05:32:09.560 VERBOSE onGstAudioFrameReady(): Audio frame size: 79, presentationTs: 3320000000
2026-05-19 05:32:09.583 VERBOSE onGstAudioFrameReady(): Audio frame size: 97, presentationTs: 3320000000
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
