### PR TITLE
Samples: Change log level from error to debug for audio thread

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -192,7 +192,7 @@ PVOID mediaSenderRoutine(PVOID customData)
     }
 
     if (pSampleConfiguration->audioSenderTid != INVALID_TID_VALUE) {
-        DLOGE("Wait audio thread join");
+        DLOGD("Wait audio thread join");
         THREAD_JOIN(pSampleConfiguration->audioSenderTid, NULL);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Change the log level for the thread join debug log for audio thread from error to audio

*Why was it changed?*
- Incorrect level for this log

*How was it changed?*
- Change from ERROR to DEBUG

*What testing was done for the changes?*
- Trivial change, CI/CD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
