### PR TITLE
Static frames samples: Initialize file size to 0

### DIFF
--- a/samples/common/StaticMedia.c
+++ b/samples/common/StaticMedia.c
@@ -199,7 +199,7 @@ STATUS checkSampleFramesExist(RTC_CODEC codec)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT32 frameSize;
+    UINT32 frameSize = 0;
 
     switch (codec) {
         case RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE:


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Initialized frameSize to 0 in `checkSampleFramesExist()`

*Why was it changed?*
- `readFile()` with a `NULL` buffer ignores the input size and overwrites it with the actual file size, but the uninitialized variable still constitutes technically undefined behavior

*How was it changed?*
- Initialize frameSize to 0.

*What testing was done for the changes?*
- No behavioral changes. The initialization is overwritten by readFile before use.
- CI/CD to validate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
