### PR TITLE
Add locks when setting TWCC callbacks

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -2164,13 +2164,21 @@ STATUS setOnTwccFeedbackReceived(PRtcPeerConnection pPeerConnection, UINT64 cust
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
+    BOOL locked = FALSE;
 
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+    CHK_ERR(IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock), STATUS_INVALID_OPERATION,
+            "TWCC is not enabled; enable sender-side bandwidth estimation to use this callback");
 
+    MUTEX_LOCK(pKvsPeerConnection->twccLock);
+    locked = TRUE;
     pKvsPeerConnection->onTwccFeedbackReceivedCustomData = customData;
     pKvsPeerConnection->onTwccFeedbackReceived = onTwccFbReceived;
 
 CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+    }
     CHK_LOG_ERR(retStatus);
 
     LEAVES();
@@ -2182,13 +2190,21 @@ STATUS setOnPeerCongestionFeedbackFn(PRtcPeerConnection pPeerConnection, UINT64 
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
+    BOOL locked = FALSE;
 
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+    CHK_ERR(IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock), STATUS_INVALID_OPERATION,
+            "TWCC is not enabled; enable sender-side bandwidth estimation to use this callback");
 
+    MUTEX_LOCK(pKvsPeerConnection->twccLock);
+    locked = TRUE;
     pKvsPeerConnection->onPeerCongestionFeedbackCustomData = customData;
     pKvsPeerConnection->onPeerCongestionFeedback = onPeerCongestionFeedback;
 
 CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+    }
     CHK_LOG_ERR(retStatus);
 
     LEAVES();


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- `setOnTwccFeedbackReceived` and `setOnPeerCongestionFeedbackFn` now hold `twccLock` while writing the callback function pointer and its associated customData.
- Added a `twccLock` validity check before acquiring the lock, returning `STATUS_INVALID_OPERATION` if TWCC is not enabled.

*Why was it changed?*
- The callback pointer and customData form a pair that must be observed atomically. Without the lock, if a caller registers a new callback during a live session while `onRtcpTwccPacket` is executing on the receive thread, the reader could observe the new function pointer with the old customData (or vice versa), invoking the callback with a stale or invalid context. The risk is low in practice since callbacks are typically registered during setup before media flows, but the fix is trivial and makes the contract explicit.
- The `twccLock` mutex is only created when `disableSenderSideBandwidthEstimation` is false. Without validation, calling these setters with TWCC disabled would attempt to lock an invalid mutex (zero-initialized via `MEMCALLOC`), causing undefined behavior. The new check returns a clear error instead.

*How was it changed?*
- Added `CHK_ERR(IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock), STATUS_INVALID_OPERATION, ...)` before the lock acquisition in both setters.
- Added `MUTEX_LOCK(pKvsPeerConnection->twccLock)` / `MUTEX_UNLOCK` around the two writes in each setter, matching the lock that `onRtcpTwccPacket` holds when reading these fields.
- Verified that the sample code (both current and v1.18.2) already guards callback registration behind `if (pSampleConfiguration->enableTwcc)`, so existing usage is unaffected.

*What testing was done for the changes?*
- Existing unit tests continue to pass. The lock acquisition is non-contended in the setup-only registration path, so no performance impact.
- CI/CD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
