### PR TITLE
Add bounds check for data channel name/label copy in onSctpSessionDat…

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -641,27 +641,21 @@ VOID onSctpSessionDataChannelOpen(UINT64 customData, UINT32 channelId, PBYTE pNa
     STATUS retStatus = STATUS_SUCCESS;
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) customData;
     PKvsDataChannel pKvsDataChannel = NULL;
-    UINT32 copyLen = 0;
 
     CHK(pKvsPeerConnection != NULL && pKvsPeerConnection->onDataChannel != NULL, STATUS_NULL_ARG);
+    CHK(nameLen <= MAX_DATA_CHANNEL_NAME_LEN, STATUS_INVALID_ARG);
 
     pKvsDataChannel = (PKvsDataChannel) MEMCALLOC(1, SIZEOF(KvsDataChannel));
     CHK(pKvsDataChannel != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
-    // Cap copy length to destination buffer size to prevent heap overflow
-    copyLen = MIN(nameLen, MAX_DATA_CHANNEL_NAME_LEN);
-    STRNCPY(pKvsDataChannel->dataChannel.name, (PCHAR) pName, copyLen);
-    pKvsDataChannel->dataChannel.name[copyLen] = '\0';
+    STRNCPY(pKvsDataChannel->dataChannel.name, (PCHAR) pName, nameLen);
     pKvsDataChannel->dataChannel.id = channelId;
     pKvsDataChannel->pRtcPeerConnection = (PRtcPeerConnection) pKvsPeerConnection;
     pKvsDataChannel->channelId = channelId;
 
-    // Set the data channel parameters when data channel is created by peer
     pKvsDataChannel->rtcDataChannelDiagnostics.dataChannelIdentifier = channelId;
     pKvsDataChannel->rtcDataChannelDiagnostics.state = RTC_DATA_CHANNEL_STATE_OPEN;
-    copyLen = MIN(nameLen, MAX_STATS_STRING_LENGTH);
-    STRNCPY(pKvsDataChannel->rtcDataChannelDiagnostics.label, (PCHAR) pName, copyLen);
-    pKvsDataChannel->rtcDataChannelDiagnostics.label[copyLen] = '\0';
+    STRNCPY(pKvsDataChannel->rtcDataChannelDiagnostics.label, (PCHAR) pName, nameLen);
     CHK_STATUS(hashTablePut(pKvsPeerConnection->pDataChannels, channelId, (UINT64) pKvsDataChannel));
     pKvsPeerConnection->onDataChannel(pKvsPeerConnection->onDataChannelCustomData, &(pKvsDataChannel->dataChannel));
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -641,13 +641,17 @@ VOID onSctpSessionDataChannelOpen(UINT64 customData, UINT32 channelId, PBYTE pNa
     STATUS retStatus = STATUS_SUCCESS;
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) customData;
     PKvsDataChannel pKvsDataChannel = NULL;
+    UINT32 copyLen = 0;
 
     CHK(pKvsPeerConnection != NULL && pKvsPeerConnection->onDataChannel != NULL, STATUS_NULL_ARG);
 
     pKvsDataChannel = (PKvsDataChannel) MEMCALLOC(1, SIZEOF(KvsDataChannel));
     CHK(pKvsDataChannel != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
-    STRNCPY(pKvsDataChannel->dataChannel.name, (PCHAR) pName, nameLen);
+    // Cap copy length to destination buffer size to prevent heap overflow
+    copyLen = MIN(nameLen, MAX_DATA_CHANNEL_NAME_LEN);
+    STRNCPY(pKvsDataChannel->dataChannel.name, (PCHAR) pName, copyLen);
+    pKvsDataChannel->dataChannel.name[copyLen] = '\0';
     pKvsDataChannel->dataChannel.id = channelId;
     pKvsDataChannel->pRtcPeerConnection = (PRtcPeerConnection) pKvsPeerConnection;
     pKvsDataChannel->channelId = channelId;
@@ -655,11 +659,16 @@ VOID onSctpSessionDataChannelOpen(UINT64 customData, UINT32 channelId, PBYTE pNa
     // Set the data channel parameters when data channel is created by peer
     pKvsDataChannel->rtcDataChannelDiagnostics.dataChannelIdentifier = channelId;
     pKvsDataChannel->rtcDataChannelDiagnostics.state = RTC_DATA_CHANNEL_STATE_OPEN;
-    STRNCPY(pKvsDataChannel->rtcDataChannelDiagnostics.label, (PCHAR) pName, nameLen);
+    copyLen = MIN(nameLen, MAX_STATS_STRING_LENGTH);
+    STRNCPY(pKvsDataChannel->rtcDataChannelDiagnostics.label, (PCHAR) pName, copyLen);
+    pKvsDataChannel->rtcDataChannelDiagnostics.label[copyLen] = '\0';
     CHK_STATUS(hashTablePut(pKvsPeerConnection->pDataChannels, channelId, (UINT64) pKvsDataChannel));
     pKvsPeerConnection->onDataChannel(pKvsPeerConnection->onDataChannelCustomData, &(pKvsDataChannel->dataChannel));
 
 CleanUp:
+    if (STATUS_FAILED(retStatus)) {
+        SAFE_MEMFREE(pKvsDataChannel);
+    }
     CHK_LOG_ERR(retStatus);
 
     LEAVES();

--- a/tst/DataChannelFunctionalityTest.cpp
+++ b/tst/DataChannelFunctionalityTest.cpp
@@ -591,6 +591,80 @@ TEST_F(DataChannelFunctionalityTest, createDataChannel_DataChannelMetricsTest)
     freePeerConnection(&answerPc);
 }
 
+TEST_F(DataChannelFunctionalityTest, dataChannelOpen_OversizedNameIsTruncated)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection pPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    UINT32 oversizedLen = MAX_DATA_CHANNEL_NAME_LEN + 100;
+    BYTE oversizedName[MAX_DATA_CHANNEL_NAME_LEN + 100];
+    volatile SIZE_T onDataChannelCount = 0;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(oversizedName, 'A', oversizedLen);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &pPeerConnection), STATUS_SUCCESS);
+    pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
+
+    auto onDataChannelCb = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) {
+        UNUSED_PARAM(pRtcDataChannel);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    EXPECT_EQ(peerConnectionOnDataChannel(pPeerConnection, (UINT64) &onDataChannelCount, onDataChannelCb), STATUS_SUCCESS);
+
+    onSctpSessionDataChannelOpen((UINT64) pKvsPeerConnection, 0, oversizedName, oversizedLen);
+
+    EXPECT_EQ(ATOMIC_LOAD(&onDataChannelCount), 1);
+
+    UINT64 hashValue = 0;
+    EXPECT_EQ(hashTableGet(pKvsPeerConnection->pDataChannels, 0, &hashValue), STATUS_SUCCESS);
+    PKvsDataChannel pKvsDataChannel = (PKvsDataChannel) hashValue;
+
+    EXPECT_EQ(STRLEN(pKvsDataChannel->dataChannel.name), MAX_DATA_CHANNEL_NAME_LEN);
+    EXPECT_EQ(pKvsDataChannel->dataChannel.name[MAX_DATA_CHANNEL_NAME_LEN], '\0');
+    EXPECT_EQ(STRLEN(pKvsDataChannel->rtcDataChannelDiagnostics.label), MAX_STATS_STRING_LENGTH);
+    EXPECT_EQ(pKvsDataChannel->rtcDataChannelDiagnostics.label[MAX_STATS_STRING_LENGTH], '\0');
+
+    freePeerConnection(&pPeerConnection);
+}
+
+TEST_F(DataChannelFunctionalityTest, dataChannelOpen_NormalNameIsPreserved)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection pPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    const CHAR normalName[] = "my-data-channel";
+    UINT32 nameLen = STRLEN(normalName);
+    volatile SIZE_T onDataChannelCount = 0;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+
+    EXPECT_EQ(createPeerConnection(&configuration, &pPeerConnection), STATUS_SUCCESS);
+    pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
+
+    auto onDataChannelCb = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) {
+        UNUSED_PARAM(pRtcDataChannel);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    EXPECT_EQ(peerConnectionOnDataChannel(pPeerConnection, (UINT64) &onDataChannelCount, onDataChannelCb), STATUS_SUCCESS);
+
+    onSctpSessionDataChannelOpen((UINT64) pKvsPeerConnection, 0, (PBYTE) normalName, nameLen);
+
+    EXPECT_EQ(ATOMIC_LOAD(&onDataChannelCount), 1);
+
+    UINT64 hashValue = 0;
+    EXPECT_EQ(hashTableGet(pKvsPeerConnection->pDataChannels, 0, &hashValue), STATUS_SUCCESS);
+    PKvsDataChannel pKvsDataChannel = (PKvsDataChannel) hashValue;
+
+    EXPECT_EQ(STRLEN(pKvsDataChannel->dataChannel.name), nameLen);
+    EXPECT_EQ(STRNCMP(pKvsDataChannel->dataChannel.name, normalName, nameLen), 0);
+    EXPECT_EQ(STRNCMP(pKvsDataChannel->rtcDataChannelDiagnostics.label, normalName, nameLen), 0);
+
+    freePeerConnection(&pPeerConnection);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/DataChannelFunctionalityTest.cpp
+++ b/tst/DataChannelFunctionalityTest.cpp
@@ -591,7 +591,7 @@ TEST_F(DataChannelFunctionalityTest, createDataChannel_DataChannelMetricsTest)
     freePeerConnection(&answerPc);
 }
 
-TEST_F(DataChannelFunctionalityTest, dataChannelOpen_OversizedNameIsTruncated)
+TEST_F(DataChannelFunctionalityTest, dataChannelOpen_OversizedNameIsRejected)
 {
     RtcConfiguration configuration;
     PRtcPeerConnection pPeerConnection = NULL;
@@ -615,16 +615,10 @@ TEST_F(DataChannelFunctionalityTest, dataChannelOpen_OversizedNameIsTruncated)
 
     onSctpSessionDataChannelOpen((UINT64) pKvsPeerConnection, 0, oversizedName, oversizedLen);
 
-    EXPECT_EQ(ATOMIC_LOAD(&onDataChannelCount), 1);
+    EXPECT_EQ(ATOMIC_LOAD(&onDataChannelCount), 0);
 
     UINT64 hashValue = 0;
-    EXPECT_EQ(hashTableGet(pKvsPeerConnection->pDataChannels, 0, &hashValue), STATUS_SUCCESS);
-    PKvsDataChannel pKvsDataChannel = (PKvsDataChannel) hashValue;
-
-    EXPECT_EQ(STRLEN(pKvsDataChannel->dataChannel.name), MAX_DATA_CHANNEL_NAME_LEN);
-    EXPECT_EQ(pKvsDataChannel->dataChannel.name[MAX_DATA_CHANNEL_NAME_LEN], '\0');
-    EXPECT_EQ(STRLEN(pKvsDataChannel->rtcDataChannelDiagnostics.label), MAX_STATS_STRING_LENGTH);
-    EXPECT_EQ(pKvsDataChannel->rtcDataChannelDiagnostics.label[MAX_STATS_STRING_LENGTH], '\0');
+    EXPECT_NE(hashTableGet(pKvsPeerConnection->pDataChannels, 0, &hashValue), STATUS_SUCCESS);
 
     freePeerConnection(&pPeerConnection);
 }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added bounds check in `onSctpSessionDataChannelOpen` to reject data channel names exceeding `MAX_DATA_CHANNEL_NAME_LEN` (255).
- Fixed memory leak of `pKvsDataChannel` on `hashTablePut` failure path.

*Why was it changed?*
- The `nameLen` parameter originates from the remote peer's DCEP packet `labelLength` field (a UINT16, max 65535). Without validation, `STRNCPY` could write past the 256-byte destination buffers and cause overflow.

*How was it changed?*
- Added `CHK(nameLen <= MAX_DATA_CHANNEL_NAME_LEN, STATUS_INVALID_ARG)` before any allocation or copy. Oversized names are rejected entirely. Data channel is not created when `onDataChannel` callback fires and the error is logged via `CHK_LOG_ERR`
- Added `SAFE_MEMFREE(pKvsDataChannel)` in the `CleanUp` block when `STATUS_FAILED(retStatus)` to prevent a leak if `hashTablePut` fails after allocation.

*What testing was done for the changes?*
- Added two unit tests in `DataChannelFunctionalityTest`:
  - `dataChannelOpen_OversizedNameIsRejected`: Calls `onSctpSessionDataChannelOpen` with `nameLen = 355`, verifies `onDataChannel` callback is NOT invoked, no entry exists in the hash table and no memory leak.
  - `dataChannelOpen_NormalNameIsPreserved`: Calls with a normal 15-byte name, verifies the name and label are preserved exactly and callback fires.
- Both tests pass with zero memory leaks under the SDK's instrumented allocator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
