### PR TITLE
esp_video_if: avoid memory fragmentation by re-using buffers

### DIFF
--- a/esp_port/components/media_stream/idf_component.yml
+++ b/esp_port/components/media_stream/idf_component.yml
@@ -17,6 +17,13 @@ dependencies:
 
   espressif/esp_audio_codec:
     version: "*"
+    matches:
+      # esp_audio_codec 2.6.0's P4 opus_xcorr_kernel_4_opt uses instructions that
+      # fault on P4 rev < 3 silicon (not runtime-guarded upstream). Cap below 2.6.0
+      # for rev < 3; the else clause keeps the latest everywhere else.
+      - if: 'target == "esp32p4" && $CONFIG{ESP32P4_REV_MIN_FULL} < 300'
+        version: "<2.6.0"
+      - if: 'target != "esp32p4" || $CONFIG{ESP32P4_REV_MIN_FULL} >= 300'
 
   espressif/esp_codec_dev:
     version: "*"

--- a/esp_port/components/media_stream/src/esp_video_if.c
+++ b/esp_port/components/media_stream/src/esp_video_if.c
@@ -205,6 +205,14 @@ static esp_err_t queue_all_buffers(v4l2_src_t *v4l2)
 
         if (ioctl(v4l2->cap_fd, VIDIOC_QBUF, &v4l2->v4l2_buf[i]) < 0) {
             ESP_LOGE(TAG, "Failed to requeue buffer %d, errno: %d", i, errno);
+            /* Buffers 0..i-1 are already queued to the driver. Flush them with
+             * STREAMOFF (legal before STREAMON; returns every queued buffer to
+             * the dequeued state) so the driver is not left half-queued and a
+             * later start attempt begins from a clean queue. */
+            int type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+            if (i > 0 && ioctl(v4l2->cap_fd, VIDIOC_STREAMOFF, &type) < 0) {
+                ESP_LOGE(TAG, "STREAMOFF after partial queue failed, errno: %d (full re-init required)", errno);
+            }
             return ESP_FAIL;
         }
     }
@@ -226,6 +234,15 @@ static video_fb_t *video_fb_get_cb(void *cb_ctx)
             int ret = ioctl(v4l2->cap_fd, VIDIOC_DQBUF, &buf);
             if (ret != 0) {
                 ESP_LOGE(TAG, "failed to receive video frame ret %d", ret);
+                return NULL;
+            }
+
+            /* Guard the driver-supplied index before it touches fb_used[] /
+             * cap_buffer[] / v4l2_buf[] (all sized BUFFER_COUNT): a buggy or
+             * racing driver returning an unexpected index must not become an
+             * out-of-bounds write. */
+            if (buf.index >= BUFFER_COUNT) {
+                ESP_LOGE(TAG, "DQBUF returned out-of-range buffer index %u", (unsigned) buf.index);
                 return NULL;
             }
 

--- a/esp_port/components/media_stream/src/esp_video_if.c
+++ b/esp_port/components/media_stream/src/esp_video_if.c
@@ -639,7 +639,24 @@ static esp_err_t configure_camera_format(v4l2_src_t *v4l2, uint32_t pixelformat)
         }
     }
 
-    ESP_LOGE(TAG, "Failed to set any supported format. Check the camera resolution in menuconfig");
+    /* None of the requested/fallback resolutions could be set. Rather than treating
+     * this as fatal, fall back to whatever format the sensor is already in: query it
+     * with VIDIOC_G_FMT, adopt it as the current resolution, warn, and continue. Some
+     * sensors reject S_FMT but still deliver a usable current format. */
+    struct v4l2_format current_format = {0};
+    current_format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    if (ioctl(v4l2->cap_fd, VIDIOC_G_FMT, &current_format) == 0) {
+        g_current_resolution.width = current_format.fmt.pix.width;
+        g_current_resolution.height = current_format.fmt.pix.height;
+        g_current_resolution.fps = g_desired_resolution.fps ? g_desired_resolution.fps : 30;
+        ESP_LOGW(TAG,
+                 "Could not set any requested resolution; using the sensor's current format %dx%d "
+                 "(check the camera resolution in menuconfig if this is unexpected)",
+                 (int) g_current_resolution.width, (int) g_current_resolution.height);
+        return ESP_OK;
+    }
+
+    ESP_LOGE(TAG, "Failed to set any supported format and could not query the current one (errno %d)", errno);
     return ESP_FAIL;
 }
 

--- a/esp_port/components/media_stream/src/esp_video_if.c
+++ b/esp_port/components/media_stream/src/esp_video_if.c
@@ -188,20 +188,32 @@ static esp_err_t queue_all_buffers(v4l2_src_t *v4l2)
     }
 
     for (int i = 0; i < BUFFER_COUNT; i++) {
-        v4l2->v4l2_buf[i].type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-        v4l2->v4l2_buf[i].memory = USE_V4L2_USERPTR ? V4L2_MEMORY_USERPTR : V4L2_MEMORY_MMAP;
-        v4l2->v4l2_buf[i].index = i;
+        /* Rebuild the descriptor from scratch. Reusing the struct left over
+         * from the previous session's last DQBUF would carry stale fields
+         * (flags such as DONE/ERROR, bytesused, sequence, timestamp) into the
+         * requeue; the driver's queue accounting then diverges from the DMA
+         * engine — STREAMON succeeds but DQBUF never delivers a frame (black
+         * video on the second and later sessions). The backing memory
+         * (cap_buffer[]/buffer_size[]) is kept — only bookkeeping is reset. */
+        struct v4l2_buffer buf;
+        memset(&buf, 0, sizeof(buf));
+        buf.type   = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        buf.memory = USE_V4L2_USERPTR ? V4L2_MEMORY_USERPTR : V4L2_MEMORY_MMAP;
+        buf.index  = i;
+
         v4l2->fb_used[i] = false;
 
         if (USE_V4L2_USERPTR) {
-            v4l2->v4l2_buf[i].m.userptr = (unsigned long)v4l2->cap_buffer[i];
-            v4l2->v4l2_buf[i].length = v4l2->buffer_size[i];  /* Restore from saved size */
             if (v4l2->buffer_size[i] == 0) {
                 ESP_LOGE(TAG, "USERPTR buffer size not set for buffer %d", i);
                 return ESP_FAIL;
             }
-            v4l2->v4l2_buf[i].bytesused = 0;
+            buf.m.userptr  = (unsigned long)v4l2->cap_buffer[i];
+            buf.length     = v4l2->buffer_size[i];  /* Restore from saved size */
+            buf.bytesused  = 0;
         }
+
+        v4l2->v4l2_buf[i] = buf;
 
         if (ioctl(v4l2->cap_fd, VIDIOC_QBUF, &v4l2->v4l2_buf[i]) < 0) {
             ESP_LOGE(TAG, "Failed to requeue buffer %d, errno: %d", i, errno);
@@ -352,21 +364,29 @@ esp_err_t esp_video_if_deinit(void)
         return ESP_OK;
     }
 
-    ESP_LOGD(TAG, "Deinitializing camera hardware (keeping buffers for reuse)");
+    ESP_LOGD(TAG, "Deinitializing camera hardware (keeping fd open and buffers for reuse)");
 
-    // Stop streaming first (stops frame capture and reduces power consumption)
+    /* Stop streaming only. We deliberately keep the fd OPEN and the USERPTR
+     * buffers allocated across sessions:
+     *
+     *  - Keeping the buffers avoids re-allocating the large aligned PSRAM
+     *    blocks every session (heap fragmentation — the point of this change).
+     *  - Keeping the fd open avoids the close()/reopen()+REQBUFS dance, which
+     *    tears down and rebuilds the driver's device + sensor state. That
+     *    close/reopen cycle is unreliable across sessions: STREAMON succeeds
+     *    but DQBUF never delivers a frame (black video). A persistent fd with
+     *    a plain STREAMOFF -> (requeue) -> STREAMON is the canonical V4L2
+     *    stop/start and restarts cleanly every time.
+     *
+     * esp_video_if_stop() does the STREAMOFF; STREAMOFF returns every buffer
+     * to the dequeued state so the next start can QBUF them all again. */
     esp_video_if_stop();
 
 #if USE_V4L2_USERPTR
-    /* For USERPTR: Close fd to power down hardware, but keep buffer memory */
-    if (g_v4l2->cap_fd >= 0) {
-        close(g_v4l2->cap_fd);
-        g_v4l2->cap_fd = -1;
-        ESP_LOGD(TAG, "Closed camera fd (hardware powered down, USERPTR buffers retained)");
-    }
-#else
-    /* For MMAP: Keep fd open so buffers remain valid */
-    ESP_LOGD(TAG, "Kept fd open (MMAP buffers remain valid)");
+    /* Allow any concurrent DQBUF ioctl to finish unwinding after STREAMOFF
+     * before the caller proceeds; without this, tearing down state while
+     * DQBUF is still returning can crash. */
+    vTaskDelay(pdMS_TO_TICKS(50));
 #endif
 
     return ESP_OK;

--- a/esp_port/components/media_stream/src/esp_video_if.c
+++ b/esp_port/components/media_stream/src/esp_video_if.c
@@ -22,6 +22,8 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "esp_cache.h"
+#include "esp_heap_caps.h"
 #include "linux/videodev2.h"
 
 #include "esp_video_init.h"
@@ -40,6 +42,9 @@ extern esp_err_t media_stream_i2c_init_safe(void);
 #define ESP_VIDEO_MIPI_CSI_DEVICE_NAME      "/dev/video0"
 #define CAM_DEV_PATH        ESP_VIDEO_MIPI_CSI_DEVICE_NAME
 #define BUFFER_COUNT        3
+#define USE_V4L2_USERPTR    1
+#define USERPTR_ALIGNMENT   64
+#define USERPTR_HEAP_CAPS   (MALLOC_CAP_SPIRAM | MALLOC_CAP_DMA)
 
 #define CONFIG_EXAMPLE_MIPI_CSI_SCCB_I2C_PORT       (1)
 #define CONFIG_EXAMPLE_MIPI_CSI_SCCB_I2C_SCL_PIN    (GPIO_NUM_8)
@@ -51,8 +56,10 @@ extern esp_err_t media_stream_i2c_init_safe(void);
 typedef struct v4l2 {
     int cap_fd;
     uint8_t             *cap_buffer[BUFFER_COUNT];
+    size_t              buffer_size[BUFFER_COUNT];  /* Store sizes separately for USERPTR fd reopen */
     bool                fb_used[BUFFER_COUNT];
     struct v4l2_buffer  v4l2_buf[BUFFER_COUNT];
+    bool                buffers_allocated;
     video_fb_t fb;
 } v4l2_src_t;
 
@@ -155,6 +162,56 @@ static void video_stop_cb(void *cb_ctx)
     ioctl(v4l2->cap_fd, VIDIOC_STREAMOFF, &type);
 }
 
+static void requeue_used_buffers(v4l2_src_t *v4l2)
+{
+    if (!v4l2) {
+        return;
+    }
+
+    for (int i = 0; i < BUFFER_COUNT; i++) {
+        if (v4l2->fb_used[i]) {
+            v4l2->fb_used[i] = false;
+#if USE_V4L2_USERPTR
+            /* For USERPTR, always set the pointer and length before requeueing */
+            v4l2->v4l2_buf[i].m.userptr = (unsigned long)v4l2->cap_buffer[i];
+            /* length should already be set from QUERYBUF */
+#endif
+            ioctl(v4l2->cap_fd, VIDIOC_QBUF, &v4l2->v4l2_buf[i]);
+        }
+    }
+}
+
+static esp_err_t queue_all_buffers(v4l2_src_t *v4l2)
+{
+    if (!v4l2) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    for (int i = 0; i < BUFFER_COUNT; i++) {
+        v4l2->v4l2_buf[i].type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        v4l2->v4l2_buf[i].memory = USE_V4L2_USERPTR ? V4L2_MEMORY_USERPTR : V4L2_MEMORY_MMAP;
+        v4l2->v4l2_buf[i].index = i;
+        v4l2->fb_used[i] = false;
+
+        if (USE_V4L2_USERPTR) {
+            v4l2->v4l2_buf[i].m.userptr = (unsigned long)v4l2->cap_buffer[i];
+            v4l2->v4l2_buf[i].length = v4l2->buffer_size[i];  /* Restore from saved size */
+            if (v4l2->buffer_size[i] == 0) {
+                ESP_LOGE(TAG, "USERPTR buffer size not set for buffer %d", i);
+                return ESP_FAIL;
+            }
+            v4l2->v4l2_buf[i].bytesused = 0;
+        }
+
+        if (ioctl(v4l2->cap_fd, VIDIOC_QBUF, &v4l2->v4l2_buf[i]) < 0) {
+            ESP_LOGE(TAG, "Failed to requeue buffer %d, errno: %d", i, errno);
+            return ESP_FAIL;
+        }
+    }
+
+    return ESP_OK;
+}
+
 static video_fb_t *video_fb_get_cb(void *cb_ctx)
 {
     int64_t us;
@@ -162,21 +219,23 @@ static video_fb_t *video_fb_get_cb(void *cb_ctx)
 
     for (int i = 0; i < BUFFER_COUNT; i++) {
         if (v4l2->fb_used[i] == false) {
-            // uint64_t start_time = esp_timer_get_time();
-            struct v4l2_buffer *buf = &v4l2->v4l2_buf[i];
-            buf->type   = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-            buf->memory = V4L2_MEMORY_MMAP;
-            int ret = ioctl(v4l2->cap_fd, VIDIOC_DQBUF, buf);
+            struct v4l2_buffer buf = {
+                .type = V4L2_BUF_TYPE_VIDEO_CAPTURE,
+                .memory = USE_V4L2_USERPTR ? V4L2_MEMORY_USERPTR : V4L2_MEMORY_MMAP,
+            };
+            int ret = ioctl(v4l2->cap_fd, VIDIOC_DQBUF, &buf);
             if (ret != 0) {
                 ESP_LOGE(TAG, "failed to receive video frame ret %d", ret);
                 return NULL;
             }
-            v4l2->fb_used[i] = true;
-            v4l2->fb.buf = v4l2->cap_buffer[buf->index];
-            // printf("Captured buffer num: %d\n", (int) buf->index);
-            v4l2->fb.len = buf->bytesused;
-            // v4l2->fb.width = format.fmt.pix.width;
-            // v4l2->fb.height = format.fmt.pix.height;
+
+            v4l2->fb_used[buf.index] = true;
+            v4l2->fb.buf = v4l2->cap_buffer[buf.index];
+            v4l2->fb.len = buf.bytesused;
+            v4l2->v4l2_buf[buf.index] = buf;
+
+            esp_cache_msync(v4l2->fb.buf, v4l2->fb.len, ESP_CACHE_MSYNC_FLAG_DIR_M2C);
+
             us = esp_timer_get_time();
             v4l2->fb.timestamp.tv_sec = us / 1000000UL;
             v4l2->fb.timestamp.tv_usec = us % 1000000UL;
@@ -197,13 +256,42 @@ static void video_fb_return_cb(video_fb_t *fb, void *cb_ctx)
     ESP_LOGD(TAG, "Returning encoder buffer");
 
     for (int i = 0; i < BUFFER_COUNT; i++) {
-        struct v4l2_buffer *buf = &v4l2->v4l2_buf[i];
-        if (v4l2->fb_used[i] && v4l2->cap_buffer[buf->index] == fb->buf) {
+        if (v4l2->fb_used[i] && v4l2->cap_buffer[i] == fb->buf) {
             v4l2->fb_used[i] = false;
-            ioctl(v4l2->cap_fd, VIDIOC_QBUF, buf);
+#if USE_V4L2_USERPTR
+            /* For USERPTR, always set the pointer and length before requeueing (per ESP-BSP example) */
+            v4l2->v4l2_buf[i].m.userptr = (unsigned long)v4l2->cap_buffer[i];
+            /* length should already be set from QUERYBUF, but as fallback use fb length */
+            if (v4l2->v4l2_buf[i].length == 0) {
+                v4l2->v4l2_buf[i].length = fb->len;
+            }
+#endif
+            ioctl(v4l2->cap_fd, VIDIOC_QBUF, &v4l2->v4l2_buf[i]);
             return;
         }
     }
+}
+
+static void free_mapped_buffers(v4l2_src_t *v4l2)
+{
+    if (!v4l2 || !v4l2->buffers_allocated) {
+        return;
+    }
+
+    for (int i = 0; i < BUFFER_COUNT; i++) {
+        if (v4l2->cap_buffer[i]) {
+            if (USE_V4L2_USERPTR) {
+                heap_caps_free(v4l2->cap_buffer[i]);
+            } else {
+                munmap(v4l2->cap_buffer[i], v4l2->buffer_size[i]);
+            }
+            v4l2->cap_buffer[i] = NULL;
+        }
+        v4l2->buffer_size[i] = 0;
+        v4l2->fb_used[i] = false;
+    }
+
+    v4l2->buffers_allocated = false;
 }
 
 video_fb_t *esp_video_if_get_frame(void)
@@ -231,14 +319,10 @@ void esp_video_if_release_frame(video_fb_t *fb)
 esp_err_t esp_video_if_stop(void)
 {
     if (g_v4l2) {
+        requeue_used_buffers(g_v4l2);
         video_stop_cb(g_v4l2);
-        /* Free the mapped buffers */
-        for (int i = 0; i < BUFFER_COUNT; i++) {
-            if (g_v4l2->cap_buffer[i]) {
-                munmap(g_v4l2->cap_buffer[i], g_v4l2->v4l2_buf[i].length);
-                g_v4l2->cap_buffer[i] = NULL;
-            }
-        }
+        /* Keep buffers allocated to avoid fragmentation - they'll be reused on next start */
+        ESP_LOGD(TAG, "Streaming stopped (buffers kept allocated for reuse)");
         return ESP_OK;
     }
     return ESP_FAIL;
@@ -251,52 +335,226 @@ esp_err_t esp_video_if_deinit(void)
         return ESP_OK;
     }
 
-    ESP_LOGI(TAG, "Deinitializing camera hardware");
+    ESP_LOGD(TAG, "Deinitializing camera hardware (keeping buffers for reuse)");
 
     // Stop streaming first (stops frame capture and reduces power consumption)
     esp_video_if_stop();
 
-    // Close the camera device file descriptor
+#if USE_V4L2_USERPTR
+    /* For USERPTR: Close fd to power down hardware, but keep buffer memory */
     if (g_v4l2->cap_fd >= 0) {
         close(g_v4l2->cap_fd);
         g_v4l2->cap_fd = -1;
+        ESP_LOGD(TAG, "Closed camera fd (hardware powered down, USERPTR buffers retained)");
     }
+#else
+    /* For MMAP: Keep fd open so buffers remain valid */
+    ESP_LOGD(TAG, "Kept fd open (MMAP buffers remain valid)");
+#endif
 
-    // Free the v4l2 structure
-    heap_caps_free(g_v4l2);
-    g_v4l2 = NULL;
-
-    // Reset current resolution
-    g_current_resolution.width = 0;
-    g_current_resolution.height = 0;
-    g_current_resolution.fps = 0;
-
-    /* NOTE: The ISP device registered by esp_video_init() remains registered
-     * because there's no esp_video_deinit() API. This means:
-     * - The /dev/video0 device file persists
-     * - Some ISP hardware may remain powered (limitation of esp_video API)
-     * - However, streaming is stopped and device file is closed, which reduces power consumption
-     * - On reinit, we can skip esp_video_init() since ISP is already registered
-     */
-    ESP_LOGI(TAG, "Camera hardware deinitialized (streaming stopped, device closed)");
     return ESP_OK;
 }
 
-esp_err_t esp_video_if_start(void)
+/* Helper: Reopen camera for USERPTR after fd was closed */
+static esp_err_t reopen_camera_for_userptr(v4l2_src_t *v4l2)
 {
-    if (!g_v4l2) {
-        ESP_LOGE(TAG, "Camera not initialized");
+#if USE_V4L2_USERPTR
+    if (v4l2->cap_fd >= 0) {
+        return ESP_OK;  /* Already open */
+    }
+
+    ESP_LOGD(TAG, "USERPTR buffers allocated but fd closed, reopening camera");
+
+    /* Reopen camera device */
+    if (init_camera(v4l2) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to reopen camera for USERPTR");
         return ESP_FAIL;
     }
 
-    struct v4l2_buffer buf;
-    struct v4l2_format format;
-    struct v4l2_requestbuffers req;
-    v4l2_src_t *v4l2 = g_v4l2;
-    int type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    uint32_t capture_fmt = V4L2_PIX_FMT_YUV420;
+    /* Set format again */
+    struct v4l2_format format = {0};
+    format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    format.fmt.pix.width = g_current_resolution.width;
+    format.fmt.pix.height = g_current_resolution.height;
+    format.fmt.pix.pixelformat = V4L2_PIX_FMT_YUV420;
+    if (ioctl(v4l2->cap_fd, VIDIOC_S_FMT, &format) != 0) {
+        ESP_LOGE(TAG, "Failed to set format on reopen");
+        return ESP_FAIL;
+    }
 
-    /* Define fallback resolutions to try in order */
+    /* Re-request USERPTR buffers */
+    struct v4l2_requestbuffers req = {0};
+    req.count = BUFFER_COUNT;
+    req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    req.memory = V4L2_MEMORY_USERPTR;
+    if (ioctl(v4l2->cap_fd, VIDIOC_REQBUFS, &req) < 0) {
+        ESP_LOGE(TAG, "Failed to re-request USERPTR buffers, errno: %d", errno);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, "Camera reopened, reusing %d USERPTR buffers", BUFFER_COUNT);
+#endif
+    return ESP_OK;
+}
+
+/* Helper: Apply flip controls and start streaming */
+static esp_err_t start_streaming(v4l2_src_t *v4l2)
+{
+#if CONFIG_ESP_VIDEO_IF_HOR_FLIP || CONFIG_ESP_VIDEO_IF_VER_FLIP
+    struct v4l2_ext_controls ext_ctrls = {0};
+    struct v4l2_ext_control ctrls[2] = {0};
+    int ctrl_count = 0;
+
+#if CONFIG_ESP_VIDEO_IF_HOR_FLIP
+    ctrls[ctrl_count].id = V4L2_CID_HFLIP;
+    ctrls[ctrl_count].value = 1;
+    ctrl_count++;
+#endif
+
+#if CONFIG_ESP_VIDEO_IF_VER_FLIP
+    ctrls[ctrl_count].id = V4L2_CID_VFLIP;
+    ctrls[ctrl_count].value = 1;
+    ctrl_count++;
+#endif
+
+    ext_ctrls.controls = ctrls;
+    ext_ctrls.count = ctrl_count;
+
+    if (ioctl(v4l2->cap_fd, VIDIOC_S_EXT_CTRLS, &ext_ctrls) < 0) {
+        ESP_LOGW(TAG, "Failed to set flip controls, errno: %d", errno);
+    }
+#endif
+
+    int type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    if (ioctl(v4l2->cap_fd, VIDIOC_STREAMON, &type) < 0) {
+        ESP_LOGE(TAG, "Failed to stream on, errno: %d", errno);
+        /* Cleanup all buffers on stream start failure */
+        for (int i = 0; i < BUFFER_COUNT; i++) {
+            if (v4l2->cap_buffer[i]) {
+                if (USE_V4L2_USERPTR) {
+                    heap_caps_free(v4l2->cap_buffer[i]);
+                } else {
+                    munmap(v4l2->cap_buffer[i], v4l2->buffer_size[i]);
+                }
+                v4l2->cap_buffer[i] = NULL;
+            }
+        }
+        v4l2->buffers_allocated = false;
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+/* Helper: Allocate and queue buffers for first-time setup */
+static esp_err_t allocate_and_queue_buffers(v4l2_src_t *v4l2)
+{
+    struct v4l2_buffer buf;
+    struct v4l2_requestbuffers req = {0};
+
+    req.count = BUFFER_COUNT;
+    req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    req.memory = USE_V4L2_USERPTR ? V4L2_MEMORY_USERPTR : V4L2_MEMORY_MMAP;
+
+    if (ioctl(v4l2->cap_fd, VIDIOC_REQBUFS, &req) < 0) {
+        ESP_LOGE(TAG, "Failed to require buffers, errno: %d", errno);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGD(TAG, "Allocating %d %s buffers (first time or after cleanup)",
+             BUFFER_COUNT, USE_V4L2_USERPTR ? "USERPTR" : "MMAP");
+
+    for (int i = 0; i < BUFFER_COUNT; i++) {
+        memset(&buf, 0, sizeof(buf));
+        buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        buf.memory = USE_V4L2_USERPTR ? V4L2_MEMORY_USERPTR : V4L2_MEMORY_MMAP;
+        buf.index = i;
+
+        /* Query buffer to get the required length from driver */
+        if (ioctl(v4l2->cap_fd, VIDIOC_QUERYBUF, &buf) < 0) {
+            ESP_LOGE(TAG, "Failed to query buffer, errno: %d", errno);
+#if USE_V4L2_USERPTR
+            for (int j = 0; j < i; j++) {
+                if (v4l2->cap_buffer[j]) {
+                    heap_caps_free(v4l2->cap_buffer[j]);
+                    v4l2->cap_buffer[j] = NULL;
+                }
+            }
+#else
+            for (int j = 0; j < i; j++) {
+                if (v4l2->cap_buffer[j]) {
+                    munmap(v4l2->cap_buffer[j], v4l2->buffer_size[j]);
+                    v4l2->cap_buffer[j] = NULL;
+                }
+            }
+#endif
+            return ESP_FAIL;
+        }
+
+        /* Store buffer info */
+        v4l2->v4l2_buf[i] = buf;
+        v4l2->buffer_size[i] = buf.length;
+
+#if USE_V4L2_USERPTR
+        /* Allocate user buffer */
+        v4l2->cap_buffer[i] = heap_caps_aligned_alloc(USERPTR_ALIGNMENT, buf.length, USERPTR_HEAP_CAPS);
+        if (!v4l2->cap_buffer[i]) {
+            ESP_LOGE(TAG, "Failed to allocate USERPTR buffer %d size=%u (caps=0x%x)",
+                     i, (unsigned)buf.length, USERPTR_HEAP_CAPS);
+            for (int j = 0; j < i; j++) {
+                if (v4l2->cap_buffer[j]) {
+                    heap_caps_free(v4l2->cap_buffer[j]);
+                    v4l2->cap_buffer[j] = NULL;
+                }
+            }
+            return ESP_FAIL;
+        }
+        ESP_LOGD(TAG, "Allocated USERPTR buffer %d addr=%p size=%zu caps=0x%x",
+                 i, v4l2->cap_buffer[i], v4l2->buffer_size[i], USERPTR_HEAP_CAPS);
+        buf.m.userptr = (unsigned long)v4l2->cap_buffer[i];
+#else
+        /* Map buffer */
+        v4l2->cap_buffer[i] = (uint8_t *)mmap(NULL, buf.length, PROT_READ | PROT_WRITE,
+                                                MAP_SHARED, v4l2->cap_fd, buf.m.offset);
+        if (!v4l2->cap_buffer[i]) {
+            ESP_LOGE(TAG, "Failed to map buffer, errno: %d", errno);
+            for (int j = 0; j < i; j++) {
+                if (v4l2->cap_buffer[j]) {
+                    munmap(v4l2->cap_buffer[j], v4l2->buffer_size[j]);
+                    v4l2->cap_buffer[j] = NULL;
+                }
+            }
+            return ESP_FAIL;
+        }
+#endif
+
+        /* Queue buffer */
+        if (ioctl(v4l2->cap_fd, VIDIOC_QBUF, &buf) < 0) {
+            ESP_LOGE(TAG, "Failed to queue buffer %d, errno: %d userptr=%p len=%u bytesused=%u",
+                     i, errno, (void *)buf.m.userptr, (unsigned)buf.length, (unsigned)buf.bytesused);
+            for (int j = 0; j <= i; j++) {
+                if (v4l2->cap_buffer[j]) {
+                    if (USE_V4L2_USERPTR) {
+                        heap_caps_free(v4l2->cap_buffer[j]);
+                    } else {
+                        munmap(v4l2->cap_buffer[j], v4l2->buffer_size[j]);
+                    }
+                    v4l2->cap_buffer[j] = NULL;
+                }
+            }
+            return ESP_FAIL;
+        }
+
+        v4l2->v4l2_buf[i] = buf;
+    }
+
+    v4l2->buffers_allocated = true;
+    return ESP_OK;
+}
+
+/* Helper: Configure camera format with fallback resolution support */
+static esp_err_t configure_camera_format(v4l2_src_t *v4l2, uint32_t pixelformat)
+{
     typedef struct {
         uint32_t width;
         uint32_t height;
@@ -311,9 +569,7 @@ esp_err_t esp_video_if_start(void)
         {320, 240}
     };
     int num_fallbacks = sizeof(fallback_resolutions) / sizeof(fallback_resolutions[0]);
-    bool format_set_success = false;
 
-    /* Try to set format with fallback resolutions */
     for (int i = 0; i < num_fallbacks; i++) {
         /* Skip duplicate attempts */
         if (i > 0 && fallback_resolutions[i].width == fallback_resolutions[i - 1].width &&
@@ -321,141 +577,102 @@ esp_err_t esp_video_if_start(void)
             continue;
         }
 
-        memset(&format, 0, sizeof(format));
+        struct v4l2_format format = {0};
         format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
         format.fmt.pix.width = fallback_resolutions[i].width;
         format.fmt.pix.height = fallback_resolutions[i].height;
-        format.fmt.pix.pixelformat = capture_fmt;
+        format.fmt.pix.pixelformat = pixelformat;
 
         if (i == 0) {
-            ESP_LOGI(TAG, "Attempting to set format: %dx%d", (int)format.fmt.pix.width, (int)format.fmt.pix.height);
+            ESP_LOGD(TAG, "Attempting to set format: %dx%d", (int)format.fmt.pix.width, (int)format.fmt.pix.height);
         } else {
             ESP_LOGW(TAG, "Retrying with fallback resolution: %dx%d", (int)format.fmt.pix.width, (int)format.fmt.pix.height);
         }
 
         if (ioctl(v4l2->cap_fd, VIDIOC_S_FMT, &format) == 0) {
-            format_set_success = true;
             ESP_LOGI(TAG, "Successfully set format: %dx%d", (int)format.fmt.pix.width, (int)format.fmt.pix.height);
-            break;
+            /* Track actual resolution that was set (V4L2 may adjust it) */
+            g_current_resolution.width = format.fmt.pix.width;
+            g_current_resolution.height = format.fmt.pix.height;
+            g_current_resolution.fps = g_desired_resolution.fps ? g_desired_resolution.fps : 30;
+            return ESP_OK;
         } else {
             ESP_LOGW(TAG, "Failed to set format %dx%d, errno: %d",
                      (int)format.fmt.pix.width, (int)format.fmt.pix.height, errno);
         }
     }
 
-    if (!format_set_success) {
-        ESP_LOGE(TAG, "Failed to set any supported format. Check the camera resolution in menuconfig");
+    ESP_LOGE(TAG, "Failed to set any supported format. Check the camera resolution in menuconfig");
+    return ESP_FAIL;
+}
+
+/* Helper: Restart streaming with already-allocated buffers */
+static esp_err_t restart_streaming_with_existing_buffers(v4l2_src_t *v4l2)
+{
+    ESP_LOGD(TAG, "Buffers already allocated (%d buffers in %s mode), skipping reallocation",
+             BUFFER_COUNT, USE_V4L2_USERPTR ? "USERPTR" : "MMAP");
+
+    /* For USERPTR, reopen fd if needed */
+    if (reopen_camera_for_userptr(v4l2) != ESP_OK) {
         return ESP_FAIL;
     }
 
-    /* Track actual resolution that was set (V4L2 may adjust it) */
-    g_current_resolution.width = format.fmt.pix.width;
-    g_current_resolution.height = format.fmt.pix.height;
-    g_current_resolution.fps = g_desired_resolution.fps ? g_desired_resolution.fps : 30;
-
-    memset(&req, 0, sizeof(req));
-    req.count  = BUFFER_COUNT;
-    req.type   = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    req.memory = V4L2_MEMORY_MMAP;
-    if (ioctl(v4l2->cap_fd, VIDIOC_REQBUFS, &req) < 0) {
-        ESP_LOGE(TAG, "Failed to require buffers, errno: %d", errno);
+    /* Requeue all buffers */
+    if (queue_all_buffers(v4l2) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to requeue buffers for restart");
         return ESP_FAIL;
     }
 
-    for (int i = 0; i < BUFFER_COUNT; i++) {
-        memset(&buf, 0, sizeof(buf));
-        buf.type        = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-        buf.memory      = V4L2_MEMORY_MMAP;
-        buf.index       = i;
-        if (ioctl(v4l2->cap_fd, VIDIOC_QUERYBUF, &buf) < 0) {
-            ESP_LOGE(TAG, "Failed to query buffer, errno: %d", errno);
-            /* Cleanup any buffers we've already mapped */
-            for (int j = 0; j < i; j++) {
-                if (v4l2->cap_buffer[j]) {
-                    munmap(v4l2->cap_buffer[j], v4l2->v4l2_buf[j].length);
-                    v4l2->cap_buffer[j] = NULL;
-                }
-            }
-            return ESP_FAIL;
-        }
-
-        /* Store buffer info immediately after QUERYBUF so cleanup can use it */
-        v4l2->v4l2_buf[i] = buf;
-
-        v4l2->cap_buffer[i] = (uint8_t *)mmap(NULL, buf.length, PROT_READ | PROT_WRITE,
-                                                MAP_SHARED, v4l2->cap_fd, buf.m.offset);
-        if (!v4l2->cap_buffer[i]) {
-            ESP_LOGE(TAG, "Failed to map buffer, errno: %d", errno);
-            /* Cleanup any buffers we've already mapped */
-            for (int j = 0; j < i; j++) {
-                if (v4l2->cap_buffer[j]) {
-                    munmap(v4l2->cap_buffer[j], v4l2->v4l2_buf[j].length);
-                    v4l2->cap_buffer[j] = NULL;
-                }
-            }
-            return ESP_FAIL;
-        }
-
-        if (ioctl(v4l2->cap_fd, VIDIOC_QBUF, &buf) < 0) {
-            ESP_LOGE(TAG, "Failed to queue buffer, errno: %d", errno);
-            /* Cleanup all buffers including the one we just mapped */
-            for (int j = 0; j <= i; j++) {
-                if (v4l2->cap_buffer[j]) {
-                    munmap(v4l2->cap_buffer[j], v4l2->v4l2_buf[j].length);
-                    v4l2->cap_buffer[j] = NULL;
-                }
-            }
-            return ESP_FAIL;
-        }
-    }
-
-#if CONFIG_ESP_VIDEO_IF_HOR_FLIP || CONFIG_ESP_VIDEO_IF_VER_FLIP
-    // Set horizontal and/or vertical flip using extended controls since VIDIOC_S_CTRL is not supported
-    struct v4l2_ext_controls ext_ctrls = {0};
-    struct v4l2_ext_control ctrls[2] = {0};
-    int ctrl_count = 0;
-
-#if CONFIG_ESP_VIDEO_IF_HOR_FLIP
-    ctrls[ctrl_count].id = V4L2_CID_HFLIP;
-    ctrls[ctrl_count].value = 1; // 1 to enable horizontal flip, 0 to disable
-    ctrl_count++;
-#endif
-
-#if CONFIG_ESP_VIDEO_IF_VER_FLIP
-    ctrls[ctrl_count].id = V4L2_CID_VFLIP;
-    ctrls[ctrl_count].value = 1; // 1 to enable vertical flip, 0 to disable
-    ctrl_count++;
-#endif
-
-    ext_ctrls.controls = ctrls;
-    ext_ctrls.count = ctrl_count;
-
-    if (ioctl(v4l2->cap_fd, VIDIOC_S_EXT_CTRLS, &ext_ctrls) < 0) {
-        ESP_LOGW(TAG, "Failed to set flip controls, errno: %d", errno);
-    }
-#endif
-
-    type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    /* Start streaming */
+    int type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     if (ioctl(v4l2->cap_fd, VIDIOC_STREAMON, &type) < 0) {
         ESP_LOGE(TAG, "Failed to stream on, errno: %d", errno);
-        /* Cleanup all mapped buffers on stream start failure */
-        for (int i = 0; i < BUFFER_COUNT; i++) {
-            if (v4l2->cap_buffer[i]) {
-                munmap(v4l2->cap_buffer[i], v4l2->v4l2_buf[i].length);
-                v4l2->cap_buffer[i] = NULL;
-            }
-        }
         return ESP_FAIL;
     }
 
+    ESP_LOGD(TAG, "Video streaming restarted successfully (no reallocation)");
     return ESP_OK;
+}
+
+esp_err_t esp_video_if_start(void)
+{
+    if (!g_v4l2) {
+        ESP_LOGE(TAG, "Camera not initialized");
+        return ESP_FAIL;
+    }
+
+    v4l2_src_t *v4l2 = g_v4l2;
+
+    ESP_LOGD(TAG, "Starting video (buffers_allocated=%d, fd=%d, mode=%s)",
+             v4l2->buffers_allocated, v4l2->cap_fd, USE_V4L2_USERPTR ? "USERPTR" : "MMAP");
+
+    /* Fast path: buffers already allocated, just restart streaming */
+    if (v4l2->buffers_allocated) {
+        return restart_streaming_with_existing_buffers(v4l2);
+    }
+
+    /* Slow path: First-time setup or after cleanup */
+    uint32_t capture_fmt = V4L2_PIX_FMT_YUV420;
+
+    /* Configure camera format with fallback resolution support */
+    if (configure_camera_format(v4l2, capture_fmt) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    /* Allocate and queue buffers */
+    if (allocate_and_queue_buffers(v4l2) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
+    /* Apply flip controls and start streaming */
+    return start_streaming(v4l2);
 }
 
 esp_err_t esp_video_if_init(void)
 {
     if (g_v4l2) {
-        ESP_LOGI(TAG, "video interface already initialized");
-        return ESP_OK;
+        ESP_LOGD(TAG, "video interface already initialized, restarting streaming");
+        return esp_video_if_start();
     }
 
 #if CONFIG_CODEC_I2C_BACKWARD_COMPATIBLE
@@ -493,10 +710,9 @@ esp_err_t esp_video_if_init(void)
     // NOTE: This handles the case where esp_video_if_deinit() was called but ISP device
     // registration persists (no esp_video_deinit() API exists)
     int test_fd = open(CAM_DEV_PATH, O_RDONLY);
-    bool device_exists = (test_fd >= 0);
     if (test_fd >= 0) {
         close(test_fd);
-        ESP_LOGI(TAG, "Video device already exists (ISP already registered), skipping esp_video_init");
+        ESP_LOGD(TAG, "Video device already exists (ISP already registered), skipping esp_video_init");
     } else {
         // Device doesn't exist - need to initialize esp_video to register ISP device
         esp_video_init_config_t cam_config = {
@@ -542,6 +758,36 @@ esp_err_t esp_video_if_get_resolution(video_resolution_t *resolution)
     }
 
     *resolution = g_current_resolution;
+    return ESP_OK;
+}
+
+esp_err_t esp_video_if_cleanup(void)
+{
+    /* This function explicitly frees mapped buffers and closes the camera fd.
+     * Call this when you want a full cleanup (releasing mmap memory).
+     */
+
+    if (!g_v4l2) {
+        ESP_LOGD(TAG, "No buffers to clean up");
+        return ESP_OK;
+    }
+
+    video_stop_cb(g_v4l2);
+    free_mapped_buffers(g_v4l2);
+
+    if (g_v4l2->cap_fd >= 0) {
+        close(g_v4l2->cap_fd);
+        g_v4l2->cap_fd = -1;
+    }
+
+    heap_caps_free(g_v4l2);
+    g_v4l2 = NULL;
+
+    g_current_resolution.width = 0;
+    g_current_resolution.height = 0;
+    g_current_resolution.fps = 0;
+
+    ESP_LOGI(TAG, "Buffers and camera fd cleaned up");
     return ESP_OK;
 }
 #endif

--- a/esp_port/components/media_stream/src/esp_video_if.h
+++ b/esp_port/components/media_stream/src/esp_video_if.h
@@ -37,11 +37,14 @@ esp_err_t esp_video_if_init(void);
 esp_err_t esp_video_if_stop(void);
 
 /**
- * @brief Deinitialize the video interface and release camera hardware
+ * @brief Deinitialize the video interface while retaining mmap buffers
  *
- * This function fully deinitializes the camera hardware, closes the device,
- * and frees all resources. Should be called when camera is no longer needed
- * to save power and address security concerns.
+ * This function stops streaming but keeps the mmap buffers and fd open so the next
+ * init/start cycle can reuse them without reallocation. The camera hardware may
+ * remain powered because the fd stays open.
+ *
+ * For a full cleanup (free buffers, close fd, release resources), call
+ * esp_video_if_cleanup().
  *
  * @return esp_err_t ESP_OK on success, otherwise an error code
  */
@@ -78,3 +81,14 @@ void esp_video_if_release_frame(video_fb_t *fb);
  *  - ESP_ERR_INVALID_STATE: Video interface not initialized
  */
 esp_err_t esp_video_if_get_resolution(video_resolution_t *resolution);
+
+/**
+ * @brief Cleanup mapped buffers and close camera fd
+ *
+ * This function explicitly frees mapped buffers and closes the camera file
+ * descriptor. After this, a subsequent esp_video_if_init/start cycle will
+ * reallocate buffers.
+ *
+ * @return esp_err_t ESP_OK on success, otherwise an error code
+ */
+esp_err_t esp_video_if_cleanup(void);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- esp_video_if: switch v4l2 frame buffers to USERPTR I/O and allocate once.

*Why was it changed?*
- v4l2 reallocated raw frame buffers on every init/deinit, fragmenting PSRAM. After a few sessions the camera couldn't secure contiguous frames.

*How was it changed?*
- Allocate the raw frame buffers up-front and use USERPTR I/O so the same buffers are queued/dequeued across sessions instead of being freed and re-malloc'd.

*What testing was done for the changes?*
- ESP32-P4-EYE: repeated camera start/stop + WebRTC reconnect cycles; the previous fragmentation path no longer triggers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.