### PR TITLE
Add minimum length validation for stun ERROR_CODE parsing

### DIFF
--- a/src/source/Stun/Stun.c
+++ b/src/source/Stun/Stun.c
@@ -700,8 +700,10 @@ STATUS deserializeStunPacket(PBYTE pStunBuffer, UINT32 bufferSize, PBYTE passwor
             case STUN_ATTRIBUTE_TYPE_ERROR_CODE:
                 attributeSize = SIZEOF(StunAttributeErrorCode);
 
-                // Validate the size of the length against the max value of error phrase
-                CHK(stunAttributeHeader.length <= STUN_MAX_ERROR_PHRASE_LEN, STATUS_STUN_INVALID_ERROR_CODE_ATTRIBUTE_LENGTH);
+                // Validate the size of the length against the min and max value of error phrase
+                CHK(stunAttributeHeader.length >= STUN_ERROR_CODE_PACKET_ERROR_PHRASE_OFFSET &&
+                        stunAttributeHeader.length <= STUN_MAX_ERROR_PHRASE_LEN,
+                    STATUS_STUN_INVALID_ERROR_CODE_ATTRIBUTE_LENGTH);
                 CHK(!fingerprintFound && !messaageIntegrityFound, STATUS_STUN_ATTRIBUTES_AFTER_FINGERPRINT_MESSAGE_INTEGRITY);
 
                 // Add the length of the string itself
@@ -950,9 +952,11 @@ STATUS deserializeStunPacket(PBYTE pStunBuffer, UINT32 bufferSize, PBYTE passwor
                 pStunAttributeErrorCode->errorPhrase = (PCHAR) (pStunAttributeErrorCode + 1);
 
                 // Copy the padded error phrase
-                MEMCPY(pStunAttributeErrorCode->errorPhrase,
-                       ((PBYTE) pStunAttributeHeader + STUN_ATTRIBUTE_HEADER_LEN + STUN_ERROR_CODE_PACKET_ERROR_PHRASE_OFFSET),
-                       pStunAttributeErrorCode->paddedLength - STUN_ERROR_CODE_PACKET_ERROR_PHRASE_OFFSET);
+                if (pStunAttributeErrorCode->paddedLength >= STUN_ERROR_CODE_PACKET_ERROR_PHRASE_OFFSET) {
+                    MEMCPY(pStunAttributeErrorCode->errorPhrase,
+                           ((PBYTE) pStunAttributeHeader + STUN_ATTRIBUTE_HEADER_LEN + STUN_ERROR_CODE_PACKET_ERROR_PHRASE_OFFSET),
+                           pStunAttributeErrorCode->paddedLength - STUN_ERROR_CODE_PACKET_ERROR_PHRASE_OFFSET);
+                }
                 attributeSize = SIZEOF(StunAttributeErrorCode) + pStunAttributeErrorCode->paddedLength;
 
                 break;

--- a/tst/StunFunctionalityTest.cpp
+++ b/tst/StunFunctionalityTest.cpp
@@ -6,8 +6,7 @@ namespace kinesis {
 namespace video {
 namespace webrtcclient {
 
-class StunFunctionalityTest : public WebRtcClientTestBase {
-};
+class StunFunctionalityTest : public WebRtcClientTestBase {};
 
 #define TEST_STUN_PASSWORD (PCHAR) "bf1f29259cea581c873248d4ae73b30f"
 
@@ -691,6 +690,46 @@ TEST_F(StunFunctionalityTest, deserializeStunErrorCode)
     EXPECT_EQ(0, STRCMP(pStunAttributeErrorCode->errorPhrase, "Forbidden IP"));
 
     EXPECT_EQ(STATUS_SUCCESS, freeStunPacket(&pStunPacket));
+}
+
+TEST_F(StunFunctionalityTest, errorCodeZeroLengthUnderflowTest)
+{
+    PStunPacket pStunPacket = NULL;
+
+    /** STUN Binding Request with a single ERROR_CODE attribute whose length = 0.
+     *  Layout:
+     *   [0..1]   0x0001  BINDING_REQUEST
+     *   [2..3]   0x0008  message length (8 bytes of attributes follow the header)
+     *   [4..7]   0x2112A442  magic cookie
+     *   [8..19]  transaction ID (arbitrary)
+     *   [20..21] 0x0009  ERROR_CODE attribute type
+     *   [22..23] 0x0000  attribute length = 0 (incorrect length)
+     *   [24..27] 0x00000000  padding
+     */
+    BYTE malformedPacket[] = {0x00, 0x01, 0x00, 0x08, 0x21, 0x12, 0xA4, 0x42, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+                              0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+    // The parser should reject the packet with an invalid length error.
+    EXPECT_EQ(STATUS_STUN_INVALID_ERROR_CODE_ATTRIBUTE_LENGTH,
+              deserializeStunPacket(malformedPacket, SIZEOF(malformedPacket), NULL, 0, &pStunPacket));
+    EXPECT_EQ(NULL, pStunPacket);
+}
+
+TEST_F(StunFunctionalityTest, errorCodeTooShortLengthUnderflowTest)
+{
+    PStunPacket pStunPacket = NULL;
+
+    // ERROR_CODE with length=3: paddedLength = ROUND_UP(3,4) = 4
+    BYTE malformedPacket[] = {
+        0x00, 0x01, 0x00, 0x08, 0x21, 0x12, 0xA4, 0x42, 0x01, 0x02, 0x03, 0x04,
+        0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x00, 0x09, 0x00, 0x03, // ERROR_CODE, length=3
+        0x00, 0x00, 0x00, 0x00                                                  // padding (required for 4-byte alignment)
+    };
+
+    // The parser should reject the packet with an invalid length error.
+    EXPECT_EQ(STATUS_STUN_INVALID_ERROR_CODE_ATTRIBUTE_LENGTH,
+              deserializeStunPacket(malformedPacket, SIZEOF(malformedPacket), NULL, 0, &pStunPacket));
+    EXPECT_EQ(NULL, pStunPacket);
 }
 
 } // namespace webrtcclient


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added minimum length validation for STUN attribute ERROR_CODE in `deserializeStunPacket` (Stun.c)

*Why was it changed?*
- The ERROR_CODE attribute parser only validated an upper bound (length <= 128) but not a lower bound (length >= 4). When `attribute.length = 0`, the computation `paddedLength - 4` underflows (UINT16 wraps to ~65532), causing a massive MEMCPY that crashes the process. Per RFC 5389, ERROR_CODE must contain at least 4 bytes (reserved + error class + error number).

*How was it changed?*
- Added `stunAttributeHeader.length >= STUN_ERROR_CODE_PACKET_ERROR_PHRASE_OFFSET` to the existing validation check, rejecting malformed attributes with length more than 4.
- Added an if guard around the `MEMCPY` to prevent the underflow even if a zero-length attribute somehow reaches the copy stage.

*What testing was done for the changes?*
- Added unit test for cases where attribute length is less than 4.
- All tests are now passing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
