### PR TITLE
Fix uninitialized payloadArray in createPayloadForVP8 error path

### DIFF
--- a/src/source/Rtp/Codecs/RtpVP8Payloader.c
+++ b/src/source/Rtp/Codecs/RtpVP8Payloader.c
@@ -12,9 +12,10 @@ STATUS createPayloadForVP8(UINT32 mtu, PBYTE pData, UINT32 dataLen, PBYTE payloa
     UINT32 payloadRemaining = dataLen, payloadLenConsumed = 0;
     PBYTE currentData = pData;
 
+    MEMSET(&payloadArray, 0, SIZEOF(payloadArray));
+
     CHK(pData != NULL && pPayloadSubLenSize != NULL && pPayloadLength != NULL && (sizeCalculationOnly || pPayloadSubLength != NULL), STATUS_NULL_ARG);
 
-    MEMSET(&payloadArray, 0, SIZEOF(payloadArray));
     payloadArray.payloadBuffer = payloadBuffer;
 
     while (payloadRemaining > 0) {

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -659,6 +659,21 @@ TEST_F(RtpFunctionalityTest, writeFrameNullArgs)
     EXPECT_EQ(STATUS_NULL_ARG, writeFrame(NULL, NULL));
 }
 
+TEST_F(RtpFunctionalityTest, createPayloadForVP8NullDataWithNonNullBuffer)
+{
+    BYTE payloadBuffer[100];
+    UINT32 payloadLength = 0xDEADBEEF;
+    UINT32 payloadSubLenSize = 0xDEADBEEF;
+    UINT32 payloadSubLength[10];
+
+    // pData is NULL but payloadBuffer is non-NULL (sizeCalculationOnly = FALSE).
+    // Should return STATUS_NULL_ARG and zero out the output parameters.
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createPayloadForVP8(DEFAULT_MTU_SIZE_BYTES, NULL, 100, payloadBuffer, &payloadLength, payloadSubLength, &payloadSubLenSize));
+    EXPECT_EQ(0, payloadLength);
+    EXPECT_EQ(0, payloadSubLenSize);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
  - Added `MEMSET(&payloadArray, 0, SIZEOF(payloadArray))` before input validation in `createPayloadForVP8()`

  *Why was it changed?*
  - When `payloadBuffer` is non-NULL but `pData` is NULL, the `CHK` macro jumps to `CleanUp` before `payloadArray` is initialized. The cleanup code only zeroes the struct when `sizeCalculationOnly` is true, so in this path uninitialized stack values are written to `*pPayloadLength` and `*pPayloadSubLenSize`. Detected by clang static analyzer (scan-build).

  *How was it changed?*
  - Moved `MEMSET` to before the `CHK` in `RtpVP8Payloader.c` so the struct is always zeroed regardless of which branch the error path takes.

  *What testing was done for the changes?*
  - Verified locally with a unit test that triggers the error path (non-NULL payloadBuffer, NULL pData/nalus) and confirms output parameters are zeroed instead of garbage.
  - CI/CD to validate no regressions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
