### PR TITLE
Gracefully handle invalid SDP missing payload types in m-lines

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1430,6 +1430,14 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
                 attributeValue = end + 1;
             }
         } while (end != NULL && !foundMediaSectionWithCodec);
+
+        // If codecs is NULL, the m-line had no payload types (e.g., "m=audio 9 UDP/TLS/RTP/SAVPF" with nothing after the protocol).
+        // There is no first payload type to extract for a fake transceiver, so skip this media section.
+        if (codecs == NULL) {
+            DLOGW("No payload types found in m-line, skipping media section %u", currentMedia);
+            continue;
+        }
+
         // get the first payload type from codecs in case we need to use it to generate a fake transceiver to respond to an m-line
         // if we don't have a user-created one corresponding to an m-line
         // we can respond to an m-line by including any one codec the offer had

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -3976,6 +3976,49 @@ a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
     });
 }
 
+// Parse invalid codec type
+TEST_F(SdpApiTest, setRemoteDescription_MlineWithNoPayloadTypes)
+{
+    // m=audio line has no payload types after "UDP/TLS/RTP/SAVPF"; only 3 tokens before the codec list
+    // It's missing payload type parameter at the end of the line
+    CHAR offer[] = R"(v=0
+o=- 123456 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=msid-semantic: WMS
+m=audio 9 UDP/TLS/RTP/SAVPF
+c=IN IP4 0.0.0.0
+a=mid:0
+a=ice-ufrag:abcd
+a=ice-pwd:abcdefghijklmnopqrstuvwx
+a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5
+a=setup:actpass
+a=rtcp-mux
+a=recvonly
+)";
+
+    assertLFAndCRLF(offer, ARRAY_SIZE(offer) - 1, [](PCHAR sdp) {
+        RtcConfiguration configuration{};
+        PRtcPeerConnection pRtcPeerConnection = nullptr;
+        RtcSessionDescriptionInit offerSdp{};
+        RtcSessionDescriptionInit answerSdp{};
+
+        EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+        EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_OPUS));
+
+        offerSdp.type = SDP_TYPE_OFFER;
+        STRNCPY(offerSdp.sdp, sdp, MAX_SESSION_DESCRIPTION_INIT_SDP_LEN);
+
+        EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(pRtcPeerConnection, &offerSdp));
+        // createAnswer triggers findTransceiversByRemoteDescription which would crash on NULL codecs
+        EXPECT_EQ(STATUS_SUCCESS, createAnswer(pRtcPeerConnection, &answerSdp));
+
+        closePeerConnection(pRtcPeerConnection);
+        EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+    });
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Gracefully handle invalid SDP missing payload types in m-lines

*Why was it changed?*
- If a remote SDP offer contains a malformed m-line with no payload types (e.g., `m=audio 9 UDP/TLS/RTP/SAVPF` with no codec numbers), the `do-while` loop exits before `count` reaches 4, leaving `codecs` as `NULL`. This results in a NULL pointer dereference in `strchr`/`strlen`/`strncpy` during answer creation.

*How was it changed?*
- When the m-line is malformed, it will now log a warning and continue to the next media section, skipping the malformed m-line entirely.

*What testing was done for the changes?*
- Added the new test, which fails before the change, and passes after the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
