### PR TITLE
Address unused var in stun serializer code

### DIFF
--- a/src/source/Stun/Stun.c
+++ b/src/source/Stun/Stun.c
@@ -509,8 +509,8 @@ STATUS serializeStunPacket(PStunPacket pStunPacket, PBYTE password, UINT32 passw
             // Advance the current position
             pCurrentBufferPosition += encodedLen;
 
-            // Decrement the remaining size
-            remaining -= encodedLen;
+            // Note: not decrementing remaining here because fingerprint is always the last attribute.
+            // If new attributes are added after fingerprint, add: remaining -= encodedLen;
         } else {
             packetSize += encodedLen;
         }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
  - Removed the dead `remaining -= encodedLen` decrement in the fingerprint serialization block of `serializeStunPacket` in `src/source/Stun/Stun.c`
  - Added a comment explaining why the decrement is intentionally omitted


*Why was it changed?*
- "Dead increment" warning at line 513. The fingerprint is always the last attribute serialized in a STUN packet per RFC 5389, so  decrementing `remaining` after it serves no purpose since the value is never read again.

*How was it changed?*
  - Removed `remaining -= encodedLen;`
  - Added a comment noting that fingerprint is always the last attribute, and that the decrement should be restored if attributes are ever added after it

*What testing was done for the changes?*
  - CI/CD to validate the changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
