### PR TITLE
Add bound check for candidate length in deserializeRtcIceCandidateInit

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1563,6 +1563,7 @@ STATUS deserializeRtcIceCandidateInit(PCHAR pJson, UINT32 jsonLen, PRtcIceCandid
 
     for (i = 1; i < (tokenCount - 1); i += 2) {
         if (STRNCMP(CANDIDATE_KEY, pJson + tokens[i].start, ARRAY_SIZE(CANDIDATE_KEY) - 1) == 0) {
+            CHK((tokens[i + 1].end - tokens[i + 1].start) <= MAX_ICE_CANDIDATE_INIT_CANDIDATE_LEN, STATUS_ICE_CANDIDATE_INIT_MALFORMED);
             STRNCPY(pRtcIceCandidateInit->candidate, pJson + tokens[i + 1].start, (tokens[i + 1].end - tokens[i + 1].start));
         }
     }

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -33,6 +33,17 @@ TEST_F(PeerConnectionApiTest, deserializeRtcIceCandidateInit)
     auto validCandidate2 = "{candidate: \"candidate: 1 2 3\", \"sdpMid\": 0}";
     EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) validCandidate2, STRLEN(validCandidate2), &rtcIceCandidateInit), STATUS_SUCCESS);
     EXPECT_STREQ(rtcIceCandidateInit.candidate, "candidate: 1 2 3");
+
+    std::string oversizedCandidate = "{candidate: \"";
+    oversizedCandidate += std::string(MAX_ICE_CANDIDATE_INIT_CANDIDATE_LEN + 10, 'A');
+    oversizedCandidate += "\"}";
+    EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) oversizedCandidate.c_str(), STRLEN(oversizedCandidate.c_str()), &rtcIceCandidateInit),
+              STATUS_ICE_CANDIDATE_INIT_MALFORMED);
+
+    std::string maxLengthCandidate = "{candidate: \"";
+    maxLengthCandidate += std::string(MAX_ICE_CANDIDATE_INIT_CANDIDATE_LEN, 'B');
+    maxLengthCandidate += "\"}";
+    EXPECT_EQ(deserializeRtcIceCandidateInit((PCHAR) maxLengthCandidate.c_str(), STRLEN(maxLengthCandidate.c_str()), &rtcIceCandidateInit), STATUS_SUCCESS);
 }
 
 TEST_F(PeerConnectionApiTest, serializeSessionDescriptionInit)


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added bounds check for ICE candidate JSON value length in `deserializeRtcIceCandidateInit` and added a unit test for oversized candidate rejection.

*Why was it changed?*
- The function copies the JSON `"candidate"` value into a 256-byte buffer (`MAX_ICE_CANDIDATE_INIT_CANDIDATE_LEN + 1`) via `STRNCPY` without validating that the value length fits within the buffer. A candidate string exceeding 255 bytes would overflow the buffer.

*How was it changed?*
- Added `CHK((tokens[i + 1].end - tokens[i + 1].start) <= MAX_ICE_CANDIDATE_INIT_CANDIDATE_LEN, STATUS_ICE_CANDIDATE_INIT_MALFORMED)` before the `STRNCPY` call in `SessionDescription.c`. This rejects oversized candidate values with the existing `STATUS_ICE_CANDIDATE_INIT_MALFORMED` error code.

*What testing was done for the changes?*
- `tst/PeerConnectionApiTest.cpp` — added test case that constructs a JSON payload with a candidate string exceeding `MAX_ICE_CANDIDATE_INIT_CANDIDATE_LEN` and verifies it is rejected with `STATUS_ICE_CANDIDATE_INIT_MALFORMED`. Confirmed the test fails (aborts due to overflow) without the fix and passes with it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
