### PR TITLE
Samples: Address remaining warnings

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -886,13 +886,15 @@ STATUS createSampleConfiguration(PCHAR channelName, SIGNALING_CHANNEL_ROLE_TYPE 
         pSessionToken = NULL;
     }
 
-    if (!IS_NULL_OR_EMPTY_STRING((pMaxLogFiles = GETENV(MAX_NUM_LOG_FILES_ENV_VAR)))) {
+    pMaxLogFiles = GETENV(MAX_NUM_LOG_FILES_ENV_VAR);
+    if (!IS_NULL_OR_EMPTY_STRING(pMaxLogFiles)) {
         CHK_STATUS_ERR(STRTOUI32(pMaxLogFiles, NULL, 10, &numLogFiles), STATUS_INVALID_ARG, "Failed to parse max number of log files: %s",
                        pMaxLogFiles);
         CHK_ERR(CHECK_IN_RANGE(numLogFiles, 1, 100), STATUS_INVALID_ARG, "MaxLogFiles must be in range: [1, 100], was: %d", numLogFiles);
     }
 
-    if (!IS_NULL_OR_EMPTY_STRING((pLogFileDir = GETENV(LOG_FILE_DIR)))) {
+    pLogFileDir = GETENV(LOG_FILE_DIR);
+    if (!IS_NULL_OR_EMPTY_STRING(pLogFileDir)) {
         pLogFilesDir = pLogFileDir;
     }
 

--- a/samples/common/StaticMedia.c
+++ b/samples/common/StaticMedia.c
@@ -59,7 +59,7 @@ PVOID sendVideoPacketsFromDisk(PVOID args)
     PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) args;
     RtcEncoderStats encoderStats;
     Frame frame;
-    UINT32 fileIndex = 0, frameSize;
+    UINT32 fileIndex = 0, frameSize = 0;
     CHAR filePath[MAX_PATH_LEN + 1];
     STATUS status;
     UINT32 i;
@@ -140,7 +140,7 @@ PVOID sendAudioPacketsFromDisk(PVOID args)
     STATUS retStatus = STATUS_SUCCESS;
     PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) args;
     Frame frame;
-    UINT32 fileIndex = 0, frameSize;
+    UINT32 fileIndex = 0, frameSize = 0;
     CHAR filePath[MAX_PATH_LEN + 1];
     UINT32 i;
     STATUS status;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Initialized `frameSize` variable in `sendVideoPacketsFromDisk` and `sendAudioPacketsFromDisk` in `samples/common/StaticMedia.c`
- Separated `GETENV()` calls from `IS_NULL_OR_EMPTY_STRING()` macro invocations in `samples/common/Common.c`

*Why was it changed?*
Improving robustness in the sample:
  1. `frameSize` was uninitialized when passed by pointer to `readFrameFromDisk(NULL, &frameSize, ...)`, where `*pSize` is read into a local before `readFile()` populates it.
  2. & 3. The `IS_NULL_OR_EMPTY_STRING(str)` macro expands its argument textually twice (`str == NULL || (str)[0] == '\0'`). When the argument contains a `GETENV()` call with an embedded assignment (e.g., `(pMaxLogFiles = GETENV(...))`), the two expansions as independent calls, flagging a potential null dereference on the `[0]` access if the second `GETENV()` invocation were to return NULL.

    **Note:** These are not real bugs under normal runtime conditions. `getenv()` is deterministic for a given key within a single-threaded section, and `readFrameFromDisk` is always called with `pFrame == NULL` first (query-size mode) where `readFile` writes the size before it's used. However, the fixes are correct defensive coding practices that eliminate the warnings without changing behavior, and make the code's intent clearer to both human readers and static analysis tools.

*How was it changed?*
  - `StaticMedia.c`: Changed `UINT32 fileIndex = 0, frameSize;` → `UINT32 fileIndex = 0, frameSize = 0;` in both `sendVideoPacketsFromDisk` and `sendAudioPacketsFromDisk`. This
  ensures the value passed to `readFrameFromDisk` is always well-defined.
  - `Common.c`: Moved the `GETENV()` calls out of the `IS_NULL_OR_EMPTY_STRING()` macro argument into separate assignment statements, then passed the already-assigned variable to the macro. This guarantees each variable is evaluated exactly once before the null/empty check.

*What testing was done for the changes?*
- Warnings resolved in the build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
