### PR TITLE
Samples: Add warning for data channel metrics send failed

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -1882,7 +1882,11 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
     if (pSampleStreamingSession == NULL) {
         STRCPY(errorMessage, "Could not generate stats since the streaming session is NULL");
         retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) errorMessage, STRLEN(errorMessage));
-        DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
+        if (STATUS_FAILED(retStatus)) {
+            DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
+        } else {
+            DLOGE("onDataChannelMessage(): %s", errorMessage);
+        }
         goto CleanUp;
     }
 
@@ -1890,7 +1894,11 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
     if (pSampleConfiguration == NULL) {
         STRCPY(errorMessage, "Could not generate stats since the sample configuration is NULL");
         retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) errorMessage, STRLEN(errorMessage));
-        DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
+        if (STATUS_FAILED(retStatus)) {
+            DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
+        } else {
+            DLOGE("onDataChannelMessage(): %s", errorMessage);
+        }
         goto CleanUp;
     }
 
@@ -1910,7 +1918,11 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
             if (tokens[0].type != JSMN_OBJECT) {
                 STRCPY(errorMessage, "Invalid JSON received, please send a valid json as the SDK is operating in datachannel-benchmarking mode");
                 retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) errorMessage, STRLEN(errorMessage));
-                DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
+                if (STATUS_FAILED(retStatus)) {
+                    DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
+                } else {
+                    DLOGE("onDataChannelMessage(): %s", errorMessage);
+                }
                 retStatus = STATUS_INVALID_API_CALL_RETURN_JSON;
                 goto CleanUp;
             }

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -2008,10 +2008,19 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
 
                 retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) pSampleStreamingSession->pSignalingClientMetricsMessage,
                                             STRLEN(pSampleStreamingSession->pSignalingClientMetricsMessage));
+                if (STATUS_FAILED(retStatus)) {
+                    DLOGW("onDataChannelMessage(): Couldn't send signaling metrics to the viewer. Status code 0x%08x", retStatus);
+                }
                 retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) pSampleStreamingSession->pPeerConnectionMetricsMessage,
                                             STRLEN(pSampleStreamingSession->pPeerConnectionMetricsMessage));
+                if (STATUS_FAILED(retStatus)) {
+                    DLOGW("onDataChannelMessage(): Couldn't send peer-connection metrics to the viewer. Status code 0x%08x", retStatus);
+                }
                 retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) pSampleStreamingSession->pIceAgentMetricsMessage,
                                             STRLEN(pSampleStreamingSession->pIceAgentMetricsMessage));
+                if (STATUS_FAILED(retStatus)) {
+                    DLOGW("onDataChannelMessage(): Couldn't send ice-agent metrics to the viewer. Status code 0x%08x", retStatus);
+                }
             }
         } else {
             DLOGI("DataChannel string message: %.*s\n", pMessageLen, pMessage);

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -1882,7 +1882,7 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
     if (pSampleStreamingSession == NULL) {
         STRCPY(errorMessage, "Could not generate stats since the streaming session is NULL");
         retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) errorMessage, STRLEN(errorMessage));
-        DLOGE("%s", errorMessage);
+        DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
         goto CleanUp;
     }
 
@@ -1890,7 +1890,7 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
     if (pSampleConfiguration == NULL) {
         STRCPY(errorMessage, "Could not generate stats since the sample configuration is NULL");
         retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) errorMessage, STRLEN(errorMessage));
-        DLOGE("%s", errorMessage);
+        DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
         goto CleanUp;
     }
 
@@ -2009,17 +2009,17 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
                 retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) pSampleStreamingSession->pSignalingClientMetricsMessage,
                                             STRLEN(pSampleStreamingSession->pSignalingClientMetricsMessage));
                 if (STATUS_FAILED(retStatus)) {
-                    DLOGW("onDataChannelMessage(): Couldn't send signaling metrics to the viewer. Status code 0x%08x", retStatus);
+                    DLOGE("onDataChannelMessage(): Couldn't send signaling metrics to the viewer. Status code 0x%08x", retStatus);
                 }
                 retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) pSampleStreamingSession->pPeerConnectionMetricsMessage,
                                             STRLEN(pSampleStreamingSession->pPeerConnectionMetricsMessage));
                 if (STATUS_FAILED(retStatus)) {
-                    DLOGW("onDataChannelMessage(): Couldn't send peer-connection metrics to the viewer. Status code 0x%08x", retStatus);
+                    DLOGE("onDataChannelMessage(): Couldn't send peer-connection metrics to the viewer. Status code 0x%08x", retStatus);
                 }
                 retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) pSampleStreamingSession->pIceAgentMetricsMessage,
                                             STRLEN(pSampleStreamingSession->pIceAgentMetricsMessage));
                 if (STATUS_FAILED(retStatus)) {
-                    DLOGW("onDataChannelMessage(): Couldn't send ice-agent metrics to the viewer. Status code 0x%08x", retStatus);
+                    DLOGE("onDataChannelMessage(): Couldn't send ice-agent metrics to the viewer. Status code 0x%08x", retStatus);
                 }
             }
         } else {

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -1910,7 +1910,7 @@ VOID onDataChannelMessage(UINT64 customData, PRtcDataChannel pDataChannel, BOOL 
             if (tokens[0].type != JSMN_OBJECT) {
                 STRCPY(errorMessage, "Invalid JSON received, please send a valid json as the SDK is operating in datachannel-benchmarking mode");
                 retStatus = dataChannelSend(pDataChannel, FALSE, (PBYTE) errorMessage, STRLEN(errorMessage));
-                DLOGE("%s", errorMessage);
+                DLOGE("onDataChannelMessage(): %s. Status code 0x%08x", errorMessage, retStatus);
                 retStatus = STATUS_INVALID_API_CALL_RETURN_JSON;
                 goto CleanUp;
             }

--- a/src/source/PeerConnection/DataChannel.c
+++ b/src/source/PeerConnection/DataChannel.c
@@ -68,7 +68,6 @@ STATUS dataChannelSend(PRtcDataChannel pRtcDataChannel, BOOL isBinary, PBYTE pMe
     pKvsDataChannel->rtcDataChannelDiagnostics.messagesSent++;
     pKvsDataChannel->rtcDataChannelDiagnostics.bytesSent += pMessageLen;
 CleanUp:
-    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }

--- a/src/source/PeerConnection/DataChannel.c
+++ b/src/source/PeerConnection/DataChannel.c
@@ -68,6 +68,7 @@ STATUS dataChannelSend(PRtcDataChannel pRtcDataChannel, BOOL isBinary, PBYTE pMe
     pKvsDataChannel->rtcDataChannelDiagnostics.messagesSent++;
     pKvsDataChannel->rtcDataChannelDiagnostics.bytesSent += pMessageLen;
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added warning-level log messages when dataChannelSend() fails while sending metrics (signaling, peer-connection, and ice-agent) to the viewer via the data channel in onDataChannelMessage().

*Why was it changed?*
- Previously, failures to send metrics over the data channel were silently ignored. This made it difficult to diagnose why a viewer might not be receiving time-to-first-frame breakdown metrics. The missing error feedback reduced observability into the metrics delivery pipeline.

*How was it changed?*
- After each dataChannelSend() call for metrics messages, the return status is now checked with STATUS_FAILED(). On failure, a DLOGW warning is emitted that identifies which metric type failed and includes the hex status code for debugging.

*What testing was done for the changes?*
- CI/CD for the changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
