### PR TITLE
Add frame timecode logs

### DIFF
--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -295,6 +295,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     UINT64 randomRtpTimeoffset = 0; // TODO: spec requires random rtp time offset
     UINT64 rtpTimestamp = 0;
     UINT64 now = GETTIME();
+    BOOL verbose = (GET_LOGGER_LOG_LEVEL() == LOG_LEVEL_VERBOSE);
 
     // stats updates
     DOUBLE fps = 0.0;
@@ -304,7 +305,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     // temp vars :(
     UINT64 tmpFrames, tmpTime;
-    UINT16 twsn;
+    UINT16 twsn, firstSeqNum, lastSeqNum;
     UINT32 extpayload;
     STATUS sendStatus;
 
@@ -380,6 +381,10 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     CHK_STATUS(constructRtpPackets(pPayloadArray, pKvsRtpTransceiver->sender.payloadType, pKvsRtpTransceiver->sender.sequenceNumber, rtpTimestamp,
                                    pKvsRtpTransceiver->sender.ssrc, pPacketList, pPayloadArray->payloadSubLenSize));
+
+    firstSeqNum = pKvsRtpTransceiver->sender.sequenceNumber;
+    lastSeqNum = GET_UINT16_SEQ_NUM(pKvsRtpTransceiver->sender.sequenceNumber + pPayloadArray->payloadSubLenSize - 1);
+
     pKvsRtpTransceiver->sender.sequenceNumber = GET_UINT16_SEQ_NUM(pKvsRtpTransceiver->sender.sequenceNumber + pPayloadArray->payloadSubLenSize);
 
     bufferAfterEncrypt = (pKvsRtpTransceiver->sender.payloadType == pKvsRtpTransceiver->sender.rtxPayloadType);
@@ -436,6 +441,23 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         headerBytesSent += headerLen;
 
         SAFE_MEMFREE(rawPacket);
+    }
+
+    if (verbose) {
+        // track: video/audio
+        // pts: presentation timestamp
+        // rtpTs: RTP timestamp
+        // size: raw frame size
+        // rtpPayload: total RTP payload after packetization, but before serialization
+        // wireSize: total bytes sent on the wire (RTP headers + payload + SRTP overhead)
+        // seqNums: RTP sequence number range of packetized frame
+        // keyFrame: "yes"/"no"/"N/A" (N/A for audio)
+        DLOGV("debug frame info: track=%s, pts=%" PRIu64 ", rtpTs=%" PRIu64 ", size=%uB, rtpPayload=%uB, wireSize=%uB, seqNums=%u-%u, keyFrame=%s",
+              MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind ? "video" : "audio", pFrame->presentationTs, rtpTimestamp,
+              pFrame->size, pPayloadArray->payloadLength, bytesSent + headerBytesSent, firstSeqNum, lastSeqNum,
+              MEDIA_STREAM_TRACK_KIND_VIDEO != pKvsRtpTransceiver->sender.track.kind ? "N/A"
+                  : CHECK_FRAME_FLAG_KEY_FRAME(pFrame->flags)                        ? "yes"
+                                                                                     : "no");
     }
 
     if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added a verbose-level debug log in `writeFrame()` that prints track type, presentation timestamp, RTP timestamp, frame size, sequence number range, and keyframe status for each frame sent.

*Why was it changed?*
- To aid debugging of frame delivery and retransmission issues. The sequence number range in the log allows direct correlation with `NACK` retransmit requests from the receiver.

*How was it changed?*
- Added a BOOL verbose variable at the top of `writeFrame()` that caches the log level check once per call.
- After `constructRtpPackets` (but before incrementing the sequence number), emit a DLOGV with frame metadata including the `seqNums=X-Y` range. The end of the range uses `GET_UINT16_SEQ_NUM` to handle wrap-around correctly.
- This only executes when log level is set to `LOG_LEVEL_VERBOSE`, so zero overhead at default log levels.

*What testing was done for the changes?*
- Ran with the JS:

```c
./samples/kvsWebrtcClientMasterGstSample demo-channel audio-video
...
2026-06-09 18:10:10.763 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=0, rtpTs=0, size=12014B, rtpPayload=11981B, wireSize=12521B, seqNums=0-17, keyFrame=yes
2026-06-09 18:10:10.764 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=400000, rtpTs=1919, size=126B, rtpPayload=126B, wireSize=156B, seqNums=2-2, keyFrame=N/A
2026-06-09 18:10:10.788 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=600000, rtpTs=2879, size=127B, rtpPayload=127B, wireSize=157B, seqNums=3-3, keyFrame=N/A
2026-06-09 18:10:10.795 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=400000, rtpTs=3599, size=132B, rtpPayload=98B, wireSize=428B, seqNums=18-28, keyFrame=no
2026-06-09 18:10:10.805 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=800000, rtpTs=3839, size=176B, rtpPayload=176B, wireSize=206B, seqNums=4-4, keyFrame=N/A
2026-06-09 18:10:10.827 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=1000000, rtpTs=4800, size=177B, rtpPayload=177B, wireSize=207B, seqNums=5-5, keyFrame=N/A
2026-06-09 18:10:10.829 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=800000, rtpTs=7199, size=132B, rtpPayload=98B, wireSize=428B, seqNums=29-39, keyFrame=no
2026-06-09 18:10:10.830 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=1200000, rtpTs=10800, size=392B, rtpPayload=358B, wireSize=688B, seqNums=40-50, keyFrame=no
2026-06-09 18:10:10.845 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=1200000, rtpTs=5759, size=177B, rtpPayload=177B, wireSize=207B, seqNums=6-6, keyFrame=N/A
2026-06-09 18:10:10.848 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=1600000, rtpTs=14399, size=931B, rtpPayload=897B, wireSize=1227B, seqNums=51-61, keyFrame=no
2026-06-09 18:10:10.867 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=1400000, rtpTs=6719, size=177B, rtpPayload=177B, wireSize=207B, seqNums=7-7, keyFrame=N/A
2026-06-09 18:10:10.883 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=1600000, rtpTs=7679, size=177B, rtpPayload=177B, wireSize=207B, seqNums=8-8, keyFrame=N/A
2026-06-09 18:10:10.884 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=2000000, rtpTs=18000, size=1331B, rtpPayload=1297B, wireSize=1627B, seqNums=62-72, keyFrame=no
2026-06-09 18:10:10.908 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=1800000, rtpTs=8640, size=177B, rtpPayload=177B, wireSize=207B, seqNums=9-9, keyFrame=N/A
2026-06-09 18:10:10.922 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=2400000, rtpTs=21600, size=2597B, rtpPayload=2563B, wireSize=2893B, seqNums=73-83, keyFrame=no
2026-06-09 18:10:10.923 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=2000000, rtpTs=9600, size=177B, rtpPayload=177B, wireSize=207B, seqNums=10-10, keyFrame=N/A
2026-06-09 18:10:10.947 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=2200000, rtpTs=10559, size=177B, rtpPayload=177B, wireSize=207B, seqNums=11-11, keyFrame=N/A
2026-06-09 18:10:10.962 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=2800000, rtpTs=25199, size=1173B, rtpPayload=1139B, wireSize=1469B, seqNums=84-94, keyFrame=no
2026-06-09 18:10:10.967 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=2400000, rtpTs=11519, size=177B, rtpPayload=177B, wireSize=207B, seqNums=12-12, keyFrame=N/A
2026-06-09 18:10:10.986 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=2600000, rtpTs=12479, size=177B, rtpPayload=177B, wireSize=207B, seqNums=13-13, keyFrame=N/A
2026-06-09 18:10:11.002 VERBOSE writeFrame(): writeFrame: track=video, trackId=myVideoTrack, pts=3200000, rtpTs=28799, size=1404B, rtpPayload=1370B, wireSize=1700B, seqNums=95-105, keyFrame=no
2026-06-09 18:10:11.006 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=2800000, rtpTs=13439, size=177B, rtpPayload=177B, wireSize=207B, seqNums=14-14, keyFrame=N/A
2026-06-09 18:10:11.025 VERBOSE writeFrame(): writeFrame: track=audio, trackId=myAudioTrack, pts=3000000, rtpTs=14399, size=177B, rtpPayload=177B, wireSize=207B, seqNums=15-15, keyFrame=N/A
...

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
