### PR TITLE
Add comment in TWCC parsing

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -583,7 +583,10 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
         MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
         locked = FALSE;
 
-        // Invoke custom callback to perform the calculation
+        // Invoke custom callback outside the lock to avoid deadlock if the callback calls back into the SDK.
+        // Safe because RTCP is processed on a single receive thread (connectionListenerReceiveDataRoutine),
+        // so parseRtcpTwccPacket cannot run concurrently. If RTCP processing becomes multi-threaded,
+        // the lock/unlock/relock pattern here and around updateTwccHashTable below must be revisited.
         retStatus = pKvsPeerConnection->onTwccFeedbackReceived(pKvsPeerConnection->onTwccFeedbackReceivedCustomData, pFeedbackList, feedbackCount,
                                                                &congestionState);
         SAFE_MEMFREE(pFeedbackList);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added a comment in `onRtcpTwccPacket` documenting the threading safety invariant around the mutex unlock/relock pattern.

*Why was it changed?*
- A review flagged a potential TOCTOU race in the unlock-before-callback pattern where `twccLock` is released before invoking `onTwccFeedbackReceived` and re-acquired after. The concern is that another thread could call `parseRtcpTwccPacket` concurrently and modify `lastReportedSeqNum`/`prevReportedBaseSeqNum`, causing `updateTwccHashTable` to operate on a stale or incorrect range. This is a false positive under the current architecture (single RTCP receive thread), but the invariant was not documented in the code.

*How was it changed?*
- Added a comment explaining why the unlock is safe (RTCP is processed on a single `connectionListenerReceiveDataRoutine` thread) and flagging that this pattern must be revisited if RTCP processing ever becomes multi-threaded.

*What testing was done for the changes?*
- CI/CD
- Comment-only change; no functional behavior modified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
