### PR TITLE
Fix RTP header-extension out-of-bounds read and length underflow in setRtpPacketFromBytes

### DIFF
--- a/src/source/Rtp/RtpPacket.c
+++ b/src/source/Rtp/RtpPacket.c
@@ -197,11 +197,18 @@ STATUS setRtpPacketFromBytes(PBYTE rawPacket, UINT32 packetLength, PRtpPacket pR
     }
 
     if (extension) {
+        // The 4-byte extension header (profile + length) must fit in what remains of the packet
+        // before it is read, otherwise the two getInt16 reads below run past the buffer.
+        CHK(packetLength >= currOffset + 2 * SIZEOF(UINT16), STATUS_RTP_INPUT_PACKET_TOO_SMALL);
         extensionProfile = getInt16(*(PUINT16) (rawPacket + currOffset));
         currOffset += SIZEOF(UINT16);
         extensionLength = getInt16(*(PUINT16) (rawPacket + currOffset)) * 4;
         currOffset += SIZEOF(UINT16);
         extensionPayload = (PBYTE) (rawPacket + currOffset);
+        // The declared extension payload must also fit. Without this the extension would claim more
+        // bytes than are present, and the trailing "packetLength - currOffset" passed as the payload
+        // length below would underflow into a huge UINT32.
+        CHK(packetLength >= currOffset + extensionLength, STATUS_RTP_INPUT_PACKET_TOO_SMALL);
         currOffset += extensionLength;
     }
 

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -25,6 +25,37 @@ TEST_F(RtpFunctionalityTest, packetUnderflow)
     }
 }
 
+TEST_F(RtpFunctionalityTest, extensionHeaderBounds)
+{
+    RtpPacket rtpPacket;
+    MEMSET(&rtpPacket, 0x00, SIZEOF(RtpPacket));
+
+    // Case 1: extension bit set, but the packet is only the 12-byte fixed header -- the 4-byte
+    // extension header itself does not fit. byte[0] = 0x90: version 2, extension bit set, 0 CSRCs.
+    {
+        const UINT32 packetLength = 12;
+        PBYTE pHeapPacket = (PBYTE) MEMCALLOC(1, packetLength);
+        ASSERT_TRUE(pHeapPacket != NULL);
+        pHeapPacket[0] = 0x90;
+        EXPECT_EQ(STATUS_RTP_INPUT_PACKET_TOO_SMALL, setRtpPacketFromBytes(pHeapPacket, packetLength, &rtpPacket));
+        SAFE_MEMFREE(pHeapPacket);
+    }
+
+    // Case 2: extension header present and in-bounds, but it declares more payload than is present.
+    // The declared extension length word is 0x00FF (-> 0x00FF * 4 = 1020 bytes), far beyond the
+    // 4 bytes that actually follow the extension header.
+    {
+        const UINT32 packetLength = 20; // 12-byte header + 4-byte ext header + 4 ext bytes
+        PBYTE pHeapPacket = (PBYTE) MEMCALLOC(1, packetLength);
+        ASSERT_TRUE(pHeapPacket != NULL);
+        pHeapPacket[0] = 0x90;                                 // extension bit set, 0 CSRCs
+        putInt16((PINT16) (pHeapPacket + 12), (INT16) 0xBEDE); // extension profile
+        putInt16((PINT16) (pHeapPacket + 14), (INT16) 0x00FF); // declared length (words) -> 1020 bytes
+        EXPECT_EQ(STATUS_RTP_INPUT_PACKET_TOO_SMALL, setRtpPacketFromBytes(pHeapPacket, packetLength, &rtpPacket));
+        SAFE_MEMFREE(pHeapPacket);
+    }
+}
+
 TEST_F(RtpFunctionalityTest, marshallUnmarshallGettingSameData)
 {
     BYTE payload[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};


### PR DESCRIPTION
 *Issue #, if available:*
  - N/A

  *What was changed?*
  - Added two bounds checks in the `if (extension)` block of `setRtpPacketFromBytes` (`src/source/Rtp/RtpPacket.c`): one for the 4-byte extension header, one for the declared extension payload length.

  *Why was it changed?*
  - When the extension bit is set, the parser reads the 4-byte extension header and advances past the declared extension length with no validation against `packetLength`. Two possible issues:
    - The two `getInt16` reads of the extension header could themselves read past the buffer 
    - The declared extension length is larger than the bytes present, and pushes `currOffset` beyond `packetLength`, so when `setRtpPacket` is called afterwards with `packetLength - currOffset`, it could underflow into a huge `UINT32`.

  *How was it changed?*
  - Before reading the extension header: `CHK(packetLength >= currOffset + 2 * SIZEOF(UINT16), STATUS_RTP_INPUT_PACKET_TOO_SMALL)`.
  - After computing the declared length: `CHK(packetLength >= currOffset + extensionLength, STATUS_RTP_INPUT_PACKET_TOO_SMALL)`.
 
  *What testing was done for the changes?*
  - New `extensionHeaderBounds` test covers both cases on exact-size heap buffers: 
    - (1) extension bit set with only the 12-byte fixed header present, and 
    - (2) an in-bounds extension header declaring 1020 bytes of payload that isn't there. 
  - Under AddressSanitizer the unpatched code aborts with `heap-buffer-overflow READ` at `RtpPacket.c`; with the fix both are rejected with `STATUS_RTP_INPUT_PACKET_TOO_SMALL`.
  - Full `RtpFunctionalityTest` suite passes under ASan.
  
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.