### PR TITLE
Log ICE candidate count summary on connection success and failure

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -171,10 +171,8 @@ VOID logIceCandidateSummary(PSampleStreamingSession pSampleStreamingSession)
 
     DLOGI("ICE candidate summary - local: %u host, %u srflx, %u prflx, %u relay (total %u); "
           "remote: %u host, %u srflx, %u prflx, %u relay (total %u)",
-          pLocal->host, pLocal->srflx, pLocal->prflx, pLocal->relay,
-          pLocal->host + pLocal->srflx + pLocal->prflx + pLocal->relay,
-          pRemote->host, pRemote->srflx, pRemote->prflx, pRemote->relay,
-          pRemote->host + pRemote->srflx + pRemote->prflx + pRemote->relay);
+          pLocal->host, pLocal->srflx, pLocal->prflx, pLocal->relay, pLocal->host + pLocal->srflx + pLocal->prflx + pLocal->relay, pRemote->host,
+          pRemote->srflx, pRemote->prflx, pRemote->relay, pRemote->host + pRemote->srflx + pRemote->prflx + pRemote->relay);
 }
 
 STATUS handleAnswer(PSampleConfiguration pSampleConfiguration, PSampleStreamingSession pSampleStreamingSession, PSignalingMessage pSignalingMessage)

--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -54,8 +54,11 @@ VOID onConnectionStateChange(UINT64 customData, RTC_PEER_CONNECTION_STATE newSta
             if (pSampleConfiguration->enableIceStats) {
                 CHK_LOG_ERR(logSelectedIceCandidatesInformation(pSampleStreamingSession));
             }
+            logIceCandidateSummary(pSampleStreamingSession);
             break;
         case RTC_PEER_CONNECTION_STATE_FAILED:
+            DLOGW("p2p connection failed");
+            logIceCandidateSummary(pSampleStreamingSession);
             // explicit fallthrough
         case RTC_PEER_CONNECTION_STATE_CLOSED:
             // explicit fallthrough
@@ -132,6 +135,46 @@ STATUS logSelectedIceCandidatesInformation(PSampleStreamingSession pSampleStream
 CleanUp:
     LEAVES();
     return retStatus;
+}
+
+VOID updateIceCandidateCount(PCHAR candidateStr, PIceCandidateCount pCount)
+{
+    if (candidateStr == NULL || pCount == NULL) {
+        return;
+    }
+
+    PCHAR pTyp = STRSTR(candidateStr, "typ ");
+    if (pTyp == NULL) {
+        return;
+    }
+    pTyp += 4;
+
+    if (STRNCMP(pTyp, "host", 4) == 0) {
+        pCount->host++;
+    } else if (STRNCMP(pTyp, "srflx", 5) == 0) {
+        pCount->srflx++;
+    } else if (STRNCMP(pTyp, "prflx", 5) == 0) {
+        pCount->prflx++;
+    } else if (STRNCMP(pTyp, "relay", 5) == 0) {
+        pCount->relay++;
+    }
+}
+
+VOID logIceCandidateSummary(PSampleStreamingSession pSampleStreamingSession)
+{
+    if (pSampleStreamingSession == NULL) {
+        return;
+    }
+
+    PIceCandidateCount pLocal = &pSampleStreamingSession->localCandidateCount;
+    PIceCandidateCount pRemote = &pSampleStreamingSession->remoteCandidateCount;
+
+    DLOGI("ICE candidate summary - local: %u host, %u srflx, %u prflx, %u relay (total %u); "
+          "remote: %u host, %u srflx, %u prflx, %u relay (total %u)",
+          pLocal->host, pLocal->srflx, pLocal->prflx, pLocal->relay,
+          pLocal->host + pLocal->srflx + pLocal->prflx + pLocal->relay,
+          pRemote->host, pRemote->srflx, pRemote->prflx, pRemote->relay,
+          pRemote->host + pRemote->srflx + pRemote->prflx + pRemote->relay);
 }
 
 STATUS handleAnswer(PSampleConfiguration pSampleConfiguration, PSampleStreamingSession pSampleStreamingSession, PSignalingMessage pSignalingMessage)
@@ -323,6 +366,10 @@ VOID onIceCandidateHandler(UINT64 customData, PCHAR candidateJson)
     SignalingMessage message = {0};
 
     CHK(pSampleStreamingSession != NULL, STATUS_NULL_ARG);
+
+    if (candidateJson != NULL) {
+        updateIceCandidateCount(candidateJson, &pSampleStreamingSession->localCandidateCount);
+    }
 
     if (candidateJson == NULL) {
         DLOGD("ice candidate gathering finished");
@@ -790,6 +837,7 @@ STATUS handleRemoteCandidate(PSampleStreamingSession pSampleStreamingSession, PS
 
     CHK_STATUS(deserializeRtcIceCandidateInit(pSignalingMessage->payload, pSignalingMessage->payloadLen, &iceCandidate));
     CHK_STATUS(addIceCandidate(pSampleStreamingSession->pPeerConnection, iceCandidate.candidate));
+    updateIceCandidateCount(iceCandidate.candidate, &pSampleStreamingSession->remoteCandidateCount);
 
 CleanUp:
 

--- a/samples/common/Samples.h
+++ b/samples/common/Samples.h
@@ -142,6 +142,13 @@ typedef struct {
     UINT64 prevTs;
 } RtcMetricsHistory, *PRtcMetricsHistory;
 
+typedef struct {
+    UINT32 host;
+    UINT32 srflx;
+    UINT32 prflx;
+    UINT32 relay;
+} IceCandidateCount, *PIceCandidateCount;
+
 struct __SampleConfiguration {
     volatile ATOMIC_BOOL appTerminateFlag;
     volatile ATOMIC_BOOL interrupted;
@@ -262,6 +269,8 @@ struct __SampleStreamingSession {
     UINT64 offerReceiveTime;
     PeerConnectionMetrics peerConnectionMetrics;
     KvsIceAgentMetrics iceMetrics;
+    IceCandidateCount localCandidateCount;
+    IceCandidateCount remoteCandidateCount;
     CHAR pPeerConnectionMetricsMessage[MAX_PEER_CONNECTION_METRICS_MESSAGE_SIZE];
     CHAR pSignalingClientMetricsMessage[MAX_SIGNALING_CLIENT_METRICS_MESSAGE_SIZE];
     CHAR pIceAgentMetricsMessage[MAX_ICE_AGENT_METRICS_MESSAGE_SIZE];
@@ -302,6 +311,8 @@ VOID onConnectionStateChange(UINT64, RTC_PEER_CONNECTION_STATE);
 STATUS sessionCleanupWait(PSampleConfiguration);
 STATUS logSignalingClientStats(PSignalingClientMetrics);
 STATUS logSelectedIceCandidatesInformation(PSampleStreamingSession);
+VOID logIceCandidateSummary(PSampleStreamingSession);
+VOID updateIceCandidateCount(PCHAR, PIceCandidateCount);
 STATUS logStartUpLatency(PSampleConfiguration);
 STATUS createMessageQueue(UINT64, PPendingMessageQueue*);
 STATUS freeMessageQueue(PPendingMessageQueue);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added ICE candidate counting by type (host, srflx, prflx, relay) for both local and remote candidates in the sample application
- Log a one-line summary when peer connection reaches CONNECTED or FAILED state

*Why was it changed?*
- To help diagnose potential ICE connectivity issues such as missing candidate types (e.g. no relay candidates when TURN is expected) or excessive candidate counts that increase session establishment latency

*How was it changed?*
- Added `IceCandidateCount` struct to `Samples.h` with per-type counters
- Added `localCandidateCount` and `remoteCandidateCount` fields to `SampleStreamingSession`
- `updateIceCandidateCount()` parses the `typ` field from SDP candidate strings and increments the appropriate counter
- `logIceCandidateSummary()` logs the summary: `ICE candidate summary - local: 3 host, 1 srflx, 0 prflx, 1 relay (total 5); remote: 20 host, 4 srflx, 0 prflx, 40 relay (total 64)`
- Local candidates are counted in `onIceCandidateHandler` as they are gathered
- Remote candidates are counted in `handleRemoteCandidate` as they arrive via signaling
- Summary is printed on both CONNECTED (success) and FAILED (to aid diagnosis)

*What testing was done for the changes?*
- Verified successful compilation of all sample targets (kvsWebrtcClientMaster, kvsWebrtcClientMasterGstSample, kvsWebrtcClientViewer)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.