### PR TITLE
Add comment about unused lock variable

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2711,11 +2711,13 @@ STATUS incomingDataHandler(UINT64 customData, PSocketConnection pSocketConnectio
         // release lock early
 
         MUTEX_UNLOCK(pIceAgent->lock);
-        locked = FALSE;
+        // Not currently used since inboundPacketFn returns VOID. No jumps to CleanUp.
+        // locked = FALSE;
         pIceAgent->iceAgentCallbacks.inboundPacketFn(pIceAgent->iceAgentCallbacks.customData, pBuffer, bufferLen);
 
         MUTEX_LOCK(pIceAgent->lock);
-        locked = TRUE;
+        // Not currently used since inboundPacketFn returns VOID. No jumps to CleanUp.
+        // locked = TRUE;
         addrLen = IS_IPV4_ADDR(pSrc) ? IPV4_ADDRESS_LENGTH : IPV6_ADDRESS_LENGTH;
         if (pIceAgent->pDataSendingIceCandidatePair != NULL &&
             pIceAgent->pDataSendingIceCandidatePair->local->pSocketConnection == pSocketConnection &&


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add comment to address "Dead assignment/Unused code"

*Why was it changed?*
- "Locked" boolean flag is used in CleanUp code to unlock the lock if it's locked (function cleanup).
- However, inboundPacketFn returns VOID. Therefore, there is no CHK that would jump to CleanUp. Therefore, the false assignment is not used and outputs a warning.

*How was it changed?*
- Comment out the FALSE assignment.

*What testing was done for the changes?*
- CI/CD to verify

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
