### PR TITLE
fix data channel stalls from missing sctp timer

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -133,7 +133,7 @@ STATUS allocateSctp(PKvsPeerConnection pKvsPeerConnection)
     sctpSessionCallbacks.dataChannelMessageFunc = onSctpSessionDataChannelMessage;
     sctpSessionCallbacks.dataChannelOpenFunc = onSctpSessionDataChannelOpen;
     sctpSessionCallbacks.customData = (UINT64) pKvsPeerConnection;
-    CHK_STATUS(createSctpSession(&sctpSessionCallbacks, &(pKvsPeerConnection->pSctpSession)));
+    CHK_STATUS(createSctpSession(&sctpSessionCallbacks, pKvsPeerConnection->timerQueueHandle, &(pKvsPeerConnection->pSctpSession)));
 
     for (; currentDataChannelId < data.currentDataChannelId; currentDataChannelId += 2) {
         pKvsDataChannel = NULL;

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -1,6 +1,87 @@
 #define LOG_CLASS "SCTP"
 #include "../Include_i.h"
 
+PSctpContext acquireSctpContext()
+{
+    ENTERS();
+    static SctpContext s = {.lastTickTime = 0, .isSctpInitialized = FALSE, .contextRefCnt = 0, .sctpContextLock = INVALID_MUTEX_VALUE};
+    ATOMIC_INCREMENT(&s.contextRefCnt);
+    LEAVES();
+    return &s;
+}
+
+VOID releaseSctpContext(PSctpContext pSctpContext)
+{
+    ENTERS();
+    ATOMIC_DECREMENT(&pSctpContext->contextRefCnt);
+    LEAVES();
+}
+
+// Initializes SCTP context, in particular the lastTickTime used for timer handling
+STATUS createSctpContext()
+{
+    ENTERS();
+    PSctpContext pSctpContext = acquireSctpContext();
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    CHK_WARN(!ATOMIC_LOAD_BOOL(&pSctpContext->isSctpInitialized), retStatus, "SCTP context already initialized, nothing to do");
+    CHK_ERR(!IS_VALID_MUTEX_VALUE(pSctpContext->sctpContextLock), retStatus, "Mutex seems to have been created already");
+
+    pSctpContext->sctpContextLock = MUTEX_CREATE(TRUE);
+    CHK_ERR(IS_VALID_MUTEX_VALUE(pSctpContext->sctpContextLock), STATUS_NULL_ARG, "Mutex creation failed");
+    MUTEX_LOCK(pSctpContext->sctpContextLock);
+    locked = TRUE;
+    pSctpContext->lastTickTime = GETTIME();
+    ATOMIC_STORE_BOOL(&pSctpContext->isSctpInitialized, TRUE);
+    DLOGI("Initialized SCTP context instance");
+
+CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pSctpContext->sctpContextLock);
+    }
+    releaseSctpContext(pSctpContext);
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS cleanupSctpContext()
+{
+    ENTERS();
+    UINT64 shutdownTimeout;
+    STATUS retStatus = STATUS_SUCCESS;
+
+    PSctpContext pSctpContext = acquireSctpContext();
+
+    DLOGD("Releasing SCTP context instance from cleanupSctpContext");
+    releaseSctpContext(pSctpContext);
+
+    CHK_WARN(ATOMIC_LOAD_BOOL(&pSctpContext->isSctpInitialized), STATUS_INVALID_OPERATION, "SCTP context not initialized, nothing to clean up");
+
+    ATOMIC_STORE_BOOL(&pSctpContext->isSctpInitialized, FALSE);
+
+    shutdownTimeout = GETTIME() + SCTP_CONTEXT_REFERENCE_WAIT_TIMEOUT;
+    while (ATOMIC_LOAD(&pSctpContext->contextRefCnt) > 0 && GETTIME() < shutdownTimeout) {
+        DLOGV("Waiting on all references to be returned...%d", pSctpContext->contextRefCnt);
+        THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    }
+
+    if (IS_VALID_MUTEX_VALUE(pSctpContext->sctpContextLock)) {
+        MUTEX_FREE(pSctpContext->sctpContextLock);
+        pSctpContext->sctpContextLock = INVALID_MUTEX_VALUE;
+    }
+
+    DLOGI("Destroyed SCTP context");
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS initSctpAddrConn(PSctpSession pSctpSession, struct sockaddr_conn* sconn)
 {
     ENTERS();
@@ -50,6 +131,11 @@ STATUS configureSctpSocket(struct socket* socket)
     initmsg.sinit_max_instreams = 300;
     CHK(usrsctp_setsockopt(socket, IPPROTO_SCTP, SCTP_INITMSG, &initmsg, SIZEOF(struct sctp_initmsg)) == 0, STATUS_SCTP_SESSION_SETUP_FAILED);
 
+    struct sctp_rtoinfo rtoinfo;
+    MEMSET(&rtoinfo, 0, SIZEOF(struct sctp_rtoinfo));
+    rtoinfo.srto_max = SCTP_RTO_MAX;
+    CHK(usrsctp_setsockopt(socket, IPPROTO_SCTP, SCTP_RTOINFO, &rtoinfo, SIZEOF(rtoinfo)) == 0, STATUS_SCTP_SESSION_SETUP_FAILED);
+
 CleanUp:
     LEAVES();
     return retStatus;
@@ -57,6 +143,7 @@ CleanUp:
 
 STATUS initSctpSession()
 {
+    ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
 
     usrsctp_init_nothreads(0, &onSctpOutboundPacket, NULL);
@@ -64,6 +151,12 @@ STATUS initSctpSession()
     // Disable Explicit Congestion Notification
     usrsctp_sysctl_set_sctp_ecn_enable(0);
 
+    CHK_STATUS(createSctpContext());
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
     return retStatus;
 }
 
@@ -73,15 +166,18 @@ VOID deinitSctpSession()
     while (usrsctp_finish() != 0) {
         THREAD_SLEEP(DEFAULT_USRSCTP_TEARDOWN_POLLING_INTERVAL);
     }
+
+    cleanupSctpContext();
 }
 
-STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSession* ppSctpSession)
+STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, TIMER_QUEUE_HANDLE timerQueueHandle, PSctpSession* ppSctpSession)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PSctpSession pSctpSession = NULL;
     struct sockaddr_conn localConn, remoteConn;
     struct sctp_paddrparams params;
+    struct sctp_assocparams assocParams;
     INT32 connectStatus = 0;
 
     CHK(ppSctpSession != NULL && pSctpSessionCallbacks != NULL, STATUS_NULL_ARG);
@@ -92,12 +188,17 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSessi
     MEMSET(&params, 0x00, SIZEOF(struct sctp_paddrparams));
     MEMSET(&localConn, 0x00, SIZEOF(struct sockaddr_conn));
     MEMSET(&remoteConn, 0x00, SIZEOF(struct sockaddr_conn));
+    MEMSET(&assocParams, 0x00, SIZEOF(struct sctp_assocparams));
 
     ATOMIC_STORE(&pSctpSession->shutdownStatus, SCTP_SESSION_ACTIVE);
     pSctpSession->sctpSessionCallbacks = *pSctpSessionCallbacks;
 
     CHK_STATUS(initSctpAddrConn(pSctpSession, &localConn));
     CHK_STATUS(initSctpAddrConn(pSctpSession, &remoteConn));
+
+    // call the timer callback now to reset the last tick time for this session while ensuring that other sessions'
+    // queued timer tasks are correctly advanced
+    sctpTimerCallback(0, GETTIME(), (UINT64) pSctpSession);
 
     CHK((pSctpSession->socket = usrsctp_socket(AF_CONN, SOCK_STREAM, IPPROTO_SCTP, onSctpInboundPacket, NULL, 0, pSctpSession)) != NULL,
         STATUS_SCTP_SESSION_SETUP_FAILED);
@@ -112,8 +213,17 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSessi
     memcpy(&params.spp_address, &remoteConn, SIZEOF(remoteConn));
     params.spp_flags = SPP_PMTUD_DISABLE;
     params.spp_pathmtu = SCTP_MTU;
+    params.spp_pathmaxrxt = SCTP_MAX_PATH_RETRANSMITS;
     CHK(usrsctp_setsockopt(pSctpSession->socket, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, &params, SIZEOF(params)) == 0,
         STATUS_SCTP_SESSION_SETUP_FAILED);
+
+    assocParams.sasoc_asocmaxrxt = SCTP_MAX_ASSOCIATION_RETRANSMITS;
+    CHK(usrsctp_setsockopt(pSctpSession->socket, IPPROTO_SCTP, SCTP_ASSOCINFO, &assocParams, SIZEOF(assocParams)) == 0,
+        STATUS_SCTP_SESSION_SETUP_FAILED);
+
+    pSctpSession->timerQueueHandle = timerQueueHandle;
+    CHK_STATUS(timerQueueAddTimer(pSctpSession->timerQueueHandle, SCTP_TIMER_START_DELAY, SCTP_TIMER_INTERVAL, sctpTimerCallback,
+                                  (UINT64) pSctpSession, &pSctpSession->timerTaskId));
 
 CleanUp:
     if (STATUS_FAILED(retStatus)) {
@@ -138,6 +248,11 @@ STATUS freeSctpSession(PSctpSession* ppSctpSession)
     pSctpSession = *ppSctpSession;
 
     CHK(pSctpSession != NULL, retStatus);
+
+    // Cancel the periodic timer before shutting down the socket
+    if (IS_VALID_TIMER_QUEUE_HANDLE(pSctpSession->timerQueueHandle)) {
+        timerQueueCancelTimer(pSctpSession->timerQueueHandle, pSctpSession->timerTaskId, (UINT64) pSctpSession);
+    }
 
     usrsctp_deregister_address(pSctpSession);
     /* handle issue mentioned here: https://github.com/sctplab/usrsctp/issues/147
@@ -297,6 +412,35 @@ STATUS putSctpPacket(PSctpSession pSctpSession, PBYTE buf, UINT32 bufLen)
     usrsctp_conninput(pSctpSession, buf, bufLen, 0);
 
     LEAVES();
+    return retStatus;
+}
+
+STATUS sctpTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 customData)
+{
+    UNUSED_PARAM(timerID);
+    STATUS retStatus = STATUS_SUCCESS;
+    PSctpSession pSctpSession = (PSctpSession) customData;
+    UINT64 elapsedMs;
+    BOOL locked = FALSE;
+    PSctpContext pSctpContext = acquireSctpContext();
+    CHK_WARN(ATOMIC_LOAD_BOOL(&pSctpContext->isSctpInitialized), STATUS_NULL_ARG, "SCTP context not initialized, cannot run timer callback");
+
+    CHK(pSctpSession != NULL, STATUS_NULL_ARG);
+    CHK(ATOMIC_LOAD(&pSctpSession->shutdownStatus) == SCTP_SESSION_ACTIVE, retStatus);
+    MUTEX_LOCK(pSctpContext->sctpContextLock);
+    locked = TRUE;
+
+    elapsedMs = (currentTime - pSctpContext->lastTickTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    pSctpContext->lastTickTime = currentTime;
+    usrsctp_handle_timers((UINT32) elapsedMs);
+
+CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pSctpContext->sctpContextLock);
+    }
+    releaseSctpContext(pSctpContext);
+    CHK_LOG_ERR(retStatus);
+
     return retStatus;
 }
 

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -1,7 +1,7 @@
 #define LOG_CLASS "SCTP"
 #include "../Include_i.h"
 
-PSctpContext getSctpContext()
+PSctpContext acquireSctpContext()
 {
     ENTERS();
     static SctpContext s = {.lastTickTime = 0, .isSctpInitialized = FALSE, .contextRefCnt = 0, .sctpContextLock = INVALID_MUTEX_VALUE};
@@ -10,7 +10,7 @@ PSctpContext getSctpContext()
     return &s;
 }
 
-VOID releaseHoldOnSctpContext(PSctpContext pSctpContext)
+VOID releaseSctpContext(PSctpContext pSctpContext)
 {
     ENTERS();
     ATOMIC_DECREMENT(&pSctpContext->contextRefCnt);
@@ -21,7 +21,7 @@ VOID releaseHoldOnSctpContext(PSctpContext pSctpContext)
 STATUS createSctpContext()
 {
     ENTERS();
-    PSctpContext pSctpContext = getSctpContext();
+    PSctpContext pSctpContext = acquireSctpContext();
     STATUS retStatus = STATUS_SUCCESS;
     BOOL locked = FALSE;
 
@@ -40,7 +40,7 @@ CleanUp:
     if (locked) {
         MUTEX_UNLOCK(pSctpContext->sctpContextLock);
     }
-    releaseHoldOnSctpContext(pSctpContext);
+    releaseSctpContext(pSctpContext);
     CHK_LOG_ERR(retStatus);
 
     LEAVES();
@@ -50,18 +50,20 @@ CleanUp:
 STATUS cleanupSctpContext()
 {
     ENTERS();
+    UINT64 shutdownTimeout;
     STATUS retStatus = STATUS_SUCCESS;
 
-    PSctpContext pSctpContext = getSctpContext();
+    PSctpContext pSctpContext = acquireSctpContext();
 
     DLOGD("Releasing SCTP context instance from cleanupSctpContext");
-    releaseHoldOnSctpContext(pSctpContext);
+    releaseSctpContext(pSctpContext);
 
     CHK_WARN(ATOMIC_LOAD_BOOL(&pSctpContext->isSctpInitialized), STATUS_INVALID_OPERATION, "SCTP context not initialized, nothing to clean up");
 
     ATOMIC_STORE_BOOL(&pSctpContext->isSctpInitialized, FALSE);
 
-    while (ATOMIC_LOAD(&pSctpContext->contextRefCnt) > 0) {
+    shutdownTimeout = GETTIME() + SCTP_CONTEXT_REFERENCE_WAIT_TIMEOUT;
+    while (ATOMIC_LOAD(&pSctpContext->contextRefCnt) > 0 && GETTIME() < shutdownTimeout) {
         DLOGV("Waiting on all references to be returned...%d", pSctpContext->contextRefCnt);
         THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
@@ -214,6 +216,10 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, TIMER_QUEU
     assocParams.sasoc_asocmaxrxt = SCTP_MAX_ASSOCIATION_RETRANSMITS;
     CHK(usrsctp_setsockopt(pSctpSession->socket, IPPROTO_SCTP, SCTP_ASSOCINFO, &assocParams, SIZEOF(assocParams)) == 0,
         STATUS_SCTP_SESSION_SETUP_FAILED);
+
+    // call the timer callback now to reset the last tick time for this session while ensuring that other session's
+    // queued timer tasks are correctly advanced
+    sctpTimerCallback(0, GETTIME(), (UINT64) pSctpSession);
 
     pSctpSession->timerQueueHandle = timerQueueHandle;
     CHK_STATUS(timerQueueAddTimer(pSctpSession->timerQueueHandle, SCTP_TIMER_START_DELAY, SCTP_TIMER_INTERVAL, sctpTimerCallback,
@@ -416,7 +422,7 @@ STATUS sctpTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 customData)
     PSctpSession pSctpSession = (PSctpSession) customData;
     UINT64 elapsedMs;
     BOOL locked = FALSE;
-    PSctpContext pSctpContext = getSctpContext();
+    PSctpContext pSctpContext = acquireSctpContext();
     CHK_WARN(ATOMIC_LOAD_BOOL(&pSctpContext->isSctpInitialized), STATUS_NULL_ARG, "SCTP context not initialized, cannot run timer callback");
 
     CHK(pSctpSession != NULL, STATUS_NULL_ARG);
@@ -432,7 +438,7 @@ CleanUp:
     if (locked) {
         MUTEX_UNLOCK(pSctpContext->sctpContextLock);
     }
-    releaseHoldOnSctpContext(pSctpContext);
+    releaseSctpContext(pSctpContext);
     CHK_LOG_ERR(retStatus);
 
     return retStatus;

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -337,6 +337,8 @@ STATUS sctpTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 customData)
     usrsctp_handle_timers((UINT32) elapsedMs);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
+
     return retStatus;
 }
 

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -1,6 +1,85 @@
 #define LOG_CLASS "SCTP"
 #include "../Include_i.h"
 
+PSctpContext getSctpContext()
+{
+    ENTERS();
+    static SctpContext s = {.lastTickTime = 0, .isSctpInitialized = FALSE, .contextRefCnt = 0, .sctpContextLock = INVALID_MUTEX_VALUE};
+    ATOMIC_INCREMENT(&s.contextRefCnt);
+    LEAVES();
+    return &s;
+}
+
+VOID releaseHoldOnSctpContext(PSctpContext pSctpContext)
+{
+    ENTERS();
+    ATOMIC_DECREMENT(&pSctpContext->contextRefCnt);
+    LEAVES();
+}
+
+// Initializes SCTP context, in particular the lastTickTime used for timer handling
+STATUS createSctpContext()
+{
+    ENTERS();
+    PSctpContext pSctpContext = getSctpContext();
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    CHK_WARN(!ATOMIC_LOAD_BOOL(&pSctpContext->isSctpInitialized), retStatus, "SCTP context already initialized, nothing to do");
+    CHK_ERR(!IS_VALID_MUTEX_VALUE(pSctpContext->sctpContextLock), retStatus, "Mutex seems to have been created already");
+
+    pSctpContext->sctpContextLock = MUTEX_CREATE(TRUE);
+    CHK_ERR(IS_VALID_MUTEX_VALUE(pSctpContext->sctpContextLock), STATUS_NULL_ARG, "Mutex creation failed");
+    MUTEX_LOCK(pSctpContext->sctpContextLock);
+    locked = TRUE;
+    pSctpContext->lastTickTime = GETTIME();
+    ATOMIC_STORE_BOOL(&pSctpContext->isSctpInitialized, TRUE);
+    DLOGI("Initialized SCTP context instance");
+
+CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pSctpContext->sctpContextLock);
+    }
+    releaseHoldOnSctpContext(pSctpContext);
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS cleanupSctpContext()
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+
+    PSctpContext pSctpContext = getSctpContext();
+
+    DLOGD("Releasing SCTP context instance from cleanupSctpContext");
+    releaseHoldOnSctpContext(pSctpContext);
+
+    CHK_WARN(ATOMIC_LOAD_BOOL(&pSctpContext->isSctpInitialized), STATUS_INVALID_OPERATION, "SCTP context not initialized, nothing to clean up");
+
+    ATOMIC_STORE_BOOL(&pSctpContext->isSctpInitialized, FALSE);
+
+    while (ATOMIC_LOAD(&pSctpContext->contextRefCnt) > 0) {
+        DLOGV("Waiting on all references to be returned...%d", pSctpContext->contextRefCnt);
+        THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    }
+
+    if (IS_VALID_MUTEX_VALUE(pSctpContext->sctpContextLock)) {
+        MUTEX_FREE(pSctpContext->sctpContextLock);
+        pSctpContext->sctpContextLock = INVALID_MUTEX_VALUE;
+    }
+
+    DLOGI("Destroyed SCTP context");
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS initSctpAddrConn(PSctpSession pSctpSession, struct sockaddr_conn* sconn)
 {
     ENTERS();
@@ -62,6 +141,7 @@ CleanUp:
 
 STATUS initSctpSession()
 {
+    ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
 
     usrsctp_init_nothreads(0, &onSctpOutboundPacket, NULL);
@@ -69,6 +149,12 @@ STATUS initSctpSession()
     // Disable Explicit Congestion Notification
     usrsctp_sysctl_set_sctp_ecn_enable(0);
 
+    CHK_STATUS(createSctpContext());
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
     return retStatus;
 }
 
@@ -78,6 +164,8 @@ VOID deinitSctpSession()
     while (usrsctp_finish() != 0) {
         THREAD_SLEEP(DEFAULT_USRSCTP_TEARDOWN_POLLING_INTERVAL);
     }
+
+    cleanupSctpContext();
 }
 
 STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, TIMER_QUEUE_HANDLE timerQueueHandle, PSctpSession* ppSctpSession)
@@ -128,7 +216,6 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, TIMER_QUEU
         STATUS_SCTP_SESSION_SETUP_FAILED);
 
     pSctpSession->timerQueueHandle = timerQueueHandle;
-    pSctpSession->lastTickTime = GETTIME();
     CHK_STATUS(timerQueueAddTimer(pSctpSession->timerQueueHandle, SCTP_TIMER_START_DELAY, SCTP_TIMER_INTERVAL, sctpTimerCallback,
                                   (UINT64) pSctpSession, &pSctpSession->timerTaskId));
 
@@ -328,15 +415,24 @@ STATUS sctpTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 customData)
     STATUS retStatus = STATUS_SUCCESS;
     PSctpSession pSctpSession = (PSctpSession) customData;
     UINT64 elapsedMs;
+    BOOL locked = FALSE;
+    PSctpContext pSctpContext = getSctpContext();
+    CHK_WARN(ATOMIC_LOAD_BOOL(&pSctpContext->isSctpInitialized), STATUS_NULL_ARG, "SCTP context not initialized, cannot run timer callback");
 
     CHK(pSctpSession != NULL, STATUS_NULL_ARG);
     CHK(ATOMIC_LOAD(&pSctpSession->shutdownStatus) == SCTP_SESSION_ACTIVE, retStatus);
+    MUTEX_LOCK(pSctpContext->sctpContextLock);
+    locked = TRUE;
 
-    elapsedMs = (currentTime - pSctpSession->lastTickTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
-    pSctpSession->lastTickTime = currentTime;
+    elapsedMs = (currentTime - pSctpContext->lastTickTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    pSctpContext->lastTickTime = currentTime;
     usrsctp_handle_timers((UINT32) elapsedMs);
 
 CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pSctpContext->sctpContextLock);
+    }
+    releaseHoldOnSctpContext(pSctpContext);
     CHK_LOG_ERR(retStatus);
 
     return retStatus;

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -50,6 +50,11 @@ STATUS configureSctpSocket(struct socket* socket)
     initmsg.sinit_max_instreams = 300;
     CHK(usrsctp_setsockopt(socket, IPPROTO_SCTP, SCTP_INITMSG, &initmsg, SIZEOF(struct sctp_initmsg)) == 0, STATUS_SCTP_SESSION_SETUP_FAILED);
 
+    struct sctp_rtoinfo rtoinfo;
+    MEMSET(&rtoinfo, 0, SIZEOF(struct sctp_rtoinfo));
+    rtoinfo.srto_max = SCTP_RTO_MAX;
+    CHK(usrsctp_setsockopt(socket, IPPROTO_SCTP, SCTP_RTOINFO, &rtoinfo, SIZEOF(rtoinfo)) == 0, STATUS_SCTP_SESSION_SETUP_FAILED);
+
 CleanUp:
     LEAVES();
     return retStatus;
@@ -75,13 +80,14 @@ VOID deinitSctpSession()
     }
 }
 
-STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSession* ppSctpSession)
+STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, TIMER_QUEUE_HANDLE timerQueueHandle, PSctpSession* ppSctpSession)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PSctpSession pSctpSession = NULL;
     struct sockaddr_conn localConn, remoteConn;
     struct sctp_paddrparams params;
+    struct sctp_assocparams assocParams;
     INT32 connectStatus = 0;
 
     CHK(ppSctpSession != NULL && pSctpSessionCallbacks != NULL, STATUS_NULL_ARG);
@@ -92,6 +98,7 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSessi
     MEMSET(&params, 0x00, SIZEOF(struct sctp_paddrparams));
     MEMSET(&localConn, 0x00, SIZEOF(struct sockaddr_conn));
     MEMSET(&remoteConn, 0x00, SIZEOF(struct sockaddr_conn));
+    MEMSET(&assocParams, 0x00, SIZEOF(struct sctp_assocparams));
 
     ATOMIC_STORE(&pSctpSession->shutdownStatus, SCTP_SESSION_ACTIVE);
     pSctpSession->sctpSessionCallbacks = *pSctpSessionCallbacks;
@@ -112,8 +119,18 @@ STATUS createSctpSession(PSctpSessionCallbacks pSctpSessionCallbacks, PSctpSessi
     memcpy(&params.spp_address, &remoteConn, SIZEOF(remoteConn));
     params.spp_flags = SPP_PMTUD_DISABLE;
     params.spp_pathmtu = SCTP_MTU;
+    params.spp_pathmaxrxt = SCTP_MAX_PATH_RETRANSMITS;
     CHK(usrsctp_setsockopt(pSctpSession->socket, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, &params, SIZEOF(params)) == 0,
         STATUS_SCTP_SESSION_SETUP_FAILED);
+
+    assocParams.sasoc_asocmaxrxt = SCTP_MAX_ASSOCIATION_RETRANSMITS;
+    CHK(usrsctp_setsockopt(pSctpSession->socket, IPPROTO_SCTP, SCTP_ASSOCINFO, &assocParams, SIZEOF(assocParams)) == 0,
+        STATUS_SCTP_SESSION_SETUP_FAILED);
+
+    pSctpSession->timerQueueHandle = timerQueueHandle;
+    pSctpSession->lastTickTime = GETTIME();
+    CHK_STATUS(timerQueueAddTimer(pSctpSession->timerQueueHandle, SCTP_TIMER_START_DELAY, SCTP_TIMER_INTERVAL, sctpTimerCallback,
+                                  (UINT64) pSctpSession, &pSctpSession->timerTaskId));
 
 CleanUp:
     if (STATUS_FAILED(retStatus)) {
@@ -138,6 +155,11 @@ STATUS freeSctpSession(PSctpSession* ppSctpSession)
     pSctpSession = *ppSctpSession;
 
     CHK(pSctpSession != NULL, retStatus);
+
+    // Cancel the periodic timer before shutting down the socket
+    if (IS_VALID_TIMER_QUEUE_HANDLE(pSctpSession->timerQueueHandle)) {
+        timerQueueCancelTimer(pSctpSession->timerQueueHandle, pSctpSession->timerTaskId, (UINT64) pSctpSession);
+    }
 
     usrsctp_deregister_address(pSctpSession);
     /* handle issue mentioned here: https://github.com/sctplab/usrsctp/issues/147
@@ -297,6 +319,24 @@ STATUS putSctpPacket(PSctpSession pSctpSession, PBYTE buf, UINT32 bufLen)
     usrsctp_conninput(pSctpSession, buf, bufLen, 0);
 
     LEAVES();
+    return retStatus;
+}
+
+STATUS sctpTimerCallback(UINT32 timerID, UINT64 currentTime, UINT64 customData)
+{
+    UNUSED_PARAM(timerID);
+    STATUS retStatus = STATUS_SUCCESS;
+    PSctpSession pSctpSession = (PSctpSession) customData;
+    UINT64 elapsedMs;
+
+    CHK(pSctpSession != NULL, STATUS_NULL_ARG);
+    CHK(ATOMIC_LOAD(&pSctpSession->shutdownStatus) == SCTP_SESSION_ACTIVE, retStatus);
+
+    elapsedMs = (currentTime - pSctpSession->lastTickTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    pSctpSession->lastTickTime = currentTime;
+    usrsctp_handle_timers((UINT32) elapsedMs);
+
+CleanUp:
     return retStatus;
 }
 

--- a/src/source/Sctp/Sctp.h
+++ b/src/source/Sctp/Sctp.h
@@ -27,6 +27,20 @@ extern "C" {
 
 #define DEFAULT_USRSCTP_TEARDOWN_POLLING_INTERVAL (10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
+#define SCTP_TIMER_INTERVAL    (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define SCTP_TIMER_START_DELAY (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+
+#define SCTP_CONTEXT_REFERENCE_WAIT_TIMEOUT (5 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
+// Values taken from defaults suggested by RFC 9260 spec: https://www.ietf.org/rfc/rfc9260.pdf
+
+// Max retransmits along a given single path. Typical default is 5
+#define SCTP_MAX_PATH_RETRANSMITS 5
+// Max retransmits across all paths for an endpoint association. Typical default is double max path retransmits
+#define SCTP_MAX_ASSOCIATION_RETRANSMITS 10
+// Retransmission timeout. Typical default is 60 seconds
+#define SCTP_RTO_MAX 60000
+
 enum { SCTP_PPID_DCEP = 50, SCTP_PPID_STRING = 51, SCTP_PPID_BINARY = 53, SCTP_PPID_STRING_EMPTY = 56, SCTP_PPID_BINARY_EMPTY = 57 };
 
 enum {
@@ -52,6 +66,15 @@ typedef VOID (*SctpSessionDataChannelOpenFunc)(UINT64, UINT32, PBYTE, UINT32);
 // Argument is ChannelID and Message + Len
 typedef VOID (*SctpSessionDataChannelMessageFunc)(UINT64, UINT32, BOOL, PBYTE, UINT32);
 
+/// Singleton context for SCTP global state
+typedef struct SctpContext {
+    // last time the periodic usrsctp timers were called
+    UINT64 lastTickTime;
+    volatile ATOMIC_BOOL isSctpInitialized;
+    SIZE_T contextRefCnt;
+    MUTEX sctpContextLock;
+} SctpContext, *PSctpContext;
+
 typedef struct {
     UINT64 customData;
     SctpSessionOutboundPacketFunc outboundPacketFunc;
@@ -66,11 +89,13 @@ typedef struct {
     BYTE packet[SCTP_MAX_ALLOWABLE_PACKET_LENGTH];
     UINT32 packetSize;
     SctpSessionCallbacks sctpSessionCallbacks;
+    TIMER_QUEUE_HANDLE timerQueueHandle;
+    UINT32 timerTaskId;
 } SctpSession, *PSctpSession;
 
 STATUS initSctpSession();
 VOID deinitSctpSession();
-STATUS createSctpSession(PSctpSessionCallbacks, PSctpSession*);
+STATUS createSctpSession(PSctpSessionCallbacks, TIMER_QUEUE_HANDLE, PSctpSession*);
 STATUS freeSctpSession(PSctpSession*);
 STATUS putSctpPacket(PSctpSession, PBYTE, UINT32);
 STATUS sctpSessionWriteMessage(PSctpSession, UINT32, BOOL, PBYTE, UINT32);
@@ -80,6 +105,8 @@ STATUS handleDcepPacket(PSctpSession, UINT32, PBYTE, SIZE_T);
 // Callbacks used by usrsctp
 INT32 onSctpOutboundPacket(PVOID, PVOID, ULONG, UINT8, UINT8);
 INT32 onSctpInboundPacket(struct socket*, union sctp_sockstore, PVOID, ULONG, struct sctp_rcvinfo, INT32, PVOID);
+// Callback to drive periodic SCTP timers
+STATUS sctpTimerCallback(UINT32, UINT64, UINT64);
 
 #ifdef __cplusplus
 }

--- a/src/source/Sctp/Sctp.h
+++ b/src/source/Sctp/Sctp.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define DEFAULT_USRSCTP_TEARDOWN_POLLING_INTERVAL (10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
-#define SCTP_TIMER_INTERVAL    (50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define SCTP_TIMER_INTERVAL    (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 #define SCTP_TIMER_START_DELAY (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
 // Values taken from defaults suggested by RFC 9260 spec: https://www.ietf.org/rfc/rfc9260.pdf
@@ -64,6 +64,15 @@ typedef VOID (*SctpSessionDataChannelOpenFunc)(UINT64, UINT32, PBYTE, UINT32);
 // Argument is ChannelID and Message + Len
 typedef VOID (*SctpSessionDataChannelMessageFunc)(UINT64, UINT32, BOOL, PBYTE, UINT32);
 
+/// Singleton context for SCTP global state
+typedef struct SctpContext {
+    // last time the periodic usrsctp timers were called
+    UINT64 lastTickTime;
+    volatile ATOMIC_BOOL isSctpInitialized;
+    SIZE_T contextRefCnt;
+    MUTEX sctpContextLock;
+} SctpContext, *PSctpContext;
+
 typedef struct {
     UINT64 customData;
     SctpSessionOutboundPacketFunc outboundPacketFunc;
@@ -80,7 +89,6 @@ typedef struct {
     SctpSessionCallbacks sctpSessionCallbacks;
     TIMER_QUEUE_HANDLE timerQueueHandle;
     UINT32 timerTaskId;
-    UINT64 lastTickTime;
 } SctpSession, *PSctpSession;
 
 STATUS initSctpSession();

--- a/src/source/Sctp/Sctp.h
+++ b/src/source/Sctp/Sctp.h
@@ -27,6 +27,18 @@ extern "C" {
 
 #define DEFAULT_USRSCTP_TEARDOWN_POLLING_INTERVAL (10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
+#define SCTP_TIMER_INTERVAL    (50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define SCTP_TIMER_START_DELAY (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+
+// Values taken from defaults suggested by RFC 9260 spec: https://www.ietf.org/rfc/rfc9260.pdf
+
+// Max retransmits along a given single path. Typical default is 5
+#define SCTP_MAX_PATH_RETRANSMITS 5
+// Max retransmits across all paths for an endpoint association. Typical default is double max path retransmits
+#define SCTP_MAX_ASSOCIATION_RETRANSMITS 10
+// Retransmission timeout. Typical default is 60 seconds
+#define SCTP_RTO_MAX 60000
+
 enum { SCTP_PPID_DCEP = 50, SCTP_PPID_STRING = 51, SCTP_PPID_BINARY = 53, SCTP_PPID_STRING_EMPTY = 56, SCTP_PPID_BINARY_EMPTY = 57 };
 
 enum {
@@ -66,11 +78,14 @@ typedef struct {
     BYTE packet[SCTP_MAX_ALLOWABLE_PACKET_LENGTH];
     UINT32 packetSize;
     SctpSessionCallbacks sctpSessionCallbacks;
+    TIMER_QUEUE_HANDLE timerQueueHandle;
+    UINT32 timerTaskId;
+    UINT64 lastTickTime;
 } SctpSession, *PSctpSession;
 
 STATUS initSctpSession();
 VOID deinitSctpSession();
-STATUS createSctpSession(PSctpSessionCallbacks, PSctpSession*);
+STATUS createSctpSession(PSctpSessionCallbacks, TIMER_QUEUE_HANDLE, PSctpSession*);
 STATUS freeSctpSession(PSctpSession*);
 STATUS putSctpPacket(PSctpSession, PBYTE, UINT32);
 STATUS sctpSessionWriteMessage(PSctpSession, UINT32, BOOL, PBYTE, UINT32);
@@ -79,6 +94,8 @@ STATUS sctpSessionWriteDcep(PSctpSession, UINT32, PCHAR, UINT32, PRtcDataChannel
 // Callbacks used by usrsctp
 INT32 onSctpOutboundPacket(PVOID, PVOID, ULONG, UINT8, UINT8);
 INT32 onSctpInboundPacket(struct socket*, union sctp_sockstore, PVOID, ULONG, struct sctp_rcvinfo, INT32, PVOID);
+// Callback to drive periodic SCTP timers
+STATUS sctpTimerCallback(UINT32, UINT64, UINT64);
 
 #ifdef __cplusplus
 }

--- a/src/source/Sctp/Sctp.h
+++ b/src/source/Sctp/Sctp.h
@@ -30,6 +30,8 @@ extern "C" {
 #define SCTP_TIMER_INTERVAL    (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 #define SCTP_TIMER_START_DELAY (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
+#define SCTP_CONTEXT_REFERENCE_WAIT_TIMEOUT (5 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
 // Values taken from defaults suggested by RFC 9260 spec: https://www.ietf.org/rfc/rfc9260.pdf
 
 // Max retransmits along a given single path. Typical default is 5

--- a/tst/DataChannelFunctionalityTest.cpp
+++ b/tst/DataChannelFunctionalityTest.cpp
@@ -97,6 +97,105 @@ TEST_F(DataChannelFunctionalityTest, createDataChannel_Disconnected)
     ASSERT_EQ(1u, remoteOpen.channels.at("Answer PeerConnection"));
 }
 
+// When a message drops from a data channel, the connection should retry it
+TEST_F(DataChannelFunctionalityTest, createDataChannel_RecoverFromDroppedMessage)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    // "offer" creates a data channel, answer just listens on it
+    PRtcDataChannel pOfferDataChannel = nullptr;
+    SIZE_T datachannelRemoteOpenCount = 0, msgCount = 0;
+    struct OnOpenHandle {
+        PSIZE_T datachannelRemoteOpenCount;
+        PSIZE_T msgCount;
+    };
+    OnOpenHandle onOpenHandle{&datachannelRemoteOpenCount, &msgCount};
+    // These variables need to be static so the lambda that uses them does not need to capture since lambdas with captures cannot
+    // be converted to function pointers
+    static bool dropNextMessage{false};
+    static std::mutex dropMessageMutex{};
+    static IceInboundPacketFunc iceInboundPacketCallback = nullptr;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Override the ice agent inbound packet callback to allow us to drop messages and simulate a flaky connection
+    iceInboundPacketCallback = ((PKvsPeerConnection) answerPc)->pIceAgent->iceAgentCallbacks.inboundPacketFn;
+    dropNextMessage = false; // do not drop any messages yet
+    // Override the ice agent inbound packet callback to drop the first message, simulating
+    // a peer that has stopped communicating without closing the connection
+    const auto dropFirstInboundMessage = [](UINT64 customData, PBYTE pBuffer, UINT32 bufferLen) {
+        std::lock_guard<std::mutex> lock{dropMessageMutex};
+        if (dropNextMessage) {
+            dropNextMessage = false;
+            return;
+        }
+
+        iceInboundPacketCallback(customData, pBuffer, bufferLen);
+    };
+    ((PKvsPeerConnection) answerPc)->pIceAgent->iceAgentCallbacks.inboundPacketFn = dropFirstInboundMessage;
+
+    // Needs to be static so onDataChannel can use it without capture
+    static auto dataChannelOnMessageCallback = [](UINT64 customData, PRtcDataChannel pDataChannel, BOOL isBinary, PBYTE pMsg, UINT32 pMsgLen) {
+        UNUSED_PARAM(pDataChannel);
+        UNUSED_PARAM(isBinary);
+        DLOGD("onDataChannelMessage '%s'", pMsg);
+        if (STRNCMP((PCHAR) pMsg, TEST_DATA_CHANNEL_MESSAGE, pMsgLen) == 0) {
+            ATOMIC_INCREMENT((PSIZE_T) customData);
+        }
+    };
+
+    auto onDataChannel = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) {
+        auto handle = reinterpret_cast<OnOpenHandle*>(customData);
+        ATOMIC_INCREMENT(handle->datachannelRemoteOpenCount);
+        DLOGD("onDataChannel '%s'", pRtcDataChannel->name);
+        // attach listener
+        EXPECT_EQ(dataChannelOnMessage(pRtcDataChannel, (UINT64) handle->msgCount, dataChannelOnMessageCallback), STATUS_SUCCESS);
+        // send a message to ensure the channel is working
+        dataChannelSend(pRtcDataChannel, FALSE, (PBYTE) TEST_DATA_CHANNEL_MESSAGE, STRLEN(TEST_DATA_CHANNEL_MESSAGE));
+    };
+
+    // Answer peer listens for data channels becoming available on which to attach the listener
+    EXPECT_EQ(peerConnectionOnDataChannel(answerPc, (UINT64) &onOpenHandle, onDataChannel), STATUS_SUCCESS);
+    // Create a DataChannel from the offer to the answer peer
+    EXPECT_EQ(createDataChannel(offerPc, (PCHAR) "Offer PeerConnection", nullptr, &pOfferDataChannel), STATUS_SUCCESS);
+    // Register listener on this side to ensure the channel is working before we simulate the failure
+    EXPECT_EQ(dataChannelOnMessage(pOfferDataChannel, (UINT64) &msgCount, dataChannelOnMessageCallback), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Busy wait until DataChannel connects
+    for (auto i = 0; i <= 100 && (ATOMIC_LOAD(&datachannelRemoteOpenCount) + ATOMIC_LOAD(&msgCount)) != 2; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    // Assert that channels are open and messages are received before testing the dropped message edge case
+    ASSERT_EQ(ATOMIC_LOAD(&datachannelRemoteOpenCount), 1);
+    ASSERT_EQ(ATOMIC_LOAD(&msgCount), 1);
+
+    // set up the ice agent to drop the next message, simulating a flaky connection
+    {
+        std::lock_guard<std::mutex> lock{dropMessageMutex};
+        dropNextMessage = true;
+    }
+
+    // send a message that will be dropped
+    dataChannelSend(pOfferDataChannel, FALSE, (PBYTE) TEST_DATA_CHANNEL_MESSAGE, STRLEN(TEST_DATA_CHANNEL_MESSAGE));
+
+    // busy wait for the message to be resent after being dropped
+    for (auto i = 0; i <= 100 && ATOMIC_LOAD(&msgCount) != 2; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    closePeerConnection(offerPc);
+    freePeerConnection(&offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&answerPc);
+
+    ASSERT_EQ(ATOMIC_LOAD(&msgCount), 2); // message should eventually make it through
+}
+
 TEST_F(DataChannelFunctionalityTest, dataChannelSendRecvMessageAfterDtlsCompleted)
 {
     RtcConfiguration configuration;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add configuration options (currently hard-coded) to the SCTP header for configuring retry and path liveness detection for data channels over sctp.
- Periodically call the usrsctp state machine step function while data channels are active
- Unit test covering the new code

*Why was it changed?*
- Observed issues in using this library where, under certain network congestion conditions, data channels would stall and never recover even though ICE transport stayed alive and media channels recovered. Issue was root-caused to a bug in the usage of the usrsctp library: since there are no periodic invocations of the timer handler, the advancement of the SCTP state machine relied on a steady stream of data being published by the data channel, which is not a guarantee. In particular, if the data channel's send buffers fill up, there is no way to clear the stall without receiving a packet from the peer.

*How was it changed?*
- Implemented a timer callback to run periodically which invokes `usrsctp_handle_timers()`. By doing so, we advance the sctp state machine, even when there is no incoming data, which allows for retry or failure detection as applicable.

*What testing was done for the changes?*
- Unit test included in this PR. I did verify that without the fix, the new unit test fails.
- Tested with proprietary application. With this fix, data channels that are stalled during a period of low network bandwidth are able to fully recover alongside the media channels.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
