### PR TITLE
Address unused vars in TurnConnection

### DIFF
--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -1102,8 +1102,6 @@ STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
     UINT32 i = 0;
     PKvsIpAddress pTurnServerIp = NULL;
 
-    UNUSED_PARAM(sendStatus);
-
     // turn mutex is assumed to be locked.
     CHK(pTurnConnection != NULL, STATUS_NULL_ARG);
     for (i = 0; i < pTurnConnection->turnPeerCount; ++i) {
@@ -1126,9 +1124,11 @@ STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
             CHK(pTurnPeer->pTransactionIdStore != NULL, STATUS_INVALID_OPERATION);
             transactionIdStoreInsert(pTurnPeer->pTransactionIdStore, pTurnConnection->pTurnCreatePermissionPacket->header.transactionId);
             getTurnConnectionIpAddress(pTurnConnection, &pTurnServerIp);
+            // Send is best-effort over UDP; do not set retStatus so we continue processing remaining peers
             sendStatus =
                 iceUtilsSendStunPacket(pTurnConnection->pTurnCreatePermissionPacket, pTurnConnection->longTermKey,
                                        ARRAY_SIZE(pTurnConnection->longTermKey), pTurnServerIp, pTurnConnection->pControlChannel, NULL, FALSE);
+            CHK_LOG_ERR(sendStatus);
 
         } else if (pTurnPeer->connectionState == TURN_PEER_CONN_STATE_BIND_CHANNEL) {
             if (pTurnPeer->firstTimeBindChannelReq) {
@@ -1153,9 +1153,11 @@ STATUS checkTurnPeerConnections(PTurnConnection pTurnConnection)
             CHK(pTurnPeer->pTransactionIdStore != NULL, STATUS_INVALID_OPERATION);
             transactionIdStoreInsert(pTurnPeer->pTransactionIdStore, pTurnConnection->pTurnChannelBindPacket->header.transactionId);
             getTurnConnectionIpAddress(pTurnConnection, &pTurnServerIp);
+            // Send is best-effort over UDP; do not set retStatus so we continue processing remaining peers
             sendStatus =
                 iceUtilsSendStunPacket(pTurnConnection->pTurnChannelBindPacket, pTurnConnection->longTermKey,
                                        ARRAY_SIZE(pTurnConnection->longTermKey), pTurnServerIp, pTurnConnection->pControlChannel, NULL, FALSE);
+            CHK_LOG_ERR(sendStatus);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
  - Added `CHK_LOG_ERR(sendStatus)` after each `iceUtilsSendStunPacket` call in `checkTurnPeerConnections` in `src/source/Ice/TurnConnection.c`
  - Added comments explaining why `retStatus` is intentionally not set from the send result

*Why was it changed?*
- Dead assignment warning because `sendStatus` was assigned but never read. The send is best-effort over UDP, failures are transient and the TURN state machine retries on the next timer tick so we do not propagate the error via `retStatus`.

*How was it changed?*
- Replaced the `UNUSED_PARAM(sendStatus)` with `CHK_LOG_ERR(sendStatus)` after each call site, which logs the error if non-success but does not alter control flow

*What testing was done for the changes?*
 - Verified the project builds cleanly. CI/CD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
