### PR TITLE
Address unused var in signaling connect code

### DIFF
--- a/src/source/Signaling/LwsApiCalls.c
+++ b/src/source/Signaling/LwsApiCalls.c
@@ -1507,6 +1507,8 @@ STATUS connectSignalingChannelLws(PSignalingClient pSignalingClient, UINT64 time
     // Check whether we are connected and reset the result
     if (ATOMIC_LOAD_BOOL(&pSignalingClient->connected)) {
         ATOMIC_STORE(&pSignalingClient->result, (SIZE_T) SERVICE_CALL_RESULT_OK);
+    } else {
+        DLOGW("Signaling connect returned result %u, connection not established", callResult);
     }
 
     MUTEX_UNLOCK(pSignalingClient->connectedLock);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
  - Added a warning log when the signaling connect loop exits but the connection is not established, using the `callResult` captured in the loop condition

*Why was it changed?*
-  "Dead nested assignment" at line 1503: `callResult` was assigned in the `while` loop condition but never read afterward.
- Adding a warning log when the  connection is not established makes the variable live and provides useful diagnostic output for debugging signaling connection failures that don't result in a timeout.

*How was it changed?*
- Added an `else` branch after the `ATOMIC_LOAD_BOOL(&pSignalingClient->connected)` check that logs the `callResult` value via `DLOGW`

*What testing was done for the changes?*
- Verified the project builds cleanly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
