### PR TITLE
Dependencies: Add parallel build support

### DIFF
--- a/.github/build_windows_mbedtls.bat
+++ b/.github/build_windows_mbedtls.bat
@@ -2,5 +2,5 @@ call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Buil
 mkdir build
 cd build
 cmd.exe /c cmake -G "NMake Makefiles" ..
-cmake -G "NMake Makefiles" -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_TEST=TRUE -DEXT_PTHREAD_INCLUDE_DIR="C:/tools/pthreads-w32-2-9-1-release/Pre-built.2/include/" -DEXT_PTHREAD_LIBRARIES="C:/tools/pthreads-w32-2-9-1-release/Pre-built.2/lib/x64/libpthreadGC2.a" ..
+cmake -G "NMake Makefiles" -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_TEST=TRUE -DPARALLEL_BUILD=ON -DEXT_PTHREAD_INCLUDE_DIR="C:/tools/pthreads-w32-2-9-1-release/Pre-built.2/include/" -DEXT_PTHREAD_LIBRARIES="C:/tools/pthreads-w32-2-9-1-release/Pre-built.2/lib/x64/libpthreadGC2.a" ..
 nmake

--- a/.github/build_windows_openssl.bat
+++ b/.github/build_windows_openssl.bat
@@ -2,5 +2,5 @@ call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Buil
 mkdir build
 cd build
 cmd.exe /c cmake -G "NMake Makefiles" ..
-cmake -G "NMake Makefiles" -DBUILD_TEST=TRUE -DENABLE_AWS_SDK_IN_TESTS=OFF -DPKG_CONFIG_EXECUTABLE="D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe" -DEXT_PTHREAD_INCLUDE_DIR="C:/tools/pthreads-w32-2-9-1-release/Pre-built.2/include/" -DEXT_PTHREAD_LIBRARIES="C:/tools/pthreads-w32-2-9-1-release/Pre-built.2/lib/x64/libpthreadGC2.a" ..
+cmake -G "NMake Makefiles" -DBUILD_TEST=TRUE -DENABLE_AWS_SDK_IN_TESTS=OFF -DPARALLEL_BUILD=ON -DPKG_CONFIG_EXECUTABLE="D:\\gstreamer\\1.0\\x86_64\\bin\\pkg-config.exe" -DEXT_PTHREAD_INCLUDE_DIR="C:/tools/pthreads-w32-2-9-1-release/Pre-built.2/include/" -DEXT_PTHREAD_LIBRARIES="C:/tools/pthreads-w32-2-9-1-release/Pre-built.2/lib/x64/libpthreadGC2.a" ..
 nmake

--- a/.github/workflows/cache-dualstack-test.yml
+++ b/.github/workflows/cache-dualstack-test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_SAMPLE=ON
+          cmake .. -DBUILD_SAMPLE=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Test 1 - Run sample with dual-stack endpoints enabled

--- a/.github/workflows/cache-media-storage-reverse-test.yml
+++ b/.github/workflows/cache-media-storage-reverse-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_SAMPLE=ON
+          cmake .. -DBUILD_SAMPLE=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Provision AWS resources with storage enabled

--- a/.github/workflows/cache-media-storage-test.yml
+++ b/.github/workflows/cache-media-storage-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_SAMPLE=ON
+          cmake .. -DBUILD_SAMPLE=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Provision AWS resources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,13 @@ jobs:
         compiler: [ gcc, clang ]
         config:
           - name: Shared OpenSSL
-            cmake_flags: "-DBUILD_TEST=ON"
+            cmake_flags: "-DBUILD_TEST=ON -DPARALLEL_BUILD=ON"
           - name: Static OpenSSL
-            cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=ON"
+            cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=ON -DPARALLEL_BUILD=ON"
           - name: Shared MbedTLS
-            cmake_flags: "-DBUILD_TEST=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON"
+            cmake_flags: "-DBUILD_TEST=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DPARALLEL_BUILD=ON"
           - name: Static MbedTLS
-            cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON"
+            cmake_flags: "-DBUILD_TEST=ON -DBUILD_STATIC_LIBS=ON -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DPARALLEL_BUILD=ON"
           - name: Shared OpenSSL System Deps
             # Tests disabled (due to dependency issues): 
             # - GCC: Homebrew's libgtest is built with
@@ -91,7 +91,7 @@ jobs:
             #   (std::__cxx11:: ABI), causing linking errors.
             # - GCC/CLang: Homebrew's OpenSSL 3.x is incompatible with SDK requirement (1.1.1x) 
             #   which causes certain test failure (HMAC() returns NULL)
-            cmake_flags: "-DBUILD_TEST=OFF -DBUILD_DEPENDENCIES=OFF"
+            cmake_flags: "-DBUILD_TEST=OFF -DBUILD_DEPENDENCIES=OFF -DPARALLEL_BUILD=ON"
             system_deps: true
       fail-fast: false
 
@@ -222,7 +222,7 @@ jobs:
       - name: Build Repository
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE
+          cmake .. -DBUILD_STATIC_LIBS=TRUE -DBUILD_TEST=TRUE -DPARALLEL_BUILD=ON
           make -j
 
   mbedtls-ubuntu-gcc-4-4:
@@ -261,7 +261,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DBUILD_TEST=ON -DENABLE_AWS_SDK_IN_TESTS=OFF -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_OLD_MBEDTLS_VERSION=ON
+          cmake .. -DBUILD_TEST=ON -DENABLE_AWS_SDK_IN_TESTS=OFF -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DBUILD_OLD_MBEDTLS_VERSION=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Configure AWS Credentials
@@ -357,7 +357,7 @@ jobs:
             BUILD_TEST_FLAG="-DBUILD_TEST=OFF"
           fi
 
-          cmake .. ${BUILD_TEST_FLAG} -DENABLE_AWS_SDK_IN_TESTS=OFF ${{ matrix.build-configuration.cmake-args }}
+          cmake .. ${BUILD_TEST_FLAG} -DENABLE_AWS_SDK_IN_TESTS=OFF -DPARALLEL_BUILD=ON ${{ matrix.build-configuration.cmake-args }}
           make -j
           if [[ "${BUILD_TEST_FLAG}" == "-DBUILD_TEST=ON" ]]; then
             file ./tst/webrtc_client_test
@@ -487,7 +487,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DBUILD_TEST=ON -DENABLE_STATS_CALCULATION_CONTROL=ON -DENABLE_AWS_SDK_IN_TESTS=OFF
+          cmake .. -DBUILD_TEST=ON -DENABLE_STATS_CALCULATION_CONTROL=ON -DENABLE_AWS_SDK_IN_TESTS=OFF -DPARALLEL_BUILD=ON
           make -j
 
       - name: Run tests

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir build 
           cd build
-          cmake .. -DCODE_COVERAGE=ON -DBUILD_TEST=ON
+          cmake .. -DCODE_COVERAGE=ON -DBUILD_TEST=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Configure AWS Credentials

--- a/.github/workflows/cross-compilation.yml
+++ b/.github/workflows/cross-compilation.yml
@@ -95,6 +95,7 @@ jobs:
           
           cmake .. -DBUILD_TEST=ON \
             -DENABLE_AWS_SDK_IN_TESTS=OFF \
+            -DPARALLEL_BUILD=ON \
             ${{ matrix.build-type.cmake_flags }} \
             ${{ matrix.crypto.cmake_flags }} \
             ${{ matrix.compiler.cmake_flags }} \

--- a/.github/workflows/profile-stats.yml
+++ b/.github/workflows/profile-stats.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build
         run: |
           mkdir -p build && cd build
-          cmake .. -DBUILD_SAMPLE=ON
+          cmake .. -DBUILD_SAMPLE=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Setup Signaling Channel

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake ..
+          cmake .. -DPARALLEL_BUILD=ON
           make -j
 
       - name: Sample check
@@ -82,7 +82,7 @@ jobs:
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
           mkdir build && cd build
-          cmake .. -DENABLE_DATA_CHANNEL=OFF
+          cmake .. -DENABLE_DATA_CHANNEL=OFF -DPARALLEL_BUILD=ON
           make
       - name: Sample check without data channel
         run: |
@@ -112,7 +112,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake ..
+          cmake .. -DPARALLEL_BUILD=ON
           make
       - name: Sample check with force TURN
         run: |
@@ -182,7 +182,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Run tests

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -57,7 +57,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DBUILD_TEST=ON -DADDRESS_SANITIZER=ON
+          cmake .. -DBUILD_TEST=ON -DADDRESS_SANITIZER=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Run tests
@@ -103,7 +103,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DBUILD_TEST=ON -DUNDEFINED_BEHAVIOR_SANITIZER=ON
+          cmake .. -DBUILD_TEST=ON -DUNDEFINED_BEHAVIOR_SANITIZER=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Run tests
@@ -165,7 +165,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DBUILD_TEST=ON -DTHREAD_SANITIZER=ON
+          cmake .. -DBUILD_TEST=ON -DTHREAD_SANITIZER=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Configure AWS Credentials

--- a/.github/workflows/storage-samples.yml
+++ b/.github/workflows/storage-samples.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build repository
         run: |
           mkdir build && cd build
-          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON
+          cmake .. -DUSE_OPENSSL=OFF -DUSE_MBEDTLS=ON -DPARALLEL_BUILD=ON
           make -j
 
       - name: Run tests

--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -1,5 +1,10 @@
 # build library from source
 function(build_dependency lib_name)
+  if (WIN32 OR NOT PARALLEL_BUILD)
+    set(PARALLEL_BUILD "")
+  else()
+    set(PARALLEL_BUILD "--parallel")
+  endif()
   set(supported_libs
       gperftools
       gtest
@@ -68,7 +73,7 @@ function(build_dependency lib_name)
     message(FATAL_ERROR "CMake step for lib${lib_name} failed: ${result}")
   endif()
   execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
+    COMMAND ${CMAKE_COMMAND} --build . ${PARALLEL_BUILD}
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${OPEN_SRC_INSTALL_PREFIX}/lib${lib_name})
   if(result)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(ENABLE_AWS_SDK_IN_TESTS "Enable support for compiling AWS SDKs for tests"
 option(ENABLE_STATS_CALCULATION_CONTROL "Enable support for runtime control of ice agent stat calculations." OFF)
 option(BUILD_OLD_MBEDTLS_VERSION "Use MbedTLS version 2.28.8." OFF)
 option(INCREASE_PRECISION_TIMING_LOGS "PROFILE-level timing logs have 2 decimals of milliseconds (otherwise truncated to whole millisecond)" ON)
+option(PARALLEL_BUILD "Build dependencies with parallel flag" OFF)
 
 # Developer Flags
 option(BUILD_TEST "Build the testing tree." OFF)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ You can pass the following options to `cmake ..`:
 * `-DENABLE_KVS_THREADPOOL` -- Enable the KVS threadpool which is off by default.
 * `-DENABLE_STATS_CALCULATION_CONTROL` -- Enable the runtime control of ICE agent stats calculations.
 * `-DINCREASE_PRECISION_TIMING_LOGS` -- Default ON. ON=Use 2 decimals in PROFILE-logs timing. OFF=Truncates down to whole ms.
+* `-DPARALLEL_BUILD` -- Build dependencies with multiple cores. OFF by default. Disabled on Windows.
 
 These options get propagated to [PIC](https://github.com/awslabs/amazon-kinesis-video-streams-pic):
 * `-DKVS_STACK_SIZE` -- Default stack size for threads created using THREAD_CREATE(), in bytes.
@@ -521,8 +522,8 @@ freeIotCredentialProvider(&pSampleConfiguration->pCredentialProvider);
 Build the samples using IoT Core credentials mode:
 
 ```shell
-cmake .. -DIOT_CORE_ENABLE_CREDENTIALS=ON
-make
+cmake .. -DIOT_CORE_ENABLE_CREDENTIALS=ON -DPARALLEL_BUILD=ON
+make -j
 ```
 
 Set the environment variables for IoT Core credentials:


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added a `PARALLEL_BUILD` CMake option (defaulting to OFF) that builds the dependencies with the `cmake --parallel` flag.
- Update the CI to use the new parallel build flag.

*Why was it changed?*
- Improve the build speed of the SDK when building with dependencies
- Note: defaulted to OFF here due since some build systems are unstable when using parallel builds.

*How was it changed?*
- Added the `--parallel flag` to dependency build commands during the CMake configure step.

*What testing was done for the changes?*
- Built the project locally from a clean state with `BUILD_DEPENDENCIES=ON`.

Before:
```sh
rm -rf build open-source
mkdir build
cd build
time cmake .. -DUSE_MBEDTLS=ON -DUSE_OPENSSL=OFF -DENABLE_AWS_SDK_IN_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=ON -DBUILD_DEPENDENCIES=ON

69.13s user 62.47s system 53% cpu 4:04.75 total
```

After:
```sh
rm -rf build open-source
mkdir build
cd build
time cmake .. -DUSE_MBEDTLS=ON -DUSE_OPENSSL=OFF -DENABLE_AWS_SDK_IN_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DBUILD_TEST=ON -DBUILD_DEPENDENCIES=ON -DPARALLEL_BUILD=ON

75.87s user 92.57s system 89% cpu 3:07.89 total
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
