### PR TITLE
Handle null parameter to parseExtId

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1372,14 +1372,19 @@ CleanUp:
 UINT32 parseExtId(PCHAR extmapValue)
 {
     ENTERS();
-    UINT32 extid = 0;
-    if (extmapValue == NULL || STRCHR(extmapValue, ' ') == NULL) {
-        LEAVES();
-        return 0;
-    }
-    if (STATUS_FAILED(STRTOUI32(extmapValue, STRCHR(extmapValue, ' '), 10, &extid))) {
-        LEAVES();
-        return 0;
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 extid;
+
+    CHK(extmapValue != NULL, STATUS_NULL_ARG);
+    CHK(STRCHR(extmapValue, ' ') != NULL, STATUS_INVALID_ARG);
+
+    CHK_STATUS(STRTOUI32(extmapValue, STRCHR(extmapValue, ' '), 10, &extid));
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+
+    if (STATUS_FAILED(retStatus)) {
+        extid = 0;
     }
 
     LEAVES();

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1373,7 +1373,7 @@ UINT32 parseExtId(PCHAR extmapValue)
 {
     ENTERS();
     UINT32 extid = 0;
-    if (extmapValue == NULL && STRCHR(extmapValue, ' ') == NULL) {
+    if (extmapValue == NULL || STRCHR(extmapValue, ' ') == NULL) {
         LEAVES();
         return 0;
     }

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -1536,6 +1536,19 @@ TEST_F(PeerConnectionFunctionalityTest, twccHeaderOnlyOnEnabledTransceivers)
     freePeerConnection(&answerPc);
 }
 
+TEST_F(PeerConnectionFunctionalityTest, parseExtIdHandlesNull)
+{
+    // NULL input must return 0
+    EXPECT_EQ(0u, parseExtId(NULL));
+
+    // String without a space should return 0
+    EXPECT_EQ(0u, parseExtId((PCHAR) "noSpace"));
+
+    // Valid extmap value: "$number $url"
+    EXPECT_EQ(5u, parseExtId((PCHAR) "5 http://example.com"));
+    EXPECT_EQ(12u, parseExtId((PCHAR) "12 urn:ietf:params"));
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fixed a logic bug in `parseExtId` where `&&` should have been `||`, causing a NULL pointer dereference. Note: this code path is unreachable since the input string is guaranteed to not be null.

*Why was it changed?*
  - The guard condition (`extmapValue == NULL && STRCHR(extmapValue, ' ') == NULL`) evaluates the second operand even when `extmapValue` is `NULL` because C short-circuits `&&` only when the left operand is false. Since the left operand is true when `NULL`, `STRCHR(NULL, ' ')` executes, which is undefined behavior.
  - The call site currently guarantees non-NULL since it only call `parseExtId` after a successful `STRSTR` match), so this is a latent defect, but any future caller passing `NULL` would crash.

*How was it changed?*
  - Changed `&&` to `||` in the `NULL`/space guard in `parseExtId`. Now if `extmapValue` is `NULL`, the function returns 0 immediately without evaluating `STRCHR`.

*What testing was done for the changes?*
- Added unit test to exercise this path
- It fails before the change, and passes after the change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
