### PR TITLE
Clamp max TWCC packet len

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -207,6 +207,11 @@ STATUS parseRtcpTwccPacket(PRtcpPacket pRtcpPacket, PTwccManager pTwccManager)
         CHK(FALSE, STATUS_SUCCESS);
     }
 
+    if (packetStatusCount > TWCC_MAX_PACKET_STATUS_COUNT) {
+        DLOGD("Malformed TWCC packet: packetStatusCount %u exceeds max %u, clamping", packetStatusCount, TWCC_MAX_PACKET_STATUS_COUNT);
+        packetStatusCount = TWCC_MAX_PACKET_STATUS_COUNT;
+    }
+
     referenceTime = (pRtcpPacket->payload[12] << 16) | (pRtcpPacket->payload[13] << 8) | (pRtcpPacket->payload[14] & 0xff);
     referenceTime = KVS_CONVERT_TIMESCALE(referenceTime * 64, MILLISECONDS_PER_SECOND, HUNDREDS_OF_NANOS_IN_A_SECOND);
     // TODO: handle lost twcc report packets
@@ -551,6 +556,12 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
         PTwccRtpPacketInfo pPktInfo = NULL;
         UINT16 reportLen = (UINT16) (pTwccManager->lastReportedSeqNum - pTwccManager->prevReportedBaseSeqNum + 1);
         UINT16 packetStatusCount = TWCC_PACKET_STATUS_COUNT(pRtcpPacket->payload);
+
+        // Hard cap to prevent attacker-controlled allocation via crafted TWCC packets
+        if (packetStatusCount > TWCC_MAX_PACKET_STATUS_COUNT) {
+            DLOGD("Malformed TWCC packet: packetStatusCount %u exceeds max %u", packetStatusCount, TWCC_MAX_PACKET_STATUS_COUNT);
+            packetStatusCount = TWCC_MAX_PACKET_STATUS_COUNT;
+        }
 
         // Cap reportLen to packetStatusCount to bound the allocation size
         if (reportLen > packetStatusCount) {

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -55,6 +55,11 @@ STATUS computeTwccTrendline(PTwccManager, PDOUBLE, PDOUBLE);
 // Max packet age in the TWCC hash table. If feedback is not received within this
 // window, the entry is evicted. Entries are also evicted once we receive feedback.
 #define TWCC_ESTIMATOR_TIME_WINDOW (4 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+// Hard upper bound on packets reported in a single TWCC feedback to prevent
+// too large allocations via crafted packetStatusCount (UINT16 field).
+// 2048 is well above any legitimate report (~270 pkts/sec at typical rates)
+// while capping allocation to ~45 KB instead of ~1.4 MB at UINT16 max.
+#define TWCC_MAX_PACKET_STATUS_COUNT 2048
 // Minimum payload length for a TWCC feedback packet (two SSRCs + base seq + status count + ref time + fb pkt count)
 #define TWCC_FB_PAYLOAD_MIN_LEN 16
 

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1475,6 +1475,81 @@ TEST_F(RtcpFunctionalityTest, parseRtcpTwccPacketRejectsShortPayload)
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+TEST_F(RtcpFunctionalityTest, parseRtcpTwccPacketClampsOversizedPacketStatusCount)
+{
+    // Verify that the feedback list is bounded to TWCC_MAX_PACKET_STATUS_COUNT.
+    // Without the fix, reportLen = 2049 and the callback receives 2049 items.
+    // With the fix, it's capped to 2048.
+    const UINT16 OVERSIZED_COUNT = TWCC_MAX_PACKET_STATUS_COUNT + 1; // 2049
+    const UINT16 BASE_SEQ = 0;
+
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection = nullptr;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket{};
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnSenderBandwidthEstimation(pRtcPeerConnection, 0, testBwHandler));
+
+    TwccCallbackCtx ctx{};
+    ctx.delayTrendToReturn = 0.5;
+    EXPECT_EQ(STATUS_SUCCESS, setOnTwccFeedbackReceived(pRtcPeerConnection, (UINT64) &ctx, testTwccFeedbackCallback));
+
+    // Pre-populate the hash table with OVERSIZED_COUNT sent packets
+    BYTE extBuf[4];
+    for (UINT16 i = 0; i < OVERSIZED_COUNT; i++) {
+        MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+        rtpPacket.header.extension = TRUE;
+        rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+        rtpPacket.header.extensionLength = SIZEOF(UINT32);
+        UINT16 twsn = BASE_SEQ + i;
+        UINT32 extpayload = TWCC_PAYLOAD(parseExtId(TWCC_EXT_URL), twsn);
+        MEMCPY(extBuf, &extpayload, SIZEOF(UINT32));
+        rtpPacket.header.extensionPayload = extBuf;
+        rtpPacket.payloadLength = 100;
+        rtpPacket.payload = extBuf;
+        EXPECT_EQ(STATUS_SUCCESS, twccManagerOnPacketSent(pKvsPeerConnection, &rtpPacket));
+    }
+
+    // Build TWCC feedback payload:
+    //   16 bytes header + 2 bytes run-length chunk + OVERSIZED_COUNT delta bytes
+    const UINT32 payloadSize = 16 + 2 + OVERSIZED_COUNT;
+    std::vector<BYTE> twccPayload(payloadSize, 0);
+
+    // Bytes 8-9: base sequence number
+    twccPayload[8] = (BYTE) (BASE_SEQ >> 8);
+    twccPayload[9] = (BYTE) (BASE_SEQ & 0xFF);
+    // Bytes 10-11: packet status count = OVERSIZED_COUNT (2049)
+    twccPayload[10] = (BYTE) (OVERSIZED_COUNT >> 8);
+    twccPayload[11] = (BYTE) (OVERSIZED_COUNT & 0xFF);
+    // Bytes 12-14: reference time = 1
+    twccPayload[14] = 0x01;
+    // Byte 15: fb packet count
+    twccPayload[15] = 0x01;
+    // Bytes 16-17: run-length chunk (SMALLDELTA, count=OVERSIZED_COUNT)
+    UINT16 runLenChunk = (0x01 << 13) | OVERSIZED_COUNT;
+    twccPayload[16] = (BYTE) (runLenChunk >> 8);
+    twccPayload[17] = (BYTE) (runLenChunk & 0xFF);
+    // Delta bytes: 1 tick (250us) each
+    for (UINT32 i = 0; i < OVERSIZED_COUNT; i++) {
+        twccPayload[18 + i] = 0x01;
+    }
+
+    RtcpPacket rtcpPacket{};
+    rtcpPacket.payload = twccPayload.data();
+    rtcpPacket.payloadLength = payloadSize;
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection));
+
+    EXPECT_EQ(1u, ctx.callCount);
+    // Key assertion: without the fix feedbackCount would be 2049, with it <= 2048
+    EXPECT_LE(ctx.feedbackCount, (UINT32) TWCC_MAX_PACKET_STATUS_COUNT);
+
+    SAFE_MEMFREE(ctx.pCapturedList);
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added TWCC_MAX_PACKET_STATUS_COUNT (2048) hard cap in Rtcp.h
- Added clamping of packetStatusCount in both parseRtcpTwccPacket() and onRtcpTwccPacket() in Rtcp.c

*Why was it changed?*
- The packetStatusCount field is a UINT16 read directly from the RTCP TWCC packet payload (remote authenticated peer).

*How was it changed?*
- Defined TWCC_MAX_PACKET_STATUS_COUNT 2048, well above any legitimate TWCC report (~270 packets/sec at typical bitrates, ~27-68 per feedback interval) while capping allocation to ~45KB worst-case.
- In parseRtcpTwccPacket(): clamp packetStatusCount immediately after reading it from the packet, before it's used to drive iteration.
- In onRtcpTwccPacket(): clamp packetStatusCount before it's used to bound reportLen and the subsequent MEMALLOC.

*What testing was done for the changes?*
- New unit test crafts a TWCC packet with packetStatusCount = 2049, pre-populates the hash table with 2049 sent packets, and asserts the callback receives <= 2048 feedback items.
- Validated test fails without the fix (feedbackCount = 2049 > 2048) and passes with the fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
