### PR TITLE
Address unused variables in JoinStorageSession

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1547,12 +1547,8 @@ STATUS joinStorageSessionLws(PSignalingClient pSignalingClient, UINT64 time)
     CHAR url[MAX_URI_CHAR_LEN + 1];
     CHAR paramsJson[MAX_JSON_PARAMETER_STRING_LEN];
     PLwsCallInfo pLwsCallInfo = NULL;
-    PCHAR pResponseStr;
-    UINT32 resultLen;
 
-    UNUSED_PARAM(pResponseStr);
     UNUSED_PARAM(pLwsCallInfo);
-    UNUSED_PARAM(resultLen);
     CHK(pSignalingClient != NULL, STATUS_NULL_ARG);
     CHK(pSignalingClient->channelEndpointWebrtc[0] != '\0', STATUS_INTERNAL_ERROR);
 
@@ -1594,8 +1590,6 @@ STATUS joinStorageSessionLws(PSignalingClient pSignalingClient, UINT64 time)
 
     // Set the service call result
     ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) pLwsCallInfo->callInfo.callResult);
-    pResponseStr = pLwsCallInfo->callInfo.responseData;
-    resultLen = pLwsCallInfo->callInfo.responseDataLen;
 
     // Early return if we have a non-success result
     CHK((SERVICE_CALL_RESULT) ATOMIC_LOAD(&pSignalingClient->result) == SERVICE_CALL_RESULT_OK, STATUS_SIGNALING_LWS_CALL_FAILED);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Removed `pResponseStr` and `resultLen` variables and their assignments from `joinStorageSessionLws` in `src/source/Signaling/LwsApiCalls.c`
- Removed the corresponding `UNUSED_PARAM` lines

*Why was it changed?*
- "Dead assignment" warnings at lines 1597-1598. The variables `pResponseStr` and `resultLen` are assigned from the call response but never read afterward.
- These appear to be leftover from copy-paste of `describeMediaStorageConfLws`, which uses the same pattern but actually parses the JSON response body. Unlike that function, `joinStorageSessionLws` has no response body to process, it only checks whether the call succeeded via the stored `callResult`. The error path is already handled by `CHK` + `DLOGE` in `CleanUp`, so there is nothing additional to log from these variables.

*How was it changed?*
  - Removed declarations of `pResponseStr` and `resultLen`
  - Removed their `UNUSED_PARAM` hints
  - Removed the two dead assignments after `lwsCompleteSync`

*What testing was done for the changes?*
- CI/CD for the testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
