### PR TITLE
Address unused variables in Rtcp stats

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -84,17 +84,16 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     STATUS retStatus = STATUS_SUCCESS;
     PKvsRtpTransceiver pTransceiver = NULL;
     DOUBLE fractionLost;
-    UINT32 rttPropDelayMsec = 0, rttPropDelay, delaySinceLastSR, lastSR, interarrivalJitter, extHiSeqNumReceived, cumulativeLost, senderSSRC, ssrc1;
+    UINT32 rttPropDelayMsec = 0, rttPropDelay, delaySinceLastSR, lastSR, ssrc1;
+#ifdef LOG_STREAMING
+    UINT32 interarrivalJitter, extHiSeqNumReceived, cumulativeLost, senderSSRC;
+#endif
     UINT64 currentTimeNTP = convertTimestampToNTP(GETTIME());
 
     UNUSED_PARAM(rttPropDelayMsec);
     UNUSED_PARAM(rttPropDelay);
     UNUSED_PARAM(delaySinceLastSR);
     UNUSED_PARAM(lastSR);
-    UNUSED_PARAM(interarrivalJitter);
-    UNUSED_PARAM(extHiSeqNumReceived);
-    UNUSED_PARAM(cumulativeLost);
-    UNUSED_PARAM(senderSSRC);
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
     // https://tools.ietf.org/html/rfc3550#section-6.4.2
@@ -103,7 +102,9 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
         return STATUS_SUCCESS;
     }
 
+#ifdef LOG_STREAMING
     senderSSRC = getUnalignedInt32BigEndian(pRtcpPacket->payload);
+#endif
     ssrc1 = getUnalignedInt32BigEndian(pRtcpPacket->payload + 4);
 
     if (STATUS_FAILED(findTransceiverBySsrc(pKvsPeerConnection, &pTransceiver, ssrc1))) {
@@ -111,9 +112,11 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
         return STATUS_SUCCESS; // not really an error ?
     }
     fractionLost = pRtcpPacket->payload[8] / 255.0;
+#ifdef LOG_STREAMING
     cumulativeLost = ((UINT32) getUnalignedInt32BigEndian(pRtcpPacket->payload + 8)) & 0x00ffffffu;
     extHiSeqNumReceived = getUnalignedInt32BigEndian(pRtcpPacket->payload + 12);
     interarrivalJitter = getUnalignedInt32BigEndian(pRtcpPacket->payload + 16);
+#endif
     lastSR = getUnalignedInt32BigEndian(pRtcpPacket->payload + 20);
     delaySinceLastSR = getUnalignedInt32BigEndian(pRtcpPacket->payload + 24);
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
  - Wrapped streaming-log-only variables (`senderSSRC`, `cumulativeLost`, `extHiSeqNumReceived`, `interarrivalJitter`) and their assignments in `#ifdef LOG_STREAMING` in `src/source/PeerConnection/Rtcp.c`
  - Removed the corresponding `UNUSED_PARAM` lines for those 4 variables

*Why was it changed?*
  - "Dead assignment" warnings at lines 106, 114, 115, and 116 of `onRtcpReceiverReport`. These variables are assigned values parsed from the RTCP packet but are only ever consumed by the `DLOGS(...)` (logging) macro on line 123.
  - Note: these are not real bugs. The assignments are intentional and correct when `LOG_STREAMING` is enabled. Without streaming logs enabled (default), they are simply unreachable dead code.

*How was it changed?*
  - Moved the declarations of `senderSSRC`, `cumulativeLost`, `extHiSeqNumReceived`, and `interarrivalJitter` into an `#ifdef LOG_STREAMING` block
  - Wrapped the assignments of those variables in `#ifdef LOG_STREAMING` / `#endif` guards
  - Left variables that are also used for RTT computation or stats (`fractionLost`, `lastSR`, `delaySinceLastSR`, `rttPropDelay`, `rttPropDelayMsec`) unconditional


*What testing was done for the changes?*
- Rebuilt after and the warnings are no longer there

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
