### PR TITLE
CI Expansion: Gst Samples and Deps=Off

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -240,3 +240,105 @@ jobs:
             exit 1
           fi
           echo "✅ No definite or indirect memory leaks detected."
+
+  ubuntu-docker-sample-checks:
+    name: docker-${{ matrix.runner.id }} - Samples (build_deps=${{ matrix.build-dependencies }})
+    runs-on: ubuntu-latest
+    container: ${{ matrix.runner.docker }}
+    timeout-minutes: 30
+    env:
+      AWS_KVS_LOG_LEVEL: 1
+      KVS_ICE_TRANSPORT_POLICY: relay
+      DEBIAN_FRONTEND: noninteractive
+    strategy:
+      matrix:
+        runner:
+          - id: ubuntu-20.04
+            docker: public.ecr.aws/ubuntu/ubuntu:20.04_stable
+          - id: ubuntu-22.04
+            docker: public.ecr.aws/ubuntu/ubuntu:22.04_stable
+          - id: ubuntu-24.04
+            docker: public.ecr.aws/ubuntu/ubuntu:24.04_stable
+        build-dependencies: ["ON", "OFF"]
+      fail-fast: false
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y git cmake build-essential pkg-config
+          if [ "${{ matrix.build-dependencies }}" = "OFF" ]; then
+            apt-get install -y libssl-dev libsrtp2-dev libusrsctp-dev
+          fi
+
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Build repository (static frames)
+        run: |
+          mkdir build && cd build
+          cmake .. -DBUILD_DEPENDENCIES=${{ matrix.build-dependencies }} -DBUILD_WEBSOCKETS=ON -DPARALLEL_BUILD=ON
+          make -j
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Install AWS CLI
+        run: |
+          apt-get install -y curl unzip
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          ./aws/install
+
+      - name: Run static frames sample (policy=all)
+        env:
+          KVS_ICE_TRANSPORT_POLICY: all
+        run: |
+          CHANNEL="ScaryTestChannel-docker-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-all"
+          ./scripts/prepare-channel.sh "$CHANNEL"
+          ./scripts/run-static-sample.sh "$CHANNEL"
+
+      - name: Run static frames sample (policy=relay)
+        run: |
+          CHANNEL="ScaryTestChannel-docker-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-relay"
+          ./scripts/prepare-channel.sh "$CHANNEL"
+          ./scripts/run-static-sample.sh "$CHANNEL"
+
+      - name: Install GStreamer dependencies
+        run: |
+          apt-get install -y \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-ugly \
+            gstreamer1.0-libav \
+            gstreamer1.0-tools
+
+      - name: Build repository (GStreamer)
+        run: |
+          rm -rf build open-source
+          mkdir build && cd build
+          cmake .. -DBUILD_DEPENDENCIES=${{ matrix.build-dependencies }} -DBUILD_WEBSOCKETS=ON -DPARALLEL_BUILD=ON
+          make -j
+
+      - name: Run GStreamer testsrc sample (policy=all)
+        env:
+          KVS_ICE_TRANSPORT_POLICY: all
+        run: |
+          CHANNEL="ScaryTestChannel-gst-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-all"
+          ./scripts/prepare-channel.sh "$CHANNEL"
+          ./scripts/run-gst-sample.sh "$CHANNEL"
+
+      - name: Run GStreamer testsrc sample (policy=relay)
+        run: |
+          CHANNEL="ScaryTestChannel-gst-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-relay"
+          ./scripts/prepare-channel.sh "$CHANNEL"
+          ./scripts/run-gst-sample.sh "$CHANNEL"

--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -301,13 +301,13 @@ jobs:
         env:
           KVS_ICE_TRANSPORT_POLICY: all
         run: |
-          CHANNEL="ScaryTestChannel-docker-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-all"
+          CHANNEL="ScaryTestChannel-docker-static-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-all"
           ./scripts/prepare-channel.sh "$CHANNEL"
           ./scripts/run-static-sample.sh "$CHANNEL"
 
       - name: Run static frames sample (policy=relay)
         run: |
-          CHANNEL="ScaryTestChannel-docker-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-relay"
+          CHANNEL="ScaryTestChannel-docker-static-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-relay"
           ./scripts/prepare-channel.sh "$CHANNEL"
           ./scripts/run-static-sample.sh "$CHANNEL"
 
@@ -333,12 +333,12 @@ jobs:
         env:
           KVS_ICE_TRANSPORT_POLICY: all
         run: |
-          CHANNEL="ScaryTestChannel-gst-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-all"
+          CHANNEL="ScaryTestChannel-docker-gst-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-all"
           ./scripts/prepare-channel.sh "$CHANNEL"
           ./scripts/run-gst-sample.sh "$CHANNEL"
 
       - name: Run GStreamer testsrc sample (policy=relay)
         run: |
-          CHANNEL="ScaryTestChannel-gst-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-relay"
+          CHANNEL="ScaryTestChannel-docker-gst-${{ matrix.runner.id }}-${{ matrix.build-dependencies }}-relay"
           ./scripts/prepare-channel.sh "$CHANNEL"
           ./scripts/run-gst-sample.sh "$CHANNEL"

--- a/scripts/prepare-channel.sh
+++ b/scripts/prepare-channel.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Creates a KVS signaling channel if it doesn't already exist.
+#
+# Usage: ./prepare-channel.sh <channel-name>
+
+set -euo pipefail
+
+CHANNEL_NAME="${1:?Usage: $0 <channel-name>}"
+
+if aws kinesisvideo describe-signaling-channel --channel-name "$CHANNEL_NAME" 2>/dev/null; then
+    echo "Channel $CHANNEL_NAME already exists"
+else
+    echo "Creating channel $CHANNEL_NAME"
+    aws kinesisvideo create-signaling-channel --channel-name "$CHANNEL_NAME"
+fi

--- a/scripts/run-gst-sample.sh
+++ b/scripts/run-gst-sample.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Runs the GStreamer testsrc master+viewer sample and validates:
+#   - Connection succeeds
+#   - Verifies relay candidates when KVS_ICE_TRANSPORT_POLICY=relay
+#   - Viewer receives video frames
+#   - video.mkv is generated and non-empty
+#   - video.mkv can be decoded without errors
+#
+# Usage: ./run-gst-sample.sh <channel-name>
+#
+# Environment:
+#   KVS_ICE_TRANSPORT_POLICY - set to "relay" to force TURN and verify relay candidates
+#   AWS_KVS_LOG_LEVEL        - log verbosity (use 1 for verbose to see frame logs)
+
+set -uo pipefail
+
+CHANNEL_NAME="${1:?Usage: $0 <channel-name>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SAMPLES_DIR="$SCRIPT_DIR/../build/samples"
+
+cd "$SAMPLES_DIR"
+rm -f video.mkv .SignalingCache_*
+
+dump_logs() {
+    echo "=== Master Log ==="
+    cat master.log 2>/dev/null || echo "(no master.log)"
+    echo "=== Viewer Log ==="
+    cat viewer.log 2>/dev/null || echo "(no viewer.log)"
+}
+trap 'if [ $? -ne 0 ]; then dump_logs; fi' EXIT
+
+"./kvsWebrtcClientMasterGstSample" "$CHANNEL_NAME" video-only testsrc > master.log 2>&1 &
+MASTER_PID=$!
+sleep 15
+"./kvsWebrtcClientViewerGstSample" "$CHANNEL_NAME" video-only > viewer.log 2>&1 &
+VIEWER_PID=$!
+
+# Let them run for 60s, then send SIGINT
+sleep 60
+kill -s INT $MASTER_PID $VIEWER_PID 2>/dev/null
+
+# Give them 15s to shut down gracefully, then force kill
+(sleep 15 && kill -9 $MASTER_PID $VIEWER_PID 2>/dev/null) &
+WATCHDOG_PID=$!
+
+wait $MASTER_PID 2>/dev/null
+MASTER_EXIT=$?
+wait $VIEWER_PID 2>/dev/null
+VIEWER_EXIT=$?
+
+kill $WATCHDOG_PID 2>/dev/null
+wait $WATCHDOG_PID 2>/dev/null
+
+if [ $MASTER_EXIT -ne 0 ] || [ $VIEWER_EXIT -ne 0 ]; then
+    echo "Sample execution failed. Master exit code: $MASTER_EXIT, Viewer exit code: $VIEWER_EXIT"
+    exit 1
+fi
+
+# Verify ICE candidate pair selection
+if [ "${KVS_ICE_TRANSPORT_POLICY:-}" = "relay" ]; then
+    if grep "local candidate type: relay. remote candidate type: relay" master.log || \
+       grep "local candidate type: relay. remote candidate type: relay" viewer.log; then
+        echo "SUCCESS: Force TURN verified - relay candidates selected"
+    else
+        echo "FAILURE: Expected relay candidate pair not found in logs"
+        exit 1
+    fi
+else
+    if grep "local candidate type:.*remote candidate type:" master.log || \
+       grep "local candidate type:.*remote candidate type:" viewer.log; then
+        echo "SUCCESS: ICE candidate pair selected"
+    else
+        echo "FAILURE: No ICE candidate pair selection found in logs"
+        exit 1
+    fi
+fi
+
+# Validate frames were received by the viewer
+if grep -q "Video frame size" viewer.log; then
+    FRAME_COUNT=$(grep -c "Video frame size" viewer.log)
+    echo "SUCCESS: Viewer received $FRAME_COUNT video frames"
+else
+    echo "FAILURE: Viewer did not receive any video frames"
+    exit 1
+fi
+
+# Validate the generated video.mkv file exists and is non-empty
+if [ -s video.mkv ]; then
+    FILE_SIZE=$(stat -c%s video.mkv 2>/dev/null || stat -f%z video.mkv)
+    echo "SUCCESS: video.mkv generated ($FILE_SIZE bytes)"
+else
+    echo "FAILURE: video.mkv was not generated or is empty"
+    ls -la *.mkv 2>/dev/null || echo "No .mkv files found"
+    exit 1
+fi
+
+# Validate the file is not corrupted by decoding it
+if gst-launch-1.0 filesrc location=video.mkv ! matroskademux ! decodebin ! fakesink 2>&1 | tee decode.log; then
+    echo "SUCCESS: video.mkv decoded successfully"
+else
+    echo "FAILURE: video.mkv could not be decoded"
+    cat decode.log
+    exit 1
+fi
+
+echo "SUCCESS: GStreamer testsrc sample completed on channel $CHANNEL_NAME"

--- a/scripts/run-static-sample.sh
+++ b/scripts/run-static-sample.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Runs the static frames master+viewer sample and validates the connection.
+#
+# Usage: ./run-static-sample.sh <channel-name>
+#
+# Environment:
+#   KVS_ICE_TRANSPORT_POLICY - set to "relay" to force TURN and verify relay candidates
+#   AWS_KVS_LOG_LEVEL        - log verbosity (default: inherited from environment)
+
+set -uo pipefail
+
+CHANNEL_NAME="${1:?Usage: $0 <channel-name>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SAMPLES_DIR="$SCRIPT_DIR/../build/samples"
+
+cd "$SAMPLES_DIR"
+rm -f .SignalingCache_*
+
+dump_logs() {
+    echo "=== Master Log ==="
+    cat master.log 2>/dev/null || echo "(no master.log)"
+    echo "=== Viewer Log ==="
+    cat viewer.log 2>/dev/null || echo "(no viewer.log)"
+}
+trap 'if [ $? -ne 0 ]; then dump_logs; fi' EXIT
+
+"./kvsWebrtcClientMaster" "$CHANNEL_NAME" > master.log 2>&1 &
+MASTER_PID=$!
+sleep 15
+"./kvsWebrtcClientViewer" "$CHANNEL_NAME" > viewer.log 2>&1 &
+VIEWER_PID=$!
+
+# Let them run for 60s, then send SIGINT
+sleep 60
+kill -s INT $MASTER_PID $VIEWER_PID 2>/dev/null
+
+# Give them 15s to shut down gracefully, then force kill
+(sleep 15 && kill -9 $MASTER_PID $VIEWER_PID 2>/dev/null) &
+WATCHDOG_PID=$!
+
+wait $MASTER_PID 2>/dev/null
+MASTER_EXIT=$?
+wait $VIEWER_PID 2>/dev/null
+VIEWER_EXIT=$?
+
+kill $WATCHDOG_PID 2>/dev/null
+wait $WATCHDOG_PID 2>/dev/null
+
+if [ $MASTER_EXIT -ne 0 ] || [ $VIEWER_EXIT -ne 0 ]; then
+    echo "Sample execution failed. Master exit code: $MASTER_EXIT, Viewer exit code: $VIEWER_EXIT"
+    exit 1
+fi
+
+if [ "${KVS_ICE_TRANSPORT_POLICY:-}" = "relay" ]; then
+    if grep "local candidate type: relay. remote candidate type: relay" master.log || \
+       grep "local candidate type: relay. remote candidate type: relay" viewer.log; then
+        echo "SUCCESS: Force TURN verified - relay candidates selected"
+    else
+        echo "FAILURE: Expected relay candidate pair not found in logs"
+        cat master.log
+        cat viewer.log
+        exit 1
+    fi
+else
+    if grep "local candidate type:.*remote candidate type:" master.log || \
+       grep "local candidate type:.*remote candidate type:" viewer.log; then
+        echo "SUCCESS: ICE candidate pair selected"
+    else
+        echo "FAILURE: No ICE candidate pair selection found in logs"
+        cat master.log
+        cat viewer.log
+        exit 1
+    fi
+fi
+
+echo "SUCCESS: Static frames sample completed on channel $CHANNEL_NAME"


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added Docker-based Ubuntu CI job that validates P2P static frames sample and GStreamer testsrc sample work out of the box in forceTURN and non-forceTURN modes
- New combinations: `BUILD_DEPENDENCIES=ON/OFF` x `ICE policy=all/relay` x `Sample=static/gst` x `Ubuntu 20.04/22.04/24.04`
- Added reusable scripts: `run-static-sample.sh`, `run-gst-sample.sh`, `prepare-channel.sh`

*Why was it changed?*
- Catch regressions in the out-of-box developer experience across Ubuntu LTS versions with both source-built and system-packaged dependencies

*How was it changed?*
- New `ubuntu-docker-sample-checks` job with matrix: 3 Ubuntu versions x 2 build modes = 6 combinations
- Each combination runs 4 sample checks (static frames + GStreamer, each with policy=all and policy=relay)
- libwebsockets is always built from source (`-DBUILD_WEBSOCKETS=ON`) since system versions on Ubuntu 20/22 are too old

**Test matrix (4 runs per combination = 24 validations):**

| Sample | ICE Policy | What's verified |
|--------|-----------|-----------------|
| Static frames (master+viewer) | all | Process exits cleanly, ICE candidate pair selected |
| Static frames (master+viewer) | relay | Process exits cleanly, relay candidate pair selected |
| GStreamer testsrc (master+viewer) | all | ICE pair selected, video frames received, video.mkv generated, MKV decodable |
| GStreamer testsrc (master+viewer) | relay | Relay pair selected, video frames received, video.mkv generated, MKV decodable |

**New scripts:**
- `scripts/prepare-channel.sh`: creates signaling channel if it doesn't exist
- `scripts/run-static-sample.sh`: runs master+viewer with static H264 frames, verifies ICE connectivity
- `scripts/run-gst-sample.sh`: runs GStreamer testsrc master+viewer, verifies frames received + validates generated MKV file integrity via `gst-launch-1.0` decode

*What testing was done for the changes?*
- Ran the workflow on a forked repository

<img width="1453" height="692" alt="image" src="https://github.com/user-attachments/assets/d9c35670-b2ae-42a6-93b2-69336a5c46f3" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
