### PR TITLE
Adding defensive check to TWCC hashTable

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -403,7 +403,7 @@ STATUS updateTwccHashTable(PTwccManager pTwccManager, PINT64 duration, PUINT64 r
                            PUINT64 sentPackets)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    UINT64 localStartTimeKvs, localEndTimeKvs = 0;
+    UINT64 localStartTimeKvs = TWCC_PACKET_UNITIALIZED_TIME, localEndTimeKvs = TWCC_PACKET_UNITIALIZED_TIME;
     UINT16 baseSeqNum = 0;
     BOOL localStartTimeRecorded = FALSE;
     UINT64 twccPktValue = 0;

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -509,6 +509,75 @@ TEST_F(RtcpFunctionalityTest, updateTwccHashTableIntPromotionCase) {
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+// Verifies correct duration calculation when the previous packet (seqNum - 1)
+// exists in the hash table but has a NULL pointer value.
+// Hash table should never have a NULL entry so this is not expected.
+//
+// Hash table state:
+//   key 4 -> NULL    (previous packet before range, simulates unexpected state)
+//   key 5 -> pkt{localTime=1000}  (start of range)
+//   key 6 -> pkt{localTime=2000}
+//   key 7 -> pkt{localTime=3000}  (end of range)
+//
+// Expected behavior:
+//   1. seqNum=5: hashTableGet(4) succeeds but returns NULL
+//                -> fallback uses seqNum=5's packet -> localStartTimeKvs = 1000
+//   2. seqNum=7: last packet processed -> localEndTimeKvs = 3000
+//   3. duration = 3000 - 1000 = 2000
+TEST_F(RtcpFunctionalityTest, updateTwccHashTableNullPrevPacket)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    UINT64 receivedBytes = 0, receivedPackets = 0, sentBytes = 0, sentPackets = 0;
+    INT64 duration = 0;
+    PTwccRtpPacketInfo pTwccRtpPacketInfo = NULL;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    PHashTable pTwccRtpPktInfosHashTable = pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable;
+
+    // Set range to iterate: seqNums 5 through 7
+    pKvsPeerConnection->pTwccManager->prevReportedBaseSeqNum = 5;
+    pKvsPeerConnection->pTwccManager->lastReportedSeqNum = 7;
+
+    // Simulate a NULL entry at seqNum 4 (the previous packet before the range).
+    // This exercises the case where hashTableGet(seqNum-1) succeeds but the
+    // stored pointer is NULL, requiring the fallback to determine localStartTimeKvs.
+    EXPECT_EQ(STATUS_SUCCESS, hashTableUpsert(pTwccRtpPktInfosHashTable, 4, (UINT64) NULL));
+
+    // Insert real packets at seqNums 5, 6, 7 with increasing timestamps.
+    pTwccRtpPacketInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
+    pTwccRtpPacketInfo->localTimeKvs = 1000;
+    pTwccRtpPacketInfo->remoteTimeKvs = 2000;
+    pTwccRtpPacketInfo->packetSize = 50;
+    EXPECT_EQ(STATUS_SUCCESS, hashTableUpsert(pTwccRtpPktInfosHashTable, 5, (UINT64) pTwccRtpPacketInfo));
+
+    pTwccRtpPacketInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
+    pTwccRtpPacketInfo->localTimeKvs = 2000;
+    pTwccRtpPacketInfo->remoteTimeKvs = 3000;
+    pTwccRtpPacketInfo->packetSize = 100;
+    EXPECT_EQ(STATUS_SUCCESS, hashTableUpsert(pTwccRtpPktInfosHashTable, 6, (UINT64) pTwccRtpPacketInfo));
+
+    pTwccRtpPacketInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
+    pTwccRtpPacketInfo->localTimeKvs = 3000;
+    pTwccRtpPacketInfo->remoteTimeKvs = 4000;
+    pTwccRtpPacketInfo->packetSize = 150;
+    EXPECT_EQ(STATUS_SUCCESS, hashTableUpsert(pTwccRtpPktInfosHashTable, 7, (UINT64) pTwccRtpPacketInfo));
+
+    // duration should be localEndTimeKvs(3000) - localStartTimeKvs(1000) = 2000
+    EXPECT_EQ(STATUS_SUCCESS, updateTwccHashTable(pKvsPeerConnection->pTwccManager, &duration,
+                                                  &receivedBytes, &receivedPackets,
+                                                  &sentBytes, &sentPackets));
+
+    EXPECT_EQ(2000, duration);
+    EXPECT_EQ(300, receivedBytes);
+    EXPECT_EQ(3, receivedPackets);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 // ---- TWCC Trendline and API Tests ----
 
 TEST_F(RtcpFunctionalityTest, computeTwccTrendline_stableNetwork)


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Initialized `localStartTimeKvs` to `TWCC_PACKET_UNITIALIZED_TIME` in `updateTwccHashTable()`
- Added unit test to cover the case where the previous packet entry exists in the hash table but has a NULL pointer value

*Why was it changed?*
- The declaration `UINT64 localStartTimeKvs, localEndTimeKvs = 0;` only initializes `localEndTimeKvs`. A possible path can be where `hashTableGet(seqNum - 1)` succeeds but returns a `NULL` pointer, leaving `localStartTimeKvs` uninitialized before it's used in a comparison and arithmetic.
- In practice this path is unreachable. All hash table insertions go through `twccManagerOnPacketSent` which always stores a valid `MEMCALLOC`'d pointer, and deletions fully remove the key via `hashTableRemove()` rather than replacing the value with `NULL`. This is a defensive check to guard against future changes to callers or the hash table API.

*How was it changed?*
- Changed the declaration so both variables are explicitly initialized using the sentinel macro. This makes the intent clear and ensures correctness if the code path ever becomes reachable.
- Added a test that covers this to exercise this case and verify the correct duration is computed.

*What testing was done for the changes?*
- Ran the new test locally. It fails before the change and passes after the change

```
cmake .. -DUSE_MBEDTLS=ON -DUSE_OPENSSL=OFF -DENABLE_AWS_SDK_IN_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=ON -DBUILD_DEPENDENCIES=ON
```

<details><summary>Logs</summary>


Before the zero initialization:

```
[  FAILED  ] RtcpFunctionalityTest.updateTwccHashTableNullPrevPacketPath (464 ms)
--
/Users/me/Downloads/amazon-kinesis-video-streams-webrtc-sdk-c/tst/RtcpFunctionalityTest.cpp:566: Failure
Expected equality of these values:
  2000
  duration
    Which is: 1000
```

After the zero initialization:

```
[  PASSED  ] 1 test.
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
