### PR TITLE
fix header size constant used for stap B h264 packet

### DIFF
--- a/src/source/Rtp/Codecs/RtpH264Payloader.c
+++ b/src/source/Rtp/Codecs/RtpH264Payloader.c
@@ -338,7 +338,7 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
             break;
         case STAP_B_INDICATOR:
             naluLength = 0;
-            pCurPtr = pRawPacket + STAP_A_HEADER_SIZE;
+            pCurPtr = pRawPacket + STAP_B_HEADER_SIZE;
             do {
                 subNaluSize = getUnalignedInt16BigEndian(pCurPtr);
                 pCurPtr += SIZEOF(UINT16);

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -704,6 +704,105 @@ TEST_F(RtpFunctionalityTest, createPayloadForVP8NullDataWithNonNullBuffer)
     EXPECT_EQ(0u, payloadSubLenSize);
 }
 
+TEST_F(RtpFunctionalityTest, testDepayH264StapBPacket)
+{
+    /** Construct a valid STAP-B packet:
+     * Byte 0: NAL indicator with type 25 (STAP-B)
+     * Bytes 1-2: DON (Decoding Order Number)
+     * Bytes 3-4: sub-NAL size (big-endian)
+     * Bytes 5+: sub-NAL data
+    */
+    BYTE stapBPacket[] = {
+        0x19,       // type=25 (STAP_B_INDICATOR)
+        0x00, 0x01, // DON = 1
+        0x00, 0x03, // sub-NAL size = 3
+        0x67, 0x42, 0x00, // sub-NAL data (3 bytes)
+        0x00, 0x02, // second sub-NAL size = 2
+        0xAA, 0xBB  // second sub-NAL data (2 bytes)
+    };
+    UINT32 packetLength = SIZEOF(stapBPacket);
+    UINT32 naluLength = 0;
+    BOOL isStart = FALSE;
+
+    // Size calculation pass (pNaluData = NULL)
+    EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(stapBPacket, packetLength, NULL, &naluLength, &isStart));
+    EXPECT_TRUE(isStart);
+    // Expected: start4ByteCode(4) + 3 + start4ByteCode(4) + 2 = 13
+    EXPECT_EQ(13u, naluLength);
+
+    // Copy pass - allocate exact buffer based on size
+    BYTE outputBuffer[13];
+    UINT32 outputLen = SIZEOF(outputBuffer);
+    EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(stapBPacket, packetLength, outputBuffer, &outputLen, &isStart));
+    EXPECT_EQ(13u, outputLen);
+
+    // Verify first sub-NAL has start code prefix
+    EXPECT_EQ(0x00, outputBuffer[0]);
+    EXPECT_EQ(0x00, outputBuffer[1]);
+    EXPECT_EQ(0x00, outputBuffer[2]);
+    EXPECT_EQ(0x01, outputBuffer[3]);
+    // Verify first sub-NAL data
+    EXPECT_EQ(0x67, outputBuffer[4]);
+    EXPECT_EQ(0x42, outputBuffer[5]);
+    EXPECT_EQ(0x00, outputBuffer[6]);
+    // Verify second sub-NAL has start code prefix
+    EXPECT_EQ(0x00, outputBuffer[7]);
+    EXPECT_EQ(0x00, outputBuffer[8]);
+    EXPECT_EQ(0x00, outputBuffer[9]);
+    EXPECT_EQ(0x01, outputBuffer[10]);
+    // Verify second sub-NAL data
+    EXPECT_EQ(0xAA, outputBuffer[11]);
+    EXPECT_EQ(0xBB, outputBuffer[12]);
+}
+
+TEST_F(RtpFunctionalityTest, testDepayH264StapAPacket)
+{
+    /** Construct a valid STAP-A packet:
+     * Byte 0: NAL indicator with type 24 (STAP-A)
+     * No DON field (this is what differentiates STAP-A from STAP-B)
+     * Bytes 1-2: sub-NAL size (big-endian)
+     * Bytes 3+: sub-NAL data
+     */
+    BYTE stapAPacket[] = {
+        0x18,       // NAL header: type=24 (STAP_A_INDICATOR)
+        0x00, 0x03, // first sub-NAL size = 3
+        0x67, 0x42, 0x00, // first sub-NAL data (3 bytes, fake SPS)
+        0x00, 0x02, // second sub-NAL size = 2
+        0xCC, 0xDD  // second sub-NAL data (2 bytes)
+    };
+    UINT32 packetLength = SIZEOF(stapAPacket);
+    UINT32 naluLength = 0;
+    BOOL isStart = FALSE;
+
+    // Size calculation pass (pNaluData = NULL)
+    EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(stapAPacket, packetLength, NULL, &naluLength, &isStart));
+    EXPECT_TRUE(isStart);
+    // Expected: start4ByteCode(4) + 3 + start4ByteCode(4) + 2 = 13
+    EXPECT_EQ(13u, naluLength);
+
+    // Copy pass - allocate exact buffer based on size
+    BYTE outputBuffer[13];
+    UINT32 outputLen = SIZEOF(outputBuffer);
+    EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(stapAPacket, packetLength, outputBuffer, &outputLen, &isStart));
+    EXPECT_EQ(13u, outputLen);
+
+    // Verify first sub-NAL: start code + data
+    EXPECT_EQ(0x00, outputBuffer[0]);
+    EXPECT_EQ(0x00, outputBuffer[1]);
+    EXPECT_EQ(0x00, outputBuffer[2]);
+    EXPECT_EQ(0x01, outputBuffer[3]);
+    EXPECT_EQ(0x67, outputBuffer[4]);
+    EXPECT_EQ(0x42, outputBuffer[5]);
+    EXPECT_EQ(0x00, outputBuffer[6]);
+    // Verify second sub-NAL: start code + data
+    EXPECT_EQ(0x00, outputBuffer[7]);
+    EXPECT_EQ(0x00, outputBuffer[8]);
+    EXPECT_EQ(0x00, outputBuffer[9]);
+    EXPECT_EQ(0x01, outputBuffer[10]);
+    EXPECT_EQ(0xCC, outputBuffer[11]);
+    EXPECT_EQ(0xDD, outputBuffer[12]);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
---

*Issue #, if available:*
- N/A

*What was changed?*
- Fixed incorrect header size constant in the H.264 STAP-B depayloading copy pass and added unit tests for both STAP-A and STAP-B aggregation packet depayloading.

*Why was it changed?*
- The STAP-B case in `depayH264FromRtpPayload` used `STAP_A_HEADER_SIZE` (1) instead of `STAP_B_HEADER_SIZE` (3) in the copy pass (Pass 2), while the size calculation pass (Pass 1) correctly used `STAP_B_HEADER_SIZE`. This mismatch caused Pass 2 to read the 2-byte DON field as a sub-NAL size, resulting in incorrect data copy and potential buffer overflow when processing STAP-B packets from interoperable WebRTC peers.

*How was it changed?*
- Changed `pRawPacket + STAP_A_HEADER_SIZE` to `pRawPacket + STAP_B_HEADER_SIZE` in the STAP-B copy pass at `RtpH264Payloader.c:339`, making Pass 2 consistent with Pass 1.
- Added `depayH264StapBUsesCorrectHeaderSize` test that constructs a valid STAP-B packet with two sub-NALs and verifies both the size calculation and byte-exact output.
- Added `depayH264StapAUsesCorrectHeaderSize` test that verifies the existing STAP-A path continues to work correctly (regression guard).

*What testing was done for the changes?*
- `tst/RtpFunctionalityTest.cpp` — both new tests pass with the fix. Without the fix, the STAP-B test fails with assertion errors and aborts due to buffer overflow (confirmed via reverting the fix and rebuilding).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
