### PR TITLE
Create payload for h265 logic error fix

### DIFF
--- a/src/source/Rtp/Codecs/RtpH265Payloader.c
+++ b/src/source/Rtp/Codecs/RtpH265Payloader.c
@@ -16,6 +16,8 @@ STATUS createPayloadForH265(UINT32 mtu, PBYTE nalus, UINT32 nalusLength, PBYTE p
     BOOL sizeCalculationOnly = (payloadBuffer == NULL);
     PayloadArray payloadArray;
 
+    MEMSET(&payloadArray, 0, SIZEOF(payloadArray));
+
     CHK(nalus != NULL && pPayloadSubLenSize != NULL && pPayloadLength != NULL && (sizeCalculationOnly || pPayloadSubLength != NULL), STATUS_NULL_ARG);
     CHK(mtu > H265_FU_HEADER_SIZE, STATUS_RTP_INPUT_MTU_TOO_SMALL);
 

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -659,7 +659,6 @@ TEST_F(RtpFunctionalityTest, writeFrameNullArgs)
     EXPECT_EQ(STATUS_NULL_ARG, writeFrame(NULL, NULL));
 }
 
-TEST_F(RtpFunctionalityTest, createPayloadForH265NullNalusWithNonNullBuffer)
 TEST_F(RtpFunctionalityTest, createPayloadForH264NullNalusWithNonNullBuffer)
 {
     BYTE payloadBuffer[100];
@@ -670,11 +669,22 @@ TEST_F(RtpFunctionalityTest, createPayloadForH264NullNalusWithNonNullBuffer)
     // nalus is NULL but payloadBuffer is non-NULL (sizeCalculationOnly = FALSE).
     // Should return STATUS_NULL_ARG and zero out the output parameters.
     EXPECT_EQ(STATUS_NULL_ARG,
-              createPayloadForH265(DEFAULT_MTU_SIZE_BYTES, NULL, 100, payloadBuffer, &payloadLength, payloadSubLength, &payloadSubLenSize));
-    EXPECT_EQ(0, payloadLength);
-    EXPECT_EQ(0, payloadSubLenSize);
-}
               createPayloadForH264(DEFAULT_MTU_SIZE_BYTES, NULL, 100, payloadBuffer, &payloadLength, payloadSubLength, &payloadSubLenSize));
+    EXPECT_EQ(0u, payloadLength);
+    EXPECT_EQ(0u, payloadSubLenSize);
+}
+
+TEST_F(RtpFunctionalityTest, createPayloadForH265NullNalusWithNonNullBuffer)
+{
+    BYTE payloadBuffer[100];
+    UINT32 payloadLength = 0xDEADBEEF;
+    UINT32 payloadSubLenSize = 0xDEADBEEF;
+    UINT32 payloadSubLength[10];
+
+    // nalus is NULL but payloadBuffer is non-NULL (sizeCalculationOnly = FALSE).
+    // Should return STATUS_NULL_ARG and zero out the output parameters.
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createPayloadForH265(DEFAULT_MTU_SIZE_BYTES, NULL, 100, payloadBuffer, &payloadLength, payloadSubLength, &payloadSubLenSize));
     EXPECT_EQ(0u, payloadLength);
     EXPECT_EQ(0u, payloadSubLenSize);
 }

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -659,6 +659,20 @@ TEST_F(RtpFunctionalityTest, writeFrameNullArgs)
     EXPECT_EQ(STATUS_NULL_ARG, writeFrame(NULL, NULL));
 }
 
+TEST_F(RtpFunctionalityTest, createPayloadForH265NullNalusWithNonNullBuffer)
+{
+    BYTE payloadBuffer[100];
+    UINT32 payloadLength = 0xDEADBEEF;
+    UINT32 payloadSubLenSize = 0xDEADBEEF;
+    UINT32 payloadSubLength[10];
+
+    // nalus is NULL but payloadBuffer is non-NULL (sizeCalculationOnly = FALSE).
+    // Should return STATUS_NULL_ARG and zero out the output parameters.
+    EXPECT_EQ(STATUS_NULL_ARG,
+              createPayloadForH265(DEFAULT_MTU_SIZE_BYTES, NULL, 100, payloadBuffer, &payloadLength, payloadSubLength, &payloadSubLenSize));
+    EXPECT_EQ(0, payloadLength);
+    EXPECT_EQ(0, payloadSubLenSize);
+}
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
  - Added `MEMSET(&payloadArray, 0, SIZEOF(payloadArray))` before input validation in `createPayloadForH265()`

*Why was it changed?*
  - When `payloadBuffer` is non-NULL but `nalus` is NULL, the `CHK` macro jumps to `CleanUp` before `payloadArray` is initialized. The cleanup code only
  zeroes the struct when `sizeCalculationOnly` is true, so in this path uninitialized stack values are written to `*pPayloadLength` and `*pPayloadSubLenSize`.

*How was it changed?*
  - Added `MEMSET` before the `CHK` in `RtpH265Payloader.c` so the struct is always zeroed regardless of which branch the error path takes.

*What testing was done for the changes?*
    - Verified locally with a unit test that triggers the error path (non-NULL payloadBuffer, NULL pData/nalus) and confirms output parameters are zeroed instead of garbage.
  - CI/CD to validate no regressions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
