### PR TITLE
Silence 'WebRTC Client object Object not initialized' log when threadpool is disabled

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1039,7 +1039,9 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     iceAgentCallbacks.inboundPacketFn = onInboundPacket;
     iceAgentCallbacks.connectionStateChangedFn = onIceConnectionStateChange;
     iceAgentCallbacks.newLocalCandidateFn = onNewIceLocalCandidate;
+#ifdef ENABLE_KVS_THREADPOOL
     iceAgentCallbacks.setStunServerIpFn = onSetStunServerIp;
+#endif
 
     PROFILE_CALL(CHK_STATUS(createConnectionListener(&pConnectionListener)), "Create connection listener");
     // IceAgent will own the lifecycle of pConnectionListener;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Guarded the `setStunServerIpFn` callback assignment behind `#ifdef ENABLE_KVS_THREADPOOL` in createPeerConnection.

*Why was it changed?*
- Observed the following logs when threadpool is not enabled.
  ```
  2026-06-03 16:07:43.474 WARN    onSetStunServerIp(): WebRTC Client object Object not initialized
  2026-06-03 16:07:43.474 ERROR   onSetStunServerIp(): operation returned status code: 0x00000001
  ```
- The SDK supports an optional threadpool (ENABLE_KVS_THREADPOOL) that performs async DNS resolution of the STUN server in the background at init time. When a peer connection is later created, the onSetStunServerIp callback retrieves the cached result instead of doing a blocking DNS lookup.
 - However, the callback was being assigned unconditionally, even in builds without the threadpool. Without the threadpool, the WebRTC client context is never initialized, so the callback fires and fails with a WARN log ("WebRTC Client object Object not initialized") plus an error log ("operation returned status 0x00000001") every time an ICE server is parsed. The fallback to synchronous DNS resolution still happens correctly, but the logs look alarming to anyone investigating issues. 

*How was it changed?*
- Wrapped `iceAgentCallbacks.setStunServerIpFn = onSetStunServerIp` in `#ifdef ENABLE_KVS_THREADPOOL`. When the threadpool is disabled, `setIpFn` remains `NULL` on the ICE server struct. The ICE utils code (`IceUtils.c`) already handles `setIpFn == NULL` by skipping the callback and going straight to synchronous `getIpWithHostName()`. This is the same fallback that was already triggered by the `STATUS_NULL_ARG` return, just without the noisy logs.

*What testing was done for the changes?*
- CI/CD to validate the changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
