### PR TITLE
DiscoverNatBehavior sample: Handle null parameters

### DIFF
--- a/src/source/Ice/NatBehaviorDiscovery.c
+++ b/src/source/Ice/NatBehaviorDiscovery.c
@@ -275,11 +275,11 @@ STATUS discoverNatBehavior(PCHAR stunServer, NAT_BEHAVIOR* pNatMappingBehavior, 
     PKvsIpAddress pSelectedLocalInterface = NULL;
     PConnectionListener pConnectionListener = NULL;
 
-    CHK(stunServer != NULL && pNatMappingBehavior != NULL && pNatFilteringBehavior != NULL, STATUS_NULL_ARG);
-    CHK(!IS_EMPTY_STRING(stunServer), STATUS_INVALID_ARG);
-
     MEMSET(&iceServerStun, 0x00, SIZEOF(IceServer));
     MEMSET(&customData, 0x00, SIZEOF(NatTestData));
+
+    CHK(stunServer != NULL && pNatMappingBehavior != NULL && pNatFilteringBehavior != NULL, STATUS_NULL_ARG);
+    CHK(!IS_EMPTY_STRING(stunServer), STATUS_INVALID_ARG);
     cvar = CVAR_CREATE();
     lock = MUTEX_CREATE(FALSE);
     CHK_STATUS(parseIceServer(&iceServerStun, stunServer, NULL, NULL));


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Handle NULL parameters to `discoverNatBehavior`.

*Why was it changed?*
- When `discoverNatBehavior` is called with NULL or empty arguments, the CHK macro jumps to `CleanUp` before `customData` is initialized. The cleanup code then reads `customData.bindingResponseCount` (uninitialized), potentially iterating over those pointers and calling `freeStunPacket` on them.

*How was it changed?*
- Moved the two `MEMSET` calls above the argument validation so that `customData.bindingResponseCount` is always zero-initialized regardless of which path reaches CleanUp

*What testing was done for the changes?*
- CI/CD to validate that there are no regressions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
