### PR TITLE
Fix off-by-one heap write in rtcpNackListGet sequence number list

### DIFF
--- a/src/source/Rtcp/RtcpPacket.c
+++ b/src/source/Rtcp/RtcpPacket.c
@@ -54,15 +54,18 @@ STATUS rtcpNackListGet(PBYTE pPayload, UINT32 payloadLen, PUINT32 pSenderSsrc, P
         currentSequenceNumber = getInt16(*(PUINT16) (pPayload + i));
         BLP = getInt16(*(PUINT16) (pPayload + i + 2));
 
-        // If pSsrcList is not NULL and we have space push and increment
-        if (pSequenceNumberList != NULL && sequenceNumberCount <= *pSequenceNumberListLen) {
+        // If pSsrcList is not NULL and we have space push and increment. The guard must be a strict
+        // "less than": sequenceNumberCount is the index about to be written, and the caller-supplied
+        // buffer holds exactly *pSequenceNumberListLen elements (valid indices 0..len-1). Using "<="
+        // here would write sequenceNumberList[*pSequenceNumberListLen], one element past the end.
+        if (pSequenceNumberList != NULL && sequenceNumberCount < *pSequenceNumberListLen) {
             pSequenceNumberList[sequenceNumberCount] = currentSequenceNumber;
         }
         sequenceNumberCount++;
 
         for (j = 0; j < 16; j++) {
             if ((BLP & (1 << j)) >> j) {
-                if (pSequenceNumberList != NULL && sequenceNumberCount <= *pSequenceNumberListLen) {
+                if (pSequenceNumberList != NULL && sequenceNumberCount < *pSequenceNumberListLen) {
                     pSequenceNumberList[sequenceNumberCount] = (currentSequenceNumber + j + 1);
                 }
                 sequenceNumberCount++;

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -147,6 +147,29 @@ TEST_F(RtcpFunctionalityTest, rtcpNackListCompound)
     EXPECT_EQ(compoundBuffer[1], 3327);
 }
 
+TEST_F(RtcpFunctionalityTest, rtcpNackListGetSmallBuffer)
+{
+    UINT32 senderSsrc = 0, receiverSsrc = 0;
+
+    // 8-byte SSRC header + one FCI: PID 0x0ca8, BLP 0x0004 (bit 2 set -> one extra seq num).
+    BYTE singleBLP[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0xa8, 0x00, 0x04};
+
+    // Buffer sized for exactly one element; the packet yields two.
+    const UINT32 capacity = 1;
+    UINT32 ssrcListLen = capacity;
+    PUINT16 pSeqList = (PUINT16) MEMALLOC(SIZEOF(UINT16) * capacity);
+    ASSERT_TRUE(pSeqList != NULL);
+
+    // Only pSeqList[0] is written; the second sequence number is counted but not stored.
+    EXPECT_EQ(STATUS_SUCCESS, rtcpNackListGet(singleBLP, SIZEOF(singleBLP), &senderSsrc, &receiverSsrc, pSeqList, &ssrcListLen));
+
+    // The reported count still reflects the true number of sequence numbers in the packet.
+    EXPECT_EQ(2, ssrcListLen);
+    EXPECT_EQ(3240, pSeqList[0]);
+
+    SAFE_MEMFREE(pSeqList);
+}
+
 TEST_F(RtcpFunctionalityTest, onRtcpPacketCompoundNack)
 {
     PRtpPacket pRtpPacket = nullptr;


### PR DESCRIPTION
*Issue #, if available:*
  - N/A

  *What was changed?*
  - Changed the two bounds guards in `rtcpNackListGet` (`src/source/Rtcp/RtcpPacket.c`) from `sequenceNumberCount <= *pSequenceNumberListLen` to `sequenceNumberCount < *pSequenceNumberListLen`.
  - Added `RtcpFunctionalityTest.rtcpNackListGetSmallBuffer`.

  *Why was it changed?*
  - `rtcpNackListGet` writes to a buffer of `*pSequenceNumberListLen` elements (valid indices `0 .. len-1`). The `<=` guard allowed a write at index `== len` when the NACK packet described more sequence numbers than the buffer could hold, storing one element past the end of the array. 
  
  *How was it changed?*
  - Both guards now use strict `<`, so the final in-bounds index is `len-1` and the extra sequence number is counted (so the returned length stays accurate for the caller's two-pass sizing) but not stored. 

  *What testing was done for the changes?*
  - New `rtcpNackListGetSmallBuffer` test passes in a buffer of size 1 and provides a packet with 2 sequence numbers. 
  - Under AddressSanitizer it aborts with`heap-buffer-overflow WRITE` at `RtcpPacket.c` without the fix and passes with it; it also asserts the reported count is still 2 and `pSeqList[0]` is correct.
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.