### PR TITLE
fix packet length validation in handleDcepPacket

### DIFF
--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -319,7 +319,7 @@ STATUS handleDcepPacket(PSctpSession pSctpSession, UINT32 streamId, PBYTE data, 
     putInt16((PINT16) &labelLength, labelLength);
     putInt16((PINT16) &protocolLength, protocolLength);
 
-    CHK((labelLength + protocolLength + SCTP_DCEP_HEADER_LENGTH) >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
+    CHK((labelLength + protocolLength + SCTP_DCEP_HEADER_LENGTH) <= length, STATUS_SCTP_INVALID_DCEP_PACKET);
 
     CHK(SCTP_MAX_ALLOWABLE_PACKET_LENGTH >= length, STATUS_SCTP_INVALID_DCEP_PACKET);
 

--- a/src/source/Sctp/Sctp.h
+++ b/src/source/Sctp/Sctp.h
@@ -75,6 +75,7 @@ STATUS freeSctpSession(PSctpSession*);
 STATUS putSctpPacket(PSctpSession, PBYTE, UINT32);
 STATUS sctpSessionWriteMessage(PSctpSession, UINT32, BOOL, PBYTE, UINT32);
 STATUS sctpSessionWriteDcep(PSctpSession, UINT32, PCHAR, UINT32, PRtcDataChannelInit);
+STATUS handleDcepPacket(PSctpSession, UINT32, PBYTE, SIZE_T);
 
 // Callbacks used by usrsctp
 INT32 onSctpOutboundPacket(PVOID, PVOID, ULONG, UINT8, UINT8);

--- a/tst/DataChannelApiTest.cpp
+++ b/tst/DataChannelApiTest.cpp
@@ -32,8 +32,6 @@ TEST_F(DataChannelApiTest, createDataChannel_Disconnected)
     freePeerConnection(&pPeerConnection);
 }
 
-extern "C" STATUS handleDcepPacket(PSctpSession pSctpSession, UINT32 streamId, PBYTE data, SIZE_T length);
-
 TEST_F(DataChannelApiTest, handleDcepPacket_RejectsOversizedLabelLength)
 {
     /** Construct a minimal DCEP DataChannelOpen packet (13 bytes total):

--- a/tst/DataChannelApiTest.cpp
+++ b/tst/DataChannelApiTest.cpp
@@ -7,8 +7,7 @@ namespace kinesis {
 namespace video {
 namespace webrtcclient {
 
-class DataChannelApiTest : public WebRtcClientTestBase {
-};
+class DataChannelApiTest : public WebRtcClientTestBase {};
 
 TEST_F(DataChannelApiTest, createDataChannel_Disconnected)
 {
@@ -33,6 +32,30 @@ TEST_F(DataChannelApiTest, createDataChannel_Disconnected)
     freePeerConnection(&pPeerConnection);
 }
 
+extern "C" STATUS handleDcepPacket(PSctpSession pSctpSession, UINT32 streamId, PBYTE data, SIZE_T length);
+
+TEST_F(DataChannelApiTest, handleDcepPacket_RejectsOversizedLabelLength)
+{
+    /** Construct a minimal DCEP DataChannelOpen packet (13 bytes total):
+     *   [0]     0x03  = DATA_CHANNEL_OPEN message type
+     *   [1]     0x00  = channel type (reliable ordered)
+     *   [2-3]   0x0000 = priority
+     *   [4-7]   0x00000000 = reliability parameter
+     *   [8-9]   0xFFFF = labelLength (65535)
+     *   [10-11] 0x0000 = protocolLength
+     *   [12]    0x41  = 1 byte of actual label data ("A")
+     */
+    BYTE dcepPacket[] = {0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, // labelLength = 65535 (malformed)
+                         0x00, 0x00, 0x41};
+
+    // Create a fake SctpSession with a non-NULL socket to pass the initial NULL check.
+    SctpSession sctpSession;
+    MEMSET(&sctpSession, 0, SIZEOF(SctpSession));
+    sctpSession.socket = (struct socket*) 0x1; // non-NULL dummy
+
+    // handleDcepPacket will reject the packet at the bounds check before reaching usrsctp_sendv.
+    EXPECT_EQ(STATUS_SCTP_INVALID_DCEP_PACKET, handleDcepPacket(&sctpSession, 0, dcepPacket, SIZEOF(dcepPacket)));
+}
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fixed the packet length validation in `handleDcepPacket` (Sctp.c:322) and added unit tests for the bounds check.

*Why was it changed?*
- The bounds check used `>=` instead of `<=`, which inverted the validation logic. It was intended to reject packets where the declared `labelLength + protocolLength` exceeds the actual packet size, but instead it rejected packets where the declared content was smaller than the packet. For example, A DCEP DataChannelOpen message with `labelLength=0xFFFF` but only a few bytes of actual data would pass the check and  uncapped length would be passed to `STRNCPY` in `onSctpSessionDataChannelOpen`, overflowing the 256-byte `dataChannel.name` buffer.

*How was it changed?*
- Changed `>=` to `<=` on the comparison at Sctp.c:322 so the check correctly rejects packets where declared content exceeds actual packet length.
- Added a test (`handleDcepPacket_RejectsOversizedLabelLength`) that constructs a 13-byte DCEP packet with `labelLength=0xFFFF` and verifies it is rejected with `STATUS_SCTP_INVALID_DCEP_PACKET`.

*What testing was done for the changes?*
- Ran `webrtc_client_test --gtest_filter="DataChannelApiTest.*"` new and existing DataChannel tests are passing.
- Verified the malformed packet test fails without the fix and passes with the fix (rejected at the bounds check).
- Verified a well-formed packet with matching `labelLength` passes the bounds check but fails in the next step`usrsctp_sendv` which requires a real SCTP socket.
- Verified data channel path through the JS SDK Test page. A message sent through viewer is received on master side and a response message is sent back

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
