### PR TITLE
Fix RTX payload type parsing and H265 PT override in SDP answer

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -273,9 +273,9 @@ STATUS setPayloadTypesFromOffer(PHashTable codecTable, PHashTable rtxTable, PSes
 
             if ((end = STRSTR(attributeValue, RTX_CODEC_VALUE)) != NULL) {
                 CHK_STATUS(STRTOUI64(end + STRLEN(RTX_CODEC_VALUE), NULL, 10, &parsedPayloadType));
-                if ((end = STRSTR(attributeValue, FMTP_VALUE)) != NULL) {
-                    CHK_STATUS(STRTOUI64(end + STRLEN(FMTP_VALUE), NULL, 10, &fmtpVal));
-                    aptFmtpVals[aptFmtpValCount++] = (UINT32) ((fmtpVal << 8u) & parsedPayloadType);
+                if ((end = STRCHR(attributeValue, ' ')) != NULL) {
+                    CHK_STATUS(STRTOUI64(attributeValue, end, 10, &fmtpVal));
+                    aptFmtpVals[aptFmtpValCount++] = (UINT32) ((fmtpVal << 8u) | parsedPayloadType);
                 }
             }
         }
@@ -510,7 +510,6 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
             retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_VP8, &rtxPayloadType);
         } else if (pRtcMediaStreamTrack->codec == RTC_CODEC_H265) {
             retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_H265, &rtxPayloadType);
-            payloadType = DEFAULT_PAYLOAD_H265;
         } else {
             retStatus = STATUS_HASH_KEY_NOT_PRESENT;
         }


### PR DESCRIPTION
Two bugs prevented RTX from being included in the SDP answer:

1. setPayloadTypesFromOffer: used bitwise AND (&) instead of OR (|) when packing the apt fmtp value with the RTX payload type, and parsed the fmtp attribute from the wrong substring. Fix: parse the PT before the space with STRCHR and combine with OR.

2. populateSingleMediaSection: unconditionally overwrote the negotiated H265 payload type with DEFAULT_PAYLOAD_H265 (127), discarding the actual PT from the offer. Fix: remove the override so the offer's PT is preserved.

Without this fix the SDP answer omits the RTX codec line and uses a hardcoded PT, breaking retransmission-based packet loss recovery.

*Issue #, if available:*
- N/A

*What was changed?*
- Fixed bitwise operator in `setPayloadTypesFromOffer` from AND (`&`) to OR (`|`) and corrected fmtp attribute parsing to use `STRCHR` for the space delimiter instead of searching for the wrong `FMTP_VALUE` prefix.
- Removed the unconditional `payloadType = DEFAULT_PAYLOAD_H265` override in `populateSingleMediaSection` so the negotiated payload type from the offer is preserved.

*Why was it changed?*
- The SDP answer was missing the RTX payload type entirely (e.g., `m=video ... 127` with only one PT) and using a hardcoded payload type instead of the one from the offer. This broke RTX-based retransmission, meaning NACK requests had no retransmission path and video quality degraded under packet loss.

*How was it changed?*
- In `SessionDescription.c:setPayloadTypesFromOffer` (~line 275): replaced `STRSTR(attributeValue, FMTP_VALUE)` with `STRCHR(attributeValue, ' ')` to correctly locate the payload type number, used `STRTOUI64(attributeValue, end, 10, &fmtpVal)` to parse it, and changed `(fmtpVal << 8u) & parsedPayloadType` to `(fmtpVal << 8u) | parsedPayloadType`.
- In `SessionDescription.c:populateSingleMediaSection` (~line 510): removed the `payloadType = DEFAULT_PAYLOAD_H265` line that overwrote the offer's payload type.

*What testing was done for the changes?*
- Verified via SDP offer/answer exchange with a Chrome browser. Without the fix: answer contains `m=video 9 UDP/TLS/RTP/SAVPF 127` (single hardcoded PT, no RTX, no `ssrc-group:FID`). With the fix: answer contains `m=video 9 UDP/TLS/RTP/SAVPF 51 52` (correct PT from offer + its RTX PT, with `ssrc-group:FID` and separate SSRC for retransmission).

Without fix — video m-line:
```
m=video 9 UDP/TLS/RTP/SAVPF 127              ← single hardcoded PT
a=ssrc:495355536 cname:...                    ← one SSRC only
a=rtpmap:127 H265/90000                      ← wrong PT (DEFAULT_PAYLOAD_H265)
a=fmtp:127 level-id=180;profile-id=2;...
                                              ← no RTX codec line
                                              ← no ssrc-group:FID
```

With fix — video m-line:
```
m=video 9 UDP/TLS/RTP/SAVPF 51 52            ← two PTs: primary + RTX from offer
a=ssrc-group:FID 372441738 1857386459         ← FID links primary↔retransmission
a=ssrc:372441738 ...myVideoTrack              ← primary SSRC
a=ssrc:1857386459 ...myVideoTrackRTX          ← retransmission SSRC
a=rtpmap:51 H265/90000                       ← correct PT from offer (not 127)
a=fmtp:51 level-id=180;profile-id=2;...
a=rtpmap:52 rtx/90000                        ← RTX codec present
a=fmtp:52 apt=51                             ← RTX associated to PT 51
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
