### PR TITLE
Fix duplicate stream/track IDs for fake transceivers in SDP parsing

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1511,8 +1511,8 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
             MEMSET(&track, 0x00, SIZEOF(RtcMediaStreamTrack));
             track.kind = streamKind;
             track.codec = RTC_CODEC_UNKNOWN;
-            STRCPY(track.streamId, "fakeStream");
-            STRCPY(track.trackId, "fakeTrack");
+            SNPRINTF(track.streamId, SIZEOF(track.streamId), "fakeStream%u", currentMedia);
+            SNPRINTF(track.trackId, SIZEOF(track.trackId), "fakeTrack%u", currentMedia);
             pRtcMediaStreamTrack = &track;
             CHK_STATUS(createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE, pKvsPeerConnection, (UINT32) RAND(), (UINT32) RAND(),
                                                pRtcMediaStreamTrack, NULL, RTC_CODEC_UNKNOWN, &pKvsRtpFakeTransceiver));


### PR DESCRIPTION
When multiple remote media sections map to fake (inactive) transceivers, they all shared the static IDs "fakeStream" and "fakeTrack", causing collisions. Append the media index to make each fake transceiver's stream and track IDs unique.

*Issue #, if available:*
- N/A

*What was changed?*
- In `findTransceiversByRemoteDescription()`, replaced hardcoded `STRCPY` calls for fake transceiver stream/track IDs with `SNPRINTF` that appends the `currentMedia` index.

*Why was it changed?*
- All fake transceivers shared identical `"fakeStream"` and `"fakeTrack"` IDs, causing ID collisions when a remote SDP description contains multiple media sections that don't match existing local transceivers.

*How was it changed?*
- `STRCPY(track.streamId, "fakeStream")` → `SNPRINTF(track.streamId, SIZEOF(track.streamId), "fakeStream%u", currentMedia)`
- `STRCPY(track.trackId, "fakeTrack")` → `SNPRINTF(track.trackId, SIZEOF(track.trackId), "fakeTrack%u", currentMedia)`

*What testing was done for the changes?*
- Verified multi-stream SDP offers (audio + video) produce distinct fake transceiver IDs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
