### PR TITLE
Added bounds check when parsing packet status chunks

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -231,7 +231,11 @@ STATUS parseRtcpTwccPacket(PRtcpPacket pRtcpPacket, PTwccManager pTwccManager)
     chunkOffset = 16;
     packetSeqNum = baseSeqNum;
     packetsRemaining = packetStatusCount;
-    while (packetsRemaining > 0) {
+    // Mirror the bound from the sizing walk above: a malicious feedback packet can declare a large
+    // packetStatusCount while supplying only a few status chunks, leaving packetsRemaining > 0 after
+    // the chunks are exhausted. Without the chunkOffset < payloadLength guard this second walk would
+    // read packet chunks past the end of the payload.
+    while (packetsRemaining > 0 && chunkOffset < pRtcpPacket->payloadLength) {
         packetChunk = getUnalignedInt16BigEndian(pRtcpPacket->payload + chunkOffset);
         statusSymbol = TWCC_RUNLEN_STATUS_SYMBOL(packetChunk);
         if (IS_TWCC_RUNLEN(packetChunk)) {

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1398,6 +1398,46 @@ TEST_F(RtcpFunctionalityTest, twccMalformedRunLengthExceedsStatusCountNoCrash)
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+TEST_F(RtcpFunctionalityTest, parseRtcpTwccPacketRejectsTruncatedChunks)
+{
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection = nullptr;
+    RtcConfiguration config{};
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnSenderBandwidthEstimation(pRtcPeerConnection, 0, testBwHandler));
+
+    // TWCC feedback payload layout (offsets into payload):
+    //   [0..3]   sender SSRC
+    //   [4..7]   media source SSRC
+    //   [8..9]   base sequence number
+    //   [10..11] packet status count  <-- lied: claims 0x4000 packets
+    //   [12..14] reference time, [15] feedback packet count
+    //   [16..]   status chunks (only ONE run-length chunk supplied here)
+    // The single run-length chunk encodes NOTRECEIVED for a large run, so the decode loop's
+    // packetsRemaining stays > 0 after the one present chunk is consumed.
+    const UINT32 payloadLen = 18; // 16-byte header + exactly one 2-byte chunk
+    PBYTE pHeapPayload = (PBYTE) MEMCALLOC(1, payloadLen);
+    ASSERT_TRUE(pHeapPayload != NULL);
+
+    putInt16((PINT16) (pHeapPayload + 8), 0x0000);  // base seq num
+    putInt16((PINT16) (pHeapPayload + 10), 0x4000); // packet status count (huge, lies)
+    // One run-length chunk: top bit 0 (run length), status NOTRECEIVED, run length covering many.
+    putInt16((PINT16) (pHeapPayload + 16), (INT16) 0x1FFF);
+
+    RtcpPacket rtcpPacket{};
+    rtcpPacket.payload = pHeapPayload;
+    rtcpPacket.payloadLength = payloadLen;
+    rtcpPacket.header.packetLength = payloadLen / 4;
+
+    // The walk is bounded by payloadLength and the call completes without over-reading.
+    EXPECT_EQ(STATUS_SUCCESS, parseRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection->pTwccManager));
+
+    SAFE_MEMFREE(pHeapPayload);
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 TEST_F(RtcpFunctionalityTest, parseRtcpTwccPacketRejectsTruncatedDeltas)
 {
     /** Construct a TWCC feedback packet where packetStatusCount claims more


### PR DESCRIPTION
*Issue #, if available:*
  - N/A

  *What was changed?*
  - Added a `chunkOffset < pRtcpPacket->payloadLength` bound to the second (decode) status-chunk walk in `parseRtcpTwccPacket` (`src/source/PeerConnection/Rtcp.c`).
  - Added regression test `RtcpFunctionalityTest.parseRtcpTwccPacketRejectsTruncatedChunks`.

  *Why was it changed?*
  - A TWCC feedback packet can declare a `packetStatusCount` larger than the number of status chunks it actually carries. The first (sizing) walk is bounded by `packetsRemaining > 0 && chunkOffset < payloadLength`, but the second (decode) walk looped purely on `while (packetsRemaining > 0)`. Once all the present chunks have been read, the loop would have continued calling `getUnalignedInt16BigEndian(payload + chunkOffset)` resulting in heap out-of-bounds read.

  *How was it changed?*
  - The decode loop condition now mirrors the sizing walk: `while (packetsRemaining > 0 && chunkOffset < pRtcpPacket->payloadLength)`. When the supplied chunks are exhausted the walk stops cleanly instead of reading past the buffer.

  *What testing was done for the changes?*
  - New `parseRtcpTwccPacketRejectsTruncatedChunks` test builds a packet with an inaccurate `packetStatusCount` (claims many, supplies one chunk), allocated at exact size on the heap. 
  - Under AddressSanitizer it aborts with `heap-buffer-overflow READ` without the fix and passes with it.
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.