### PR TITLE
Addressed unused var in IceAgent and PeerConnection, and dead store warnings in Rtp payloader

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -743,6 +743,8 @@ STATUS iceAgentStartAgent(PIceAgent pIceAgent, PCHAR remoteUsername, PCHAR remot
         STATUS_INVALID_ARG);
 
     MUTEX_LOCK(pIceAgent->lock);
+    // Not currently used since no jumps to CleanUp between lock/unlock.
+    // locked = TRUE;
 
     ATOMIC_STORE_BOOL(&pIceAgent->remoteCredentialReceived, TRUE);
     /* role should not change during ice restart. */
@@ -758,6 +760,8 @@ STATUS iceAgentStartAgent(PIceAgent pIceAgent, PCHAR remoteUsername, PCHAR remot
     SNPRINTF(pIceAgent->combinedUserName, ARRAY_SIZE(pIceAgent->combinedUserName), "%s:%s", pIceAgent->remoteUsername, pIceAgent->localUsername);
 
     MUTEX_UNLOCK(pIceAgent->lock);
+    // Not currently used since no jumps to CleanUp between lock/unlock.
+    // locked = FALSE;
 
     CHK_STATUS(timerQueueAddTimer(pIceAgent->timerQueueHandle, KVS_ICE_DEFAULT_TIMER_START_DELAY,
                                   pIceAgent->kvsRtcConfiguration.iceConnectionCheckPollingInterval, iceAgentStateTransitionTimerCallback,
@@ -2377,6 +2381,8 @@ STATUS iceAgentConnectedStateSetup(PIceAgent pIceAgent)
     CHK(pIceAgent != NULL, STATUS_NULL_ARG);
     if (pIceAgent->pDataSendingIceCandidatePair != NULL) {
         MUTEX_LOCK(pIceAgent->lock);
+        // Not currently used since no jumps to CleanUp between lock/unlock.
+        // locked = TRUE;
 
         /* at this point ice restart is complete */
         ATOMIC_STORE_BOOL(&pIceAgent->restart, FALSE);
@@ -2384,6 +2390,8 @@ STATUS iceAgentConnectedStateSetup(PIceAgent pIceAgent)
         pIceAgent->pDataSendingIceCandidatePair = NULL;
 
         MUTEX_UNLOCK(pIceAgent->lock);
+        // Not currently used since no jumps to CleanUp between lock/unlock.
+        // locked = FALSE;
 
         /* If pDataSendingIceCandidatePair is not NULL, then it must be the data sending pair before ice restart.
          * Free its resource here since not there is a new connected pair to replace it. */

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -743,7 +743,6 @@ STATUS iceAgentStartAgent(PIceAgent pIceAgent, PCHAR remoteUsername, PCHAR remot
         STATUS_INVALID_ARG);
 
     MUTEX_LOCK(pIceAgent->lock);
-    locked = TRUE;
 
     ATOMIC_STORE_BOOL(&pIceAgent->remoteCredentialReceived, TRUE);
     /* role should not change during ice restart. */
@@ -759,7 +758,6 @@ STATUS iceAgentStartAgent(PIceAgent pIceAgent, PCHAR remoteUsername, PCHAR remot
     SNPRINTF(pIceAgent->combinedUserName, ARRAY_SIZE(pIceAgent->combinedUserName), "%s:%s", pIceAgent->remoteUsername, pIceAgent->localUsername);
 
     MUTEX_UNLOCK(pIceAgent->lock);
-    locked = FALSE;
 
     CHK_STATUS(timerQueueAddTimer(pIceAgent->timerQueueHandle, KVS_ICE_DEFAULT_TIMER_START_DELAY,
                                   pIceAgent->kvsRtcConfiguration.iceConnectionCheckPollingInterval, iceAgentStateTransitionTimerCallback,
@@ -2379,7 +2377,6 @@ STATUS iceAgentConnectedStateSetup(PIceAgent pIceAgent)
     CHK(pIceAgent != NULL, STATUS_NULL_ARG);
     if (pIceAgent->pDataSendingIceCandidatePair != NULL) {
         MUTEX_LOCK(pIceAgent->lock);
-        locked = TRUE;
 
         /* at this point ice restart is complete */
         ATOMIC_STORE_BOOL(&pIceAgent->restart, FALSE);
@@ -2387,7 +2384,6 @@ STATUS iceAgentConnectedStateSetup(PIceAgent pIceAgent)
         pIceAgent->pDataSendingIceCandidatePair = NULL;
 
         MUTEX_UNLOCK(pIceAgent->lock);
-        locked = FALSE;
 
         /* If pDataSendingIceCandidatePair is not NULL, then it must be the data sending pair before ice restart.
          * Free its resource here since not there is a new connected pair to replace it. */

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1184,7 +1184,6 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock)) {
         if (twccLocked) {
             MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
-            twccLocked = FALSE;
         }
         MUTEX_FREE(pKvsPeerConnection->twccLock);
         pKvsPeerConnection->twccLock = INVALID_MUTEX_VALUE;

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1184,6 +1184,8 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock)) {
         if (twccLocked) {
             MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+            // Not currently used since twccLock is freed immediately after. No jumps to CleanUp.
+            // twccLocked = FALSE;
         }
         MUTEX_FREE(pKvsPeerConnection->twccLock);
         pKvsPeerConnection->twccLock = INVALID_MUTEX_VALUE;

--- a/src/source/Rtp/Codecs/RtpH264Payloader.c
+++ b/src/source/Rtp/Codecs/RtpH264Payloader.c
@@ -171,7 +171,6 @@ STATUS createPayloadFromNalu(UINT32 mtu, PBYTE nalu, UINT32 naluLength, PPayload
             // Single NALU https://tools.ietf.org/html/rfc6184#section-5.6
             MEMCPY(pPayload, nalu, naluLength);
             pPayloadArray->payloadSubLength[payloadSubLenSize - 1] = naluLength;
-            pPayload += pPayloadArray->payloadSubLength[payloadSubLenSize - 1];
         }
     } else {
         // FU-A https://tools.ietf.org/html/rfc6184#section-5.8

--- a/src/source/Rtp/Codecs/RtpH264Payloader.c
+++ b/src/source/Rtp/Codecs/RtpH264Payloader.c
@@ -171,6 +171,8 @@ STATUS createPayloadFromNalu(UINT32 mtu, PBYTE nalu, UINT32 naluLength, PPayload
             // Single NALU https://tools.ietf.org/html/rfc6184#section-5.6
             MEMCPY(pPayload, nalu, naluLength);
             pPayloadArray->payloadSubLength[payloadSubLenSize - 1] = naluLength;
+            // Note: not incrementing pPayload here because single NALU is the only payload in this branch.
+            // If additional payloads are appended after this, add: pPayload += naluLength;
         }
     } else {
         // FU-A https://tools.ietf.org/html/rfc6184#section-5.8

--- a/src/source/Rtp/Codecs/RtpH265Payloader.c
+++ b/src/source/Rtp/Codecs/RtpH265Payloader.c
@@ -169,7 +169,6 @@ STATUS createPayloadFromNaluH265(UINT32 mtu, PBYTE nalu, UINT32 naluLength, PPay
 
             MEMCPY(pPayload, nalu, naluLength);
             pPayloadArray->payloadSubLength[payloadSubLenSize - 1] = naluLength;
-            pPayload += pPayloadArray->payloadSubLength[payloadSubLenSize - 1];
         }
     } else {
         // Fragmentation units: https://www.rfc-editor.org/rfc/rfc7798.html#section-4.4.3

--- a/src/source/Rtp/Codecs/RtpH265Payloader.c
+++ b/src/source/Rtp/Codecs/RtpH265Payloader.c
@@ -169,6 +169,8 @@ STATUS createPayloadFromNaluH265(UINT32 mtu, PBYTE nalu, UINT32 naluLength, PPay
 
             MEMCPY(pPayload, nalu, naluLength);
             pPayloadArray->payloadSubLength[payloadSubLenSize - 1] = naluLength;
+            // Note: not incrementing pPayload here because single NALU is the only payload in this branch.
+            // If additional payloads are appended after this, add: pPayload += naluLength;
         }
     } else {
         // Fragmentation units: https://www.rfc-editor.org/rfc/rfc7798.html#section-4.4.3


### PR DESCRIPTION
*Issue #, if available:*
  - N/A

 *What was changed?*
  - Removed dead `pPayload` increment in the single NALU branch of `createPayloadFromNalu` in `RtpH264Payloader.c`
  - Removed dead `pPayload` increment in the single NALU branch of `createPayloadFromNaluH265` in `RtpH265Payloader.c`
  - Commented out dead `twccLocked = FALSE` assignment in `freePeerConnection` in `PeerConnection.c`
  - Commented out dead `locked = TRUE/FALSE` assignments in `iceAgentStartAgent` in `IceAgent.c`
  - Commented out dead `locked = TRUE/FALSE` assignments in `iceAgentConnectedStateSetup` in `IceAgent.c`

 *Why was it changed?*
  - "Dead increment" warning at line 174 in `RtpH264Payloader.c`: Value stored to 'pPayload' is never read. The single NALU branch exits immediately after, so the incremented value is unused.
  - "Dead increment" warning at line 172 in `RtpH265Payloader.c`: Value stored to 'pPayload' is never read. Same reasoning as H264.
  - "Dead assignment" warning at line 1187 in `PeerConnection.c`: Value stored to 'twccLocked' is never read. The lock is freed immediately after and there are no jumps to CleanUp.
  - "Dead assignment" warning at line 746 in `IceAgent.c`: Value stored to 'locked' is never read. No CHK/CHK_STATUS calls exist between lock/unlock, so the boolean is always overwritten before the CleanUp guard reads it.
  - "Dead assignment" warning at line 2382 in `IceAgent.c`: Value stored to 'locked' is never read. Same reasoning as above.

 *How was it changed?*
  - Removed the dead `pPayload +=` lines and added comments explaining why the increment is intentionally omitted and what to restore if the code changes
  - Commented out the dead lock boolean assignments with explanation that no jumps to CleanUp exist between lock/unlock

 *What testing was done for the changes?*
  - CI/CD to validate the changes
  - Built locally, scan-build showing no reports

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.