### PR TITLE
Optimization: don't call the TWCC feedback callback for empty packets

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -524,6 +524,7 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
         // Also cap reportLen to packetStatusCount to bound the allocation size
         CHK(packetStatusCount > 0, STATUS_SUCCESS);
         if (reportLen > packetStatusCount) {
+            DLOGD("Malformed TWCC packet: reportLen %u exceeds packetStatusCount %u", reportLen, packetStatusCount);
             reportLen = packetStatusCount;
         }
 
@@ -532,6 +533,11 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
         CHK(pFeedbackList != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
         for (seqNum = pTwccManager->prevReportedBaseSeqNum; seqNum != (UINT16) (pTwccManager->lastReportedSeqNum + 1); seqNum++) {
+            // Malformed packet: run-length in chunk exceeds packetStatusCount
+            if (feedbackCount >= reportLen) {
+                DLOGD("Malformed TWCC packet: feedback list full at seqNum %u, stopping early (reportLen %u)", seqNum, reportLen);
+                break;
+            }
             if (STATUS_SUCCEEDED(hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, seqNum, &twccPktVal))) {
                 pPktInfo = (PTwccRtpPacketInfo) twccPktVal;
                 if (pPktInfo != NULL && pPktInfo->remoteTimeKvs != TWCC_PACKET_LOST_TIME && pPktInfo->remoteTimeKvs != TWCC_PACKET_UNITIALIZED_TIME) {

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -511,6 +511,12 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
     pTwccManager = pKvsPeerConnection->pTwccManager;
     CHK_STATUS(parseRtcpTwccPacket(pRtcpPacket, pTwccManager));
 
+    // Skip empty reports - nothing useful for any estimator path
+    if (TWCC_PACKET_STATUS_COUNT(pRtcpPacket->payload) == 0) {
+        DLOGD("Malformed TWCC packet: packetStatusCount is 0, skipping");
+        CHK(FALSE, STATUS_SUCCESS);
+    }
+
     // Compute trendline
     if (pKvsPeerConnection->onTwccFeedbackReceived != NULL) {
         // Custom estimator callback, build feedback list from this TWCC report
@@ -523,9 +529,7 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
         UINT16 reportLen = (UINT16) (pTwccManager->lastReportedSeqNum - pTwccManager->prevReportedBaseSeqNum + 1);
         UINT16 packetStatusCount = TWCC_PACKET_STATUS_COUNT(pRtcpPacket->payload);
 
-        // Skip callback for empty reports
-        // Also cap reportLen to packetStatusCount to bound the allocation size
-        CHK(packetStatusCount > 0, STATUS_SUCCESS);
+        // Cap reportLen to packetStatusCount to bound the allocation size
         if (reportLen > packetStatusCount) {
             DLOGD("Malformed TWCC packet: reportLen %u exceeds packetStatusCount %u", reportLen, packetStatusCount);
             reportLen = packetStatusCount;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -199,6 +199,10 @@ STATUS parseRtcpTwccPacket(PRtcpPacket pRtcpPacket, PTwccManager pTwccManager)
     baseSeqNum = getUnalignedInt16BigEndian(pRtcpPacket->payload + 8);
     pTwccManager->prevReportedBaseSeqNum = baseSeqNum;
     packetStatusCount = TWCC_PACKET_STATUS_COUNT(pRtcpPacket->payload);
+
+    // Empty report, nothing to parse
+    CHK(packetStatusCount > 0, STATUS_SUCCESS);
+
     referenceTime = (pRtcpPacket->payload[12] << 16) | (pRtcpPacket->payload[13] << 8) | (pRtcpPacket->payload[14] & 0xff);
     referenceTime = KVS_CONVERT_TIMESCALE(referenceTime * 64, MILLISECONDS_PER_SECOND, HUNDREDS_OF_NANOS_IN_A_SECOND);
     // TODO: handle lost twcc report packets
@@ -514,6 +518,14 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
         UINT64 twccPktVal = 0;
         PTwccRtpPacketInfo pPktInfo = NULL;
         UINT16 reportLen = (UINT16) (pTwccManager->lastReportedSeqNum - pTwccManager->prevReportedBaseSeqNum + 1);
+        UINT16 packetStatusCount = TWCC_PACKET_STATUS_COUNT(pRtcpPacket->payload);
+
+        // Skip callback for empty reports
+        // Also cap reportLen to packetStatusCount to bound the allocation size
+        CHK(packetStatusCount > 0, STATUS_SUCCESS);
+        if (reportLen > packetStatusCount) {
+            reportLen = packetStatusCount;
+        }
 
         MEMSET(&congestionState, 0, SIZEOF(congestionState));
         pFeedbackList = (PTwccFeedback) MEMALLOC(reportLen * SIZEOF(TwccFeedback));

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -201,7 +201,10 @@ STATUS parseRtcpTwccPacket(PRtcpPacket pRtcpPacket, PTwccManager pTwccManager)
     packetStatusCount = TWCC_PACKET_STATUS_COUNT(pRtcpPacket->payload);
 
     // Empty report, nothing to parse
-    CHK(packetStatusCount > 0, STATUS_SUCCESS);
+    if (packetStatusCount == 0u) {
+        DLOGD("Received empty TWCC packet");
+        CHK(FALSE, STATUS_SUCCESS);
+    }
 
     referenceTime = (pRtcpPacket->payload[12] << 16) | (pRtcpPacket->payload[13] << 8) | (pRtcpPacket->payload[14] & 0xff);
     referenceTime = KVS_CONVERT_TIMESCALE(referenceTime * 64, MILLISECONDS_PER_SECOND, HUNDREDS_OF_NANOS_IN_A_SECOND);

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1230,6 +1230,93 @@ TEST_F(RtcpFunctionalityTest, twccSeqNumWraparoundInvokesCallbackCorrectly)
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+// Verify that a malformed TWCC packet where the run-length chunk exceeds
+// packetStatusCount does not cause a buffer overflow in the feedback list.
+// The crafted packet claims packetStatusCount=2 but has a run-length chunk of 10,
+// causing parseRtcpTwccPacket to set lastReportedSeqNum far beyond what
+// packetStatusCount indicates. Without the bounds check, the feedback loop would
+// write past the allocated buffer.
+TEST_F(RtcpFunctionalityTest, twccMalformedRunLengthExceedsStatusCountNoCrash)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    UINT32 extpayload;
+
+    struct CallbackCtx {
+        UINT32 invocations;
+        UINT32 feedbackCount;
+    } cbCtx = {0, 0};
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    auto twccCallback = [](UINT64 customData, PTwccFeedback pFeedback, UINT32 feedbackCount, PTwccCongestionState pState) -> STATUS {
+        UNUSED_PARAM(pFeedback);
+        auto* ctx = (CallbackCtx*) customData;
+        ctx->invocations++;
+        ctx->feedbackCount = feedbackCount;
+        pState->delayTrend = 0.0;
+        return STATUS_SUCCESS;
+    };
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &cbCtx, twccCallback));
+
+    // Send 10 packets with seqNums 0..9 so they exist in the hash table
+    for (UINT16 i = 0; i < 10; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), i);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    // Craft a malformed TWCC feedback packet:
+    //   baseSeqNum = 0
+    //   packetStatusCount = 2  (claims only 2 packets)
+    //   But the run-length chunk says 10 (small delta, run=10)
+    //   Followed by 10 small delta values
+    // This causes parseRtcpTwccPacket to advance lastReportedSeqNum to 9,
+    // creating a range of 10 while the allocation is only for 2 elements.
+    BYTE payload[28] = {0};
+    // SSRC of sender
+    payload[0] = 0x44; payload[1] = 0x87; payload[2] = 0xA9; payload[3] = 0xE7;
+    // SSRC of media source
+    payload[4] = 0x54; payload[5] = 0xB3; payload[6] = 0xE6; payload[7] = 0xFD;
+    // baseSeqNum = 0
+    payload[8] = 0x00; payload[9] = 0x00;
+    // packetStatusCount = 2 (the lie - actually 10 packets in the chunk)
+    payload[10] = 0x00; payload[11] = 0x02;
+    // referenceTime (3 bytes) + fb pkt count (1 byte)
+    payload[12] = 0x14; payload[13] = 0x79; payload[14] = 0x72; payload[15] = 0x01;
+    // Run-length chunk: bit 15=0 (run-length), status=01 (small delta), run length=10
+    // Format: 0|SS|RRRRRRRRRRRRR -> 0|01|0000000001010 = 0x200A
+    payload[16] = 0x20; payload[17] = 0x0A;
+    // 10 small delta values (1 byte each): all 10 (= 2.5ms each in TWCC ticks)
+    payload[18] = 0x0A; payload[19] = 0x0A; payload[20] = 0x0A; payload[21] = 0x0A;
+    payload[22] = 0x0A; payload[23] = 0x0A; payload[24] = 0x0A; payload[25] = 0x0A;
+    payload[26] = 0x0A; payload[27] = 0x0A;
+
+    rtcpPacket.header.packetLength = SIZEOF(payload) / 4;
+    rtcpPacket.header.packetType = RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK;
+    rtcpPacket.header.receptionReportCount = RTCP_FEEDBACK_MESSAGE_TYPE_APPLICATION_LAYER_FEEDBACK;
+    rtcpPacket.payload = payload;
+    rtcpPacket.payloadLength = SIZEOF(payload);
+
+    // Without the feedbackCount < reportLen guard, this would overflow the buffer.
+    // With the fix, it should complete without crashing.
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+
+    // Callback should have been invoked
+    EXPECT_EQ(1u, cbCtx.invocations);
+    // feedbackCount should be capped at packetStatusCount (2), not the full 10
+    EXPECT_LE(cbCtx.feedbackCount, 2u);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1156,6 +1156,88 @@ TEST_F(RtcpFunctionalityTest, twccZeroStatusCountAfterValidReportNoSpuriousCallb
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+// Verify that zero packetStatusCount skips ALL callbacks: onTwccFeedbackReceived,
+// onPeerCongestionFeedback, and onSenderBandwidthEstimation.
+TEST_F(RtcpFunctionalityTest, twccZeroPacketStatusCountSkipsAllCallbacks)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    UINT32 extpayload;
+
+    struct CallbackCounters {
+        UINT32 twccFeedback;
+        UINT32 congestionFeedback;
+        UINT32 bweCallback;
+    } counters = {0, 0, 0};
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    // Set all three callbacks
+    auto twccCallback = [](UINT64 customData, PTwccFeedback pFeedback, UINT32 feedbackCount, PTwccCongestionState pState) -> STATUS {
+        UNUSED_PARAM(pFeedback);
+        UNUSED_PARAM(feedbackCount);
+        ((CallbackCounters*) customData)->twccFeedback++;
+        pState->delayTrend = 0.0;
+        return STATUS_SUCCESS;
+    };
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &counters, twccCallback));
+
+    auto congestionCallback = [](UINT64 customData, PCongestionCtx pCtx) -> STATUS {
+        UNUSED_PARAM(pCtx);
+        ((CallbackCounters*) customData)->congestionFeedback++;
+        return STATUS_SUCCESS;
+    };
+    EXPECT_EQ(STATUS_SUCCESS, setOnPeerCongestionFeedbackFn(pRtcPeerConnection, (UINT64) &counters, congestionCallback));
+
+    auto bweCallback = [](UINT64 customData, UINT32 sentBytes, UINT32 receivedBytes, UINT32 sentPackets, UINT32 receivedPackets,
+                          UINT64 duration) -> VOID {
+        UNUSED_PARAM(sentBytes);
+        UNUSED_PARAM(receivedBytes);
+        UNUSED_PARAM(sentPackets);
+        UNUSED_PARAM(receivedPackets);
+        UNUSED_PARAM(duration);
+        ((CallbackCounters*) customData)->bweCallback++;
+    };
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnSenderBandwidthEstimation(pRtcPeerConnection, (UINT64) &counters, bweCallback));
+
+    // Send packets so TWCC manager has state
+    for (UINT16 i = 0; i < 10; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), i);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    // Craft a TWCC feedback packet with packetStatusCount = 0
+    BYTE payload[16] = {0};
+    payload[0] = 0x44; payload[1] = 0x87; payload[2] = 0xA9; payload[3] = 0xE7;
+    payload[4] = 0x54; payload[5] = 0xB3; payload[6] = 0xE6; payload[7] = 0xFD;
+    payload[8] = 0x00; payload[9] = 0x00;  // baseSeqNum = 0
+    payload[10] = 0x00; payload[11] = 0x00; // packetStatusCount = 0
+    payload[12] = 0x14; payload[13] = 0x7A; payload[14] = 0x00; payload[15] = 0x01;
+
+    rtcpPacket.header.packetLength = SIZEOF(payload) / 4;
+    rtcpPacket.header.packetType = RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK;
+    rtcpPacket.header.receptionReportCount = RTCP_FEEDBACK_MESSAGE_TYPE_APPLICATION_LAYER_FEEDBACK;
+    rtcpPacket.payload = payload;
+    rtcpPacket.payloadLength = SIZEOF(payload);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+
+    // None of the callbacks should have been invoked
+    EXPECT_EQ(0u, counters.twccFeedback);
+    EXPECT_EQ(0u, counters.congestionFeedback);
+    EXPECT_EQ(0u, counters.bweCallback);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 // Verify that a legitimate TWCC report spanning the UINT16 wraparound boundary
 // (e.g., seqNums 65534..1) works correctly and invokes the callback with proper data.
 TEST_F(RtcpFunctionalityTest, twccSeqNumWraparoundInvokesCallbackCorrectly)

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1019,6 +1019,217 @@ TEST_F(RtcpFunctionalityTest, onTwccFeedbackReceived_callbackErrorNoDeadlock)
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+// Verify that a TWCC packet with packetStatusCount=0 does not invoke the custom
+// feedback callback
+TEST_F(RtcpFunctionalityTest, twccZeroPacketStatusCountDoesNotInvokeCallback)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    UINT32 extpayload;
+    UINT32 callbackInvocations = 0;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    // Set custom TWCC feedback callback that counts invocations
+    auto twccCallback = [](UINT64 customData, PTwccFeedback pFeedback, UINT32 feedbackCount, PTwccCongestionState pState) -> STATUS {
+        UNUSED_PARAM(pFeedback);
+        UNUSED_PARAM(feedbackCount);
+        (*(PUINT32) customData)++;
+        pState->delayTrend = 0.0;
+        return STATUS_SUCCESS;
+    };
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &callbackInvocations, twccCallback));
+
+    // Send a few packets so TWCC manager has state
+    for (UINT16 i = 100; i < 110; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), i);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    // Craft a TWCC feedback packet with packetStatusCount = 0 but a non-zero baseSeqNum.
+    BYTE payload[16] = {0};
+    payload[0] = 0x44; payload[1] = 0x87; payload[2] = 0xA9; payload[3] = 0xE7;
+    payload[4] = 0x54; payload[5] = 0xB3; payload[6] = 0xE6; payload[7] = 0xFD;
+    // baseSeqNum = 500
+    payload[8] = 0x01; payload[9] = 0xF4;
+    // packetStatusCount = 0
+    payload[10] = 0x00; payload[11] = 0x00;
+    // referenceTime + fb pkt count
+    payload[12] = 0x14; payload[13] = 0x7A; payload[14] = 0x00; payload[15] = 0x01;
+
+    rtcpPacket.header.packetLength = SIZEOF(payload) / 4;
+    rtcpPacket.header.packetType = RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK;
+    rtcpPacket.header.receptionReportCount = RTCP_FEEDBACK_MESSAGE_TYPE_APPLICATION_LAYER_FEEDBACK;
+    rtcpPacket.payload = payload;
+    rtcpPacket.payloadLength = SIZEOF(payload);
+
+    // onRtcpTwccPacket should NOT invoke the callback for a zero-count report.
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+    EXPECT_EQ(0u, callbackInvocations);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+// Verify that after a valid TWCC report, a subsequent zero-count report does NOT
+// trigger the callback
+TEST_F(RtcpFunctionalityTest, twccZeroStatusCountAfterValidReportNoSpuriousCallback)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    UINT32 extpayload;
+    UINT32 callbackInvocations = 0;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    // Set custom TWCC feedback callback
+    auto twccCallback = [](UINT64 customData, PTwccFeedback pFeedback, UINT32 feedbackCount, PTwccCongestionState pState) -> STATUS {
+        UNUSED_PARAM(pFeedback);
+        UNUSED_PARAM(feedbackCount);
+        (*(PUINT32) customData)++;
+        pState->delayTrend = 0.0;
+        return STATUS_SUCCESS;
+    };
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &callbackInvocations, twccCallback));
+
+    // Send packets with seqNum 0..4
+    for (UINT16 i = 0; i < 5; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), i);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    // First: a valid TWCC report for baseSeqNum=0, count=2, all received
+    BYTE validPayload[20] = {0};
+    validPayload[0] = 0x44; validPayload[1] = 0x87; validPayload[2] = 0xA9; validPayload[3] = 0xE7;
+    validPayload[4] = 0x54; validPayload[5] = 0xB3; validPayload[6] = 0xE6; validPayload[7] = 0xFD;
+    validPayload[8] = 0x00; validPayload[9] = 0x00;  // baseSeqNum = 0
+    validPayload[10] = 0x00; validPayload[11] = 0x02; // packetStatusCount = 2
+    validPayload[12] = 0x14; validPayload[13] = 0x79; validPayload[14] = 0x72;
+    validPayload[15] = 0x00;
+    // Run-length chunk: status=1 (small delta), length=2
+    validPayload[16] = 0x20; validPayload[17] = 0x02;
+    // Two small deltas
+    validPayload[18] = 0xBC; validPayload[19] = 0x00;
+
+    rtcpPacket.header.packetLength = SIZEOF(validPayload) / 4;
+    rtcpPacket.header.packetType = RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK;
+    rtcpPacket.header.receptionReportCount = RTCP_FEEDBACK_MESSAGE_TYPE_APPLICATION_LAYER_FEEDBACK;
+    rtcpPacket.payload = validPayload;
+    rtcpPacket.payloadLength = SIZEOF(validPayload);
+
+    // Valid report should invoke the callback exactly once
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+    EXPECT_EQ(1u, callbackInvocations);
+
+    // Now: zero-count TWCC report with baseSeqNum=60000
+    BYTE emptyPayload[16] = {0};
+    emptyPayload[0] = 0x44; emptyPayload[1] = 0x87; emptyPayload[2] = 0xA9; emptyPayload[3] = 0xE7;
+    emptyPayload[4] = 0x54; emptyPayload[5] = 0xB3; emptyPayload[6] = 0xE6; emptyPayload[7] = 0xFD;
+    emptyPayload[8] = 0xEA; emptyPayload[9] = 0x60;  // baseSeqNum = 60000
+    emptyPayload[10] = 0x00; emptyPayload[11] = 0x00; // packetStatusCount = 0
+    emptyPayload[12] = 0x14; emptyPayload[13] = 0x7A; emptyPayload[14] = 0x00;
+    emptyPayload[15] = 0x02;
+
+    rtcpPacket.payload = emptyPayload;
+    rtcpPacket.payloadLength = SIZEOF(emptyPayload);
+    rtcpPacket.header.packetLength = SIZEOF(emptyPayload) / 4;
+
+    // Zero-count report should NOT invoke the callback again.
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+    EXPECT_EQ(1u, callbackInvocations);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+// Verify that a legitimate TWCC report spanning the UINT16 wraparound boundary
+// (e.g., seqNums 65534..1) works correctly and invokes the callback with proper data.
+TEST_F(RtcpFunctionalityTest, twccSeqNumWraparoundInvokesCallbackCorrectly)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtcpPacket rtcpPacket{};
+    RtpPacket rtpPacket{};
+    UINT32 extpayload;
+
+    struct CallbackCtx {
+        UINT32 invocations;
+        UINT32 feedbackCount;
+    } cbCtx = {0, 0};
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    // Custom callback that tracks invocations and feedbackCount
+    auto twccCallback = [](UINT64 customData, PTwccFeedback pFeedback, UINT32 feedbackCount, PTwccCongestionState pState) -> STATUS {
+        UNUSED_PARAM(pFeedback);
+        auto* ctx = (CallbackCtx*) customData;
+        ctx->invocations++;
+        ctx->feedbackCount = feedbackCount;
+        pState->delayTrend = 0.0;
+        return STATUS_SUCCESS;
+    };
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &cbCtx, twccCallback));
+
+    // Send packets with seqNums 65534, 65535, 0, 1 (wrapping around UINT16 boundary)
+    UINT16 seqNums[] = {65534, 65535, 0, 1};
+    for (int i = 0; i < 4; i++) {
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), seqNums[i]);
+        rtpPacket.header.extensionPayload = (PBYTE) &extpayload;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    // Craft a TWCC feedback packet: baseSeqNum=65534, packetStatusCount=4, all received
+    BYTE payload[22] = {0};
+    // SSRC fields (arbitrary)
+    payload[0] = 0x44; payload[1] = 0x87; payload[2] = 0xA9; payload[3] = 0xE7;
+    payload[4] = 0x54; payload[5] = 0xB3; payload[6] = 0xE6; payload[7] = 0xFD;
+    // baseSeqNum = 65534 (0xFFFE)
+    payload[8] = 0xFF; payload[9] = 0xFE;
+    // packetStatusCount = 4
+    payload[10] = 0x00; payload[11] = 0x04;
+    // referenceTime
+    payload[12] = 0x14; payload[13] = 0x79; payload[14] = 0x72;
+    // fb pkt count
+    payload[15] = 0x01;
+    // Run-length chunk: status=1 (small delta), length=4 -> 0x2004
+    payload[16] = 0x20; payload[17] = 0x04;
+    // Four small deltas (1 byte each): 10, 10, 10, 10
+    payload[18] = 0x0A; payload[19] = 0x0A; payload[20] = 0x0A; payload[21] = 0x0A;
+
+    rtcpPacket.header.packetLength = SIZEOF(payload) / 4;
+    rtcpPacket.header.packetType = RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK;
+    rtcpPacket.header.receptionReportCount = RTCP_FEEDBACK_MESSAGE_TYPE_APPLICATION_LAYER_FEEDBACK;
+    rtcpPacket.payload = payload;
+    rtcpPacket.payloadLength = SIZEOF(payload);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+
+    // Callback should have been invoked exactly once with all 4 packets reported
+    EXPECT_EQ(1u, cbCtx.invocations);
+    EXPECT_EQ(4u, cbCtx.feedbackCount);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Skip TWCC parsing and callback invocation when `packetStatusCount == 0` (empty report)
- Cap feedback list allocation size to packetStatusCount in the custom callback path

*Why was it changed?*
- There is no useful work to do for an empty TWCC report. No packet statuses to parse, no delay trends to compute, and no feedback to deliver to the application.
- Previously, an empty report would still enter the full parsing and callback path. Because `parseRtcpTwccPacket` doesn't update `lastReportedSeqNum` when there are zero packets to iterate, the downstream `reportLen` calculation in `onRtcpTwccPacket` operates on a stale value, producing an unnecessary heap allocation and invoking the callback with zero useful entries. Skipping early avoids this wasted work and the associated allocation overhead.

*How was it changed?*
- parseRtcpTwccPacket: Early-return STATUS_SUCCESS when packetStatusCount == 0. No chunks or deltas exist to parse in this case.
- onRtcpTwccPacket: In the custom `onTwccFeedbackReceived` callback path, skip if `packetStatusCount == 0` (nothing to report). Additionally, cap `reportLen` to `packetStatusCount` to tightly bound the allocation to the actual report size rather than the full sequence number range.

*What testing was done for the changes?*
  - Added three new tests in RtcpFunctionalityTest:
    - `twccZeroPacketStatusCountDoesNotInvokeCallback`: Verifies the callback is not invoked for a zero-count TWCC packet.
    - `twccZeroStatusCountAfterValidReportNoSpuriousCallback`: Verifies that after a valid report, a subsequent empty report does not spuriously invoke the callback.
    - `twccSeqNumWraparoundInvokesCallbackCorrectly`: Verifies that a legitimate report spanning the UINT16 wraparound boundary (seqNums 65534..1) correctly invokes the callback with all 4 reported packets, confirming the `reportLen` cap does not break valid wraparound behavior.
  - All 17 TWCC-related tests pass with zero regressions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
