### PR TITLE
Adding defensive programming for TWCC list for future modifications

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -521,6 +521,7 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
     UINT64 sentPackets = 0, receivedPackets = 0;
     INT64 duration = 0;
     DOUBLE delayTrend = 0.0, queueDelay = 0.0;
+    PTwccFeedback pFeedbackList = NULL;
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
     // Skip TWCC parsing if no callback is set to consume the results
@@ -544,7 +545,6 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
     if (pKvsPeerConnection->onTwccFeedbackReceived != NULL) {
         // Custom estimator callback, build feedback list from this TWCC report
         TwccCongestionState congestionState;
-        PTwccFeedback pFeedbackList = NULL;
         UINT32 feedbackCount = 0;
         UINT16 seqNum;
         UINT64 twccPktVal = 0;
@@ -623,6 +623,7 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
 
 CleanUp:
     CHK_LOG_ERR(retStatus);
+    SAFE_MEMFREE(pFeedbackList);
     if (locked) {
         MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
     }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Moved `pFeedbackList` from block scope to function scope in `onRtcpTwccPacket` and added `SAFE_MEMFREE(pFeedbackList)` in the `CleanUp` label.

*Why was it changed?*
-  Defense-in-depth for memory management.
- **While no leak path currently exists** (the existing `SAFE_MEMFREE` is always reached before any `CHK_STATUS` jump), if future code changes add a `CHK_STATUS` between the allocation and the free, the jump to `CleanUp` would leak the buffer. Hoisting the variable and freeing in `CleanUp` follows the established pattern in this codebase and prevents future regressions.

*How was it changed?*
- Declared `PTwccFeedback pFeedbackList = NULL` at function scope alongside other local variables.
- Removed the redundant block-scoped `PTwccFeedback pFeedbackList = NULL` declaration.
- Added `SAFE_MEMFREE(pFeedbackList)` in `CleanUp`. The happy-path `SAFE_MEMFREE` on line 589 sets the pointer to NULL first, making the `CleanUp` call a no-op in non-error cases.

*What testing was done for the changes?*
- CI/CD
- No functional behavior change; the allocation/free semantics are identical in all current code paths. The change only adds safety for future modifications.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
