### PR TITLE
Ice: fix prevent local candidate batch overflow

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1808,7 +1808,7 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
     IceCandidate newLocalCandidates[KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE];
     UINT32 newLocalCandidateCount = 0;
     PIceAgent pIceAgent = (PIceAgent) customData;
-    BOOL locked = FALSE, stopScheduling = FALSE;
+    BOOL locked = FALSE, stopScheduling = FALSE, moreNewLocalCandidates = FALSE;
     PDoubleListNode pCurNode = NULL;
     UINT64 data;
     PIceCandidate pIceCandidate = NULL;
@@ -1842,11 +1842,15 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
         // If the candidate has moved to valid state, then we can report it and start creating pairs with
         // srflx candidates.
         else if (pIceCandidate->state == ICE_CANDIDATE_STATE_VALID && !pIceCandidate->reported) {
-            newLocalCandidates[newLocalCandidateCount++] = *pIceCandidate;
-            pIceCandidate->reported = TRUE;
+            if (newLocalCandidateCount < ARRAY_SIZE(newLocalCandidates)) {
+                newLocalCandidates[newLocalCandidateCount++] = *pIceCandidate;
+                pIceCandidate->reported = TRUE;
 
-            if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE) {
-                CHK_STATUS(createIceCandidatePairs(pIceAgent, pIceCandidate, FALSE));
+                if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE) {
+                    CHK_STATUS(createIceCandidatePairs(pIceAgent, pIceCandidate, FALSE));
+                }
+            } else {
+                moreNewLocalCandidates = TRUE;
             }
         }
     }
@@ -1860,11 +1864,15 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
     if (ATOMIC_LOAD_BOOL(&pIceAgent->stopGathering) ||
         (totalCandidateCount > 0 && pendingCandidateCount == 0 && ATOMIC_LOAD_BOOL(&pIceAgent->addedRelayCandidate)) ||
         currentTime >= pIceAgent->candidateGatheringEndTime) {
-        DLOGI("Candidate gathering completed.");
-        PROFILE_WITH_START_END_TIME_OBJ(pIceAgent->candidateGatheringStartTime, pIceAgent->candidateGatheringProcessEndTime,
-                                        pIceAgent->iceAgentProfileDiagnostics.candidateGatheringTime, "Candidate gathering time");
-        stopScheduling = TRUE;
-        pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
+        if (moreNewLocalCandidates) {
+            DLOGD("Deferring candidate gathering completion while there are new local candidates to report.");
+        } else {
+            DLOGI("Candidate gathering completed.");
+            PROFILE_WITH_START_END_TIME_OBJ(pIceAgent->candidateGatheringStartTime, pIceAgent->candidateGatheringProcessEndTime,
+                                            pIceAgent->iceAgentProfileDiagnostics.candidateGatheringTime, "Candidate gathering time");
+            stopScheduling = TRUE;
+            pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
+        }
     }
 
     MUTEX_UNLOCK(pIceAgent->lock);

--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -495,6 +495,77 @@ TEST_F(IceFunctionalityTest, IceAgentAddRemoteCandidateUnitTest)
     EXPECT_EQ(STATUS_SUCCESS, doubleListFree(iceAgent.localCandidates));
 }
 
+TEST_F(IceFunctionalityTest, IceAgentGatherCandidateTimerCallbackReportsLocalCandidatesInBatches)
+{
+    typedef struct {
+        std::vector<std::string> list;
+    } CandidateList;
+
+    IceAgent iceAgent;
+    IceCandidate localCandidates[KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE + 2];
+    CandidateList candidateList;
+    UINT32 i;
+
+    MEMSET(&iceAgent, 0x00, SIZEOF(IceAgent));
+    MEMSET(localCandidates, 0x00, SIZEOF(localCandidates));
+
+    auto onICECandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
+        CandidateList* candidateList1 = (CandidateList*) customData;
+        candidateList1->list.push_back(candidateStr != NULL ? std::string(candidateStr) : std::string(""));
+    };
+
+    iceAgent.lock = MUTEX_CREATE(TRUE);
+    iceAgent.iceAgentCallbacks.customData = (UINT64) &candidateList;
+    iceAgent.iceAgentCallbacks.newLocalCandidateFn = onICECandidateHdlr;
+    iceAgent.candidateGatheringStartTime = GETTIME();
+    iceAgent.candidateGatheringEndTime = 0;
+    iceAgent.iceCandidateGatheringTimerTask = 1;
+    ATOMIC_STORE_BOOL(&iceAgent.addedRelayCandidate, TRUE);
+    ATOMIC_STORE_BOOL(&iceAgent.candidateGatheringFinished, FALSE);
+    ATOMIC_STORE_BOOL(&iceAgent.stopGathering, FALSE);
+    ASSERT_EQ(STATUS_SUCCESS, doubleListCreate(&iceAgent.localCandidates));
+
+    for (i = 0; i < ARRAY_SIZE(localCandidates); ++i) {
+        localCandidates[i].iceCandidateType = ICE_CANDIDATE_TYPE_HOST;
+        localCandidates[i].state = ICE_CANDIDATE_STATE_VALID;
+        localCandidates[i].foundation = i + 1;
+        localCandidates[i].priority = ICE_PRIORITY_HOST_CANDIDATE_TYPE_PREFERENCE;
+        localCandidates[i].remoteProtocol = KVS_SOCKET_PROTOCOL_UDP;
+        localCandidates[i].ipAddress.family = KVS_IP_FAMILY_TYPE_IPV4;
+        localCandidates[i].ipAddress.address[0] = 127;
+        localCandidates[i].ipAddress.address[3] = (BYTE) (i + 1);
+        localCandidates[i].ipAddress.port = htons(10000 + i);
+        SNPRINTF(localCandidates[i].id, ARRAY_SIZE(localCandidates[i].id), "cand%03u", i);
+        ASSERT_EQ(STATUS_SUCCESS, doubleListInsertItemTail(iceAgent.localCandidates, (UINT64) &localCandidates[i]));
+    }
+
+    ASSERT_EQ(STATUS_SUCCESS, iceAgentGatherCandidateTimerCallback(0, 1, (UINT64) &iceAgent));
+    ASSERT_EQ(KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE, candidateList.list.size());
+    EXPECT_FALSE(ATOMIC_LOAD_BOOL(&iceAgent.candidateGatheringFinished));
+    EXPECT_NE(MAX_UINT32, iceAgent.iceCandidateGatheringTimerTask);
+
+    for (i = 0; i < KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE; ++i) {
+        EXPECT_TRUE(localCandidates[i].reported);
+    }
+    for (; i < ARRAY_SIZE(localCandidates); ++i) {
+        EXPECT_FALSE(localCandidates[i].reported);
+    }
+
+    ASSERT_EQ(STATUS_TIMER_QUEUE_STOP_SCHEDULING, iceAgentGatherCandidateTimerCallback(0, 2, (UINT64) &iceAgent));
+    ASSERT_EQ(ARRAY_SIZE(localCandidates) + 1, candidateList.list.size());
+    ASSERT_TRUE(candidateList.list.back().empty());
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&iceAgent.candidateGatheringFinished));
+    EXPECT_EQ(MAX_UINT32, iceAgent.iceCandidateGatheringTimerTask);
+
+    for (i = 0; i < ARRAY_SIZE(localCandidates); ++i) {
+        EXPECT_TRUE(localCandidates[i].reported);
+    }
+
+    MUTEX_FREE(iceAgent.lock);
+    EXPECT_EQ(STATUS_SUCCESS, doubleListClear(iceAgent.localCandidates, FALSE));
+    EXPECT_EQ(STATUS_SUCCESS, doubleListFree(iceAgent.localCandidates));
+}
+
 TEST_F(IceFunctionalityTest, IceAgentFindCandidateWithIpUnitTest)
 {
     DoubleList candidateList;


### PR DESCRIPTION
- Limit local candidate reporting to KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE per timer tick
- Leave candidates beyond the batch unreported so the next timer invocation can report them
- Defer candidate gathering completion while unreported local candidates remain
- Add regression coverage for reporting more local candidates than the batch size

*Issue #, if available:*
when real candidates over precompiled `KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE` count,
ASan reports this as a stack-buffer-overflow; without ASan, it can corrupt the stack and crash with nothing diagnostic information in coredump file :c

*What was changed?*
- Fixed local ICE candidate reporting in `iceAgentGatherCandidateTimerCallback` to respect `KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE`.
- Added regression coverage for reporting more newly valid local candidates than the per-tick batch size.

*Why was it changed?*
- AddressSanitizer reported a stack-buffer-overflow in `iceAgentGatherCandidateTimerCallback`.
- The callback copied every newly valid candidate into the fixed-size `newLocalCandidates` stack array before invoking the user callback.
- When more than `KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE` candidates became valid in one timer tick, the write advanced past the end of that stack buffer.

*How was it changed?*
- Added a bounds check before copying into `newLocalCandidates`.
- Left candidates beyond the current batch unreported so they can be reported on the next timer invocation.
- Deferred candidate gathering completion while unreported local candidates remain.
- Added a unit test that creates more valid local candidates than the batch size and verifies they are reported across multiple timer callback invocations.

*What testing was done for the changes?*
- Built `webrtc_client_test` on Linux aarch64:
  `cmake --build build --target webrtc_client_test -j"$(nproc)"`
- Ran:
  `./build/tst/webrtc_client_test --gtest_filter=IceFunctionalityTest.IceAgentGatherCandidateTimerCallbackReportsLocalCandidatesInBatches`
- Built the ASan test binary:
  `cmake --build build-asan --target webrtc_client_test -j"$(nproc)"`
- Ran the same regression test under ASan:
  `./build-asan/tst/webrtc_client_test --gtest_filter=IceFunctionalityTest.IceAgentGatherCandidateTimerCallbackReportsLocalCandidatesInBatches`
- Both normal and ASan runs passed. ASan did not report the previous stack-buffer-overflow.


<details>

<summary>Without this patch, reproduction steps:</summary>

```
./build-asan/tst/webrtc_client_test --gtest_filter=IceFunctionalityTest.IceAgentGatherCandidateTimerCallbackReportsLocalCandidatesInBatches
Note: Google Test filter = IceFunctionalityTest.IceAgentGatherCandidateTimerCallbackReportsLocalCandidatesInBatches
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from IceFunctionalityTest
[ RUN      ] IceFunctionalityTest.IceAgentGatherCandidateTimerCallbackReportsLocalCandidatesInBatches
2026-06-13 14:51:13.184 INFO    initKvsWebRtc(): Initializing WebRTC library...
2026-06-13 14:51:13.194 INFO    initKvsWebRtc(): SDK version: 423fba5f86d83fcf9bda9f169341ef3a7d87f40c
=================================================================
==83161==ERROR: AddressSanitizer: stack-buffer-overflow on address 0xffffe9a42980 at pc 0xffffb4944a08 bp 0xffffe9a424b0 sp 0xffffe9a424a0
WRITE of size 96 at 0xffffe9a42980 thread T0
    #0 0xffffb4944a04 in iceAgentGatherCandidateTimerCallback /home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Ice/IceAgent.c:1845
    #1 0xaaaadafa10dc in com::amazonaws::kinesis::video::webrtcclient::IceFunctionalityTest_IceAgentGatherCandidateTimerCallbackReportsLocalCandidatesInBatches_Test::TestBody() /home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/tst/IceFunctionalityTest.cpp:542
    #2 0xaaaadb42d4a0 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x63d4a0)
    #3 0xaaaadb42511c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x63511c)
    #4 0xaaaadb3fff7c in testing::Test::Run() (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x60ff7c)
    #5 0xaaaadb400910 in testing::TestInfo::Run() (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x610910)
    #6 0xaaaadb4011a0 in testing::TestSuite::Run() (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x6111a0)
    #7 0xaaaadb40efbc in testing::internal::UnitTestImpl::RunAllTests() (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x61efbc)
    #8 0xaaaadb42e624 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x63e624)
    #9 0xaaaadb4263b4 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x6363b4)
    #10 0xaaaadb40d8ec in testing::UnitTest::Run() (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0x61d8ec)
    #11 0xaaaadaec4138 in RUN_ALL_TESTS() /home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/open-source/include/gtest/gtest.h:2293
    #12 0xaaaadaec4138 in main /home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/tst/main.cpp:88
    #13 0xffffb40a73fc in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #14 0xffffb40a74d4 in __libc_start_main_impl ../csu/libc-start.c:392
    #15 0xaaaadaec452c in _start (/home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/build-asan/tst/webrtc_client_test+0xd452c)

Address 0xffffe9a42980 is located in stack of thread T0 at offset 1120 in frame
    #0 0xffffb494405c in iceAgentGatherCandidateTimerCallback /home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Ice/IceAgent.c:1805

  This frame has 4 object(s):
    [32, 40) 'pCurNode' (line 1812)
    [64, 72) 'data' (line 1813)
    [96, 120) 'relayAddress' (line 1816)
    [160, 1120) 'newLocalCandidates' (line 1808) <== Memory access at offset 1120 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /home/jetson/Desktop/amazon-kinesis-video-streams-webrtc-sdk-c/src/source/Ice/IceAgent.c:1845 in iceAgentGatherCandidateTimerCallback
Shadow bytes around the buggy address:
  0x200ffd3484e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x200ffd3484f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x200ffd348500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x200ffd348510: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x200ffd348520: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x200ffd348530:[f3]f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3 f3
  0x200ffd348540: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x200ffd348550: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 f1 f1
  0x200ffd348560: f8 f2 f8 f2 f8 f2 f8 f2 04 f2 04 f2 04 f2 04 f2
  0x200ffd348570: 04 f2 04 f2 04 f2 04 f2 04 f2 04 f2 04 f2 00 f2
  0x200ffd348580: f2 f2 00 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2 00 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==83161==ABORTING
```

</details>
