### PR TITLE
Widen data type for CongestionCtx

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -679,9 +679,9 @@ STATUS sampleOnPeerCongestionFeedback(UINT64 customData, PCongestionCtx pCongest
 
     UINT64 videoBitrate, audioBitrate;
     UINT64 currentTimeMs, timeDiff;
-    UINT32 txPacketsCnt = pCongestionCtx->txPackets;
-    UINT32 rxPacketsCnt = pCongestionCtx->rxPackets;
-    UINT32 lostPacketsCnt = txPacketsCnt > rxPacketsCnt ? txPacketsCnt - rxPacketsCnt : 0;
+    UINT64 txPacketsCnt = pCongestionCtx->txPackets;
+    UINT64 rxPacketsCnt = pCongestionCtx->rxPackets;
+    UINT64 lostPacketsCnt = txPacketsCnt > rxPacketsCnt ? txPacketsCnt - rxPacketsCnt : 0;
     DOUBLE percentLost = (DOUBLE) ((txPacketsCnt > 0) ? (lostPacketsCnt * 100 / txPacketsCnt) : 0.0);
     DOUBLE delayTrendMs = pCongestionCtx->congestionState.delayTrend;
 

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1226,10 +1226,10 @@ typedef struct {
  * @brief Context provided to the bandwidth controller callback.
  */
 typedef struct {
-    UINT32 txBytes;                      //!< Bytes sent over the transport
-    UINT32 rxBytes;                      //!< Bytes reported as received
-    UINT32 txPackets;                    //!< Packets sent over the transport
-    UINT32 rxPackets;                    //!< Packets reported as received
+    UINT64 txBytes;                      //!< Bytes sent over the transport
+    UINT64 rxBytes;                      //!< Bytes reported as received
+    UINT64 txPackets;                    //!< Packets sent over the transport
+    UINT64 rxPackets;                    //!< Packets reported as received
     UINT64 duration;                     //!< Time window for this feedback (hundreds of nanos)
     TwccCongestionState congestionState; //!< Current congestion state
 } CongestionCtx, *PCongestionCtx;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -605,10 +605,10 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
         // Invoke the new congestion feedback callback if set
         if (pKvsPeerConnection->onPeerCongestionFeedback != NULL) {
             CongestionCtx ctx;
-            ctx.txBytes = (UINT32) sentBytes;
-            ctx.rxBytes = (UINT32) receivedBytes;
-            ctx.txPackets = (UINT32) sentPackets;
-            ctx.rxPackets = (UINT32) receivedPackets;
+            ctx.txBytes = sentBytes;
+            ctx.rxBytes = receivedBytes;
+            ctx.txPackets = sentPackets;
+            ctx.rxPackets = receivedPackets;
             ctx.duration = (UINT64) duration;
             ctx.congestionState.delayTrend = delayTrend;
             CHK_LOG_ERR(pKvsPeerConnection->onPeerCongestionFeedback(pKvsPeerConnection->onPeerCongestionFeedbackCustomData, &ctx));


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Widened `txBytes`, `rxBytes`, `txPackets`, and `rxPackets` fields in `CongestionCtx` from `UINT32` to `UINT64`.

*Why was it changed?*
- These fields are populated from `UINT64` values returned by `updateTwccHashTable`. The narrowing casts to `UINT32` are unnecessary and violate type consistency.
- In practice, the values are bounded by the UINT16 TWCC sequence number space (max 65535 packets per report), worst case is well within UINT32. So truncation is not reachable today. However, since `CongestionCtx` is a new struct in this release with no existing consumers to break, there's no reason to narrow from the source `UINT64` type.

*How was it changed?*
- Changed the struct field types in `Include.h` from `UINT32` to `UINT64`.
- Removed the explicit `(UINT32)` casts in `onRtcpTwccPacket` when assigning to the struct.
- Updated the sample callback in `Common.c` to use `UINT64` local variables.

*Note:* The deprecated `RtcOnSenderBandwidthEstimation` callback continues to use `UINT32` parameters. That is a pre-existing API and is not changed here. Users should migrate to the new `RtcOnPeerCongestionFeedback` callback which now uses the correct `UINT64` types via `CongestionCtx`.

*What testing was done for the changes?*
- No behavioral change at current bitrate limits. The values fit in `UINT32` today, so the only difference is eliminating future truncation risk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
