### PR TITLE
Tests for "Fix RTX payload type parsing and H265 PT override in SDP answer (#2342)"

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -273,9 +273,9 @@ STATUS setPayloadTypesFromOffer(PHashTable codecTable, PHashTable rtxTable, PSes
 
             if ((end = STRSTR(attributeValue, RTX_CODEC_VALUE)) != NULL) {
                 CHK_STATUS(STRTOUI64(end + STRLEN(RTX_CODEC_VALUE), NULL, 10, &parsedPayloadType));
-                if ((end = STRSTR(attributeValue, FMTP_VALUE)) != NULL) {
-                    CHK_STATUS(STRTOUI64(end + STRLEN(FMTP_VALUE), NULL, 10, &fmtpVal));
-                    aptFmtpVals[aptFmtpValCount++] = (UINT32) ((fmtpVal << 8u) & parsedPayloadType);
+                if ((end = STRCHR(attributeValue, ' ')) != NULL) {
+                    CHK_STATUS(STRTOUI64(attributeValue, end, 10, &fmtpVal));
+                    aptFmtpVals[aptFmtpValCount++] = (UINT32) ((fmtpVal << 8u) | parsedPayloadType);
                 }
             }
         }
@@ -510,7 +510,6 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
             retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_VP8, &rtxPayloadType);
         } else if (pRtcMediaStreamTrack->codec == RTC_CODEC_H265) {
             retStatus = hashTableGet(pKvsPeerConnection->pRtxTable, RTC_RTX_CODEC_H265, &rtxPayloadType);
-            payloadType = DEFAULT_PAYLOAD_H265;
         } else {
             retStatus = STATUS_HASH_KEY_NOT_PRESENT;
         }

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -4020,6 +4020,286 @@ a=recvonly
     });
 }
 
+// Verify that setPayloadTypesFromOffer correctly parses RTX fmtp attributes
+// and stores the RTX payload type for H265 when the offer uses a non-default PT
+TEST_F(SdpApiTest, setPayloadTypesFromOffer_H265RtxParsedFromOffer)
+{
+    auto offer = std::string(R"(v=0
+o=- 481034601 1588366671 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5
+a=group:BUNDLE 0
+m=video 9 UDP/TLS/RTP/SAVPF 51 52
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:tEm4
+a=ice-pwd:MHYra0wZc3cAECKFPlnoRpon
+a=ice-options:trickle
+a=fingerprint:sha-256 37:C4:5C:9C:C9:DA:56:22:47:1F:8C:93:E1:A1:51:A8:15:94:78:1D:89:26:69:44:65:6C:C3:83:96:10:32:43
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:51 H265/90000
+a=fmtp:51 level-id=180;profile-id=2;tier-flag=0
+a=rtcp-fb:51 nack
+a=rtcp-fb:51 nack pli
+a=rtpmap:52 rtx/90000
+a=fmtp:52 apt=51
+a=ssrc-group:FID 1234567890 9876543210
+a=ssrc:1234567890 cname:testCname
+a=ssrc:9876543210 cname:testCname
+)");
+
+    assertLFAndCRLF((PCHAR) offer.c_str(), offer.size(), [](PCHAR sdp) {
+        RtcConfiguration configuration{};
+        PRtcPeerConnection pRtcPeerConnection = nullptr;
+        RtcMediaStreamTrack track{};
+        PRtcRtpTransceiver transceiver = nullptr;
+        RtcSessionDescriptionInit offerSdp{};
+        RtcSessionDescriptionInit answerSdp{};
+
+        SNPRINTF(configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, TEST_DEFAULT_REGION, TEST_DEFAULT_STUN_URL_POSTFIX);
+
+        track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        track.codec = RTC_CODEC_H265;
+        STRNCPY(track.streamId, "myVideoStream", MAX_MEDIA_STREAM_ID_LEN);
+        STRNCPY(track.trackId, "myVideoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+        offerSdp.type = SDP_TYPE_OFFER;
+        STRNCPY(offerSdp.sdp, sdp, MAX_SESSION_DESCRIPTION_INIT_SDP_LEN);
+
+        EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+        EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H265));
+        EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &track, nullptr, &transceiver));
+
+        EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(pRtcPeerConnection, &offerSdp));
+        EXPECT_EQ(STATUS_SUCCESS, createAnswer(pRtcPeerConnection, &answerSdp));
+
+        std::string answer(answerSdp.sdp);
+
+        // The answer should use PT 51 from the offer, not the default 127
+        EXPECT_NE(std::string::npos, answer.find("m=video 9 UDP/TLS/RTP/SAVPF 51 52"));
+        EXPECT_NE(std::string::npos, answer.find("a=rtpmap:51 H265/90000"));
+        EXPECT_NE(std::string::npos, answer.find("a=rtpmap:52 rtx/90000"));
+        EXPECT_NE(std::string::npos, answer.find("a=fmtp:52 apt=51"));
+
+        // Should NOT contain the default PT 127 for H265
+        EXPECT_EQ(std::string::npos, answer.find("a=rtpmap:127 H265/90000"));
+
+        closePeerConnection(pRtcPeerConnection);
+        EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+    });
+}
+
+// Verify RTX parsing works for H264 with non-default PTs in the offer
+TEST_F(SdpApiTest, setPayloadTypesFromOffer_H264RtxParsedFromOffer)
+{
+    auto offer = std::string(R"(v=0
+o=- 481034601 1588366671 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5
+a=group:BUNDLE 0
+m=video 9 UDP/TLS/RTP/SAVPF 102 103
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:tEm4
+a=ice-pwd:MHYra0wZc3cAECKFPlnoRpon
+a=ice-options:trickle
+a=fingerprint:sha-256 37:C4:5C:9C:C9:DA:56:22:47:1F:8C:93:E1:A1:51:A8:15:94:78:1D:89:26:69:44:65:6C:C3:83:96:10:32:43
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:102 H264/90000
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=rtcp-fb:102 nack
+a=rtcp-fb:102 nack pli
+a=rtpmap:103 rtx/90000
+a=fmtp:103 apt=102
+a=ssrc-group:FID 1234567890 9876543210
+a=ssrc:1234567890 cname:testCname
+a=ssrc:9876543210 cname:testCname
+)");
+
+    assertLFAndCRLF((PCHAR) offer.c_str(), offer.size(), [](PCHAR sdp) {
+        RtcConfiguration configuration{};
+        PRtcPeerConnection pRtcPeerConnection = nullptr;
+        RtcMediaStreamTrack track{};
+        PRtcRtpTransceiver transceiver = nullptr;
+        RtcSessionDescriptionInit offerSdp{};
+        RtcSessionDescriptionInit answerSdp{};
+
+        SNPRINTF(configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, TEST_DEFAULT_REGION, TEST_DEFAULT_STUN_URL_POSTFIX);
+
+        track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+        STRNCPY(track.streamId, "myVideoStream", MAX_MEDIA_STREAM_ID_LEN);
+        STRNCPY(track.trackId, "myVideoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+        offerSdp.type = SDP_TYPE_OFFER;
+        STRNCPY(offerSdp.sdp, sdp, MAX_SESSION_DESCRIPTION_INIT_SDP_LEN);
+
+        EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+        EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+        EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &track, nullptr, &transceiver));
+
+        EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(pRtcPeerConnection, &offerSdp));
+        EXPECT_EQ(STATUS_SUCCESS, createAnswer(pRtcPeerConnection, &answerSdp));
+
+        std::string answer(answerSdp.sdp);
+
+        // The answer should use PT 102/103 from the offer
+        EXPECT_NE(std::string::npos, answer.find("m=video 9 UDP/TLS/RTP/SAVPF 102 103"));
+        EXPECT_NE(std::string::npos, answer.find("a=rtpmap:102 H264/90000"));
+        EXPECT_NE(std::string::npos, answer.find("a=rtpmap:103 rtx/90000"));
+        EXPECT_NE(std::string::npos, answer.find("a=fmtp:103 apt=102"));
+
+        closePeerConnection(pRtcPeerConnection);
+        EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+    });
+}
+
+// Verify that when the offer has no RTX for H265, the answer also omits RTX
+TEST_F(SdpApiTest, setPayloadTypesFromOffer_H265NoRtxInOffer)
+{
+    auto offer = std::string(R"(v=0
+o=- 481034601 1588366671 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5
+a=group:BUNDLE 0
+m=video 9 UDP/TLS/RTP/SAVPF 51
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:tEm4
+a=ice-pwd:MHYra0wZc3cAECKFPlnoRpon
+a=ice-options:trickle
+a=fingerprint:sha-256 37:C4:5C:9C:C9:DA:56:22:47:1F:8C:93:E1:A1:51:A8:15:94:78:1D:89:26:69:44:65:6C:C3:83:96:10:32:43
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:51 H265/90000
+a=fmtp:51 level-id=180;profile-id=2;tier-flag=0
+a=rtcp-fb:51 nack
+a=rtcp-fb:51 nack pli
+a=ssrc:1234567890 cname:testCname
+)");
+
+    assertLFAndCRLF((PCHAR) offer.c_str(), offer.size(), [](PCHAR sdp) {
+        RtcConfiguration configuration{};
+        PRtcPeerConnection pRtcPeerConnection = nullptr;
+        RtcMediaStreamTrack track{};
+        PRtcRtpTransceiver transceiver = nullptr;
+        RtcSessionDescriptionInit offerSdp{};
+        RtcSessionDescriptionInit answerSdp{};
+
+        SNPRINTF(configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, TEST_DEFAULT_REGION, TEST_DEFAULT_STUN_URL_POSTFIX);
+
+        track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        track.codec = RTC_CODEC_H265;
+        STRNCPY(track.streamId, "myVideoStream", MAX_MEDIA_STREAM_ID_LEN);
+        STRNCPY(track.trackId, "myVideoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+        offerSdp.type = SDP_TYPE_OFFER;
+        STRNCPY(offerSdp.sdp, sdp, MAX_SESSION_DESCRIPTION_INIT_SDP_LEN);
+
+        EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+        EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H265));
+        EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &track, nullptr, &transceiver));
+
+        EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(pRtcPeerConnection, &offerSdp));
+        EXPECT_EQ(STATUS_SUCCESS, createAnswer(pRtcPeerConnection, &answerSdp));
+
+        std::string answer(answerSdp.sdp);
+
+        // The answer should use PT 51 from the offer (not default 127)
+        EXPECT_NE(std::string::npos, answer.find("m=video 9 UDP/TLS/RTP/SAVPF 51"));
+        EXPECT_NE(std::string::npos, answer.find("a=rtpmap:51 H265/90000"));
+
+        // No RTX should be present since the offer didn't include it
+        EXPECT_EQ(std::string::npos, answer.find("rtx/90000"));
+
+        closePeerConnection(pRtcPeerConnection);
+        EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+    });
+}
+
+// Verify RTX works for VP8 with non-default PTs
+TEST_F(SdpApiTest, setPayloadTypesFromOffer_VP8RtxParsedFromOffer)
+{
+    auto offer = std::string(R"(v=0
+o=- 481034601 1588366671 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5
+a=group:BUNDLE 0
+m=video 9 UDP/TLS/RTP/SAVPF 96 97
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:tEm4
+a=ice-pwd:MHYra0wZc3cAECKFPlnoRpon
+a=ice-options:trickle
+a=fingerprint:sha-256 37:C4:5C:9C:C9:DA:56:22:47:1F:8C:93:E1:A1:51:A8:15:94:78:1D:89:26:69:44:65:6C:C3:83:96:10:32:43
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtcp-rsize
+a=rtpmap:96 VP8/90000
+a=rtcp-fb:96 nack
+a=rtcp-fb:96 nack pli
+a=rtpmap:97 rtx/90000
+a=fmtp:97 apt=96
+a=ssrc-group:FID 1234567890 9876543210
+a=ssrc:1234567890 cname:testCname
+a=ssrc:9876543210 cname:testCname
+)");
+
+    assertLFAndCRLF((PCHAR) offer.c_str(), offer.size(), [](PCHAR sdp) {
+        RtcConfiguration configuration{};
+        PRtcPeerConnection pRtcPeerConnection = nullptr;
+        RtcMediaStreamTrack track{};
+        PRtcRtpTransceiver transceiver = nullptr;
+        RtcSessionDescriptionInit offerSdp{};
+        RtcSessionDescriptionInit answerSdp{};
+
+        SNPRINTF(configuration.iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, TEST_DEFAULT_REGION, TEST_DEFAULT_STUN_URL_POSTFIX);
+
+        track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        track.codec = RTC_CODEC_VP8;
+        STRNCPY(track.streamId, "myVideoStream", MAX_MEDIA_STREAM_ID_LEN);
+        STRNCPY(track.trackId, "myVideoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+        offerSdp.type = SDP_TYPE_OFFER;
+        STRNCPY(offerSdp.sdp, sdp, MAX_SESSION_DESCRIPTION_INIT_SDP_LEN);
+
+        EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+        EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_VP8));
+        EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &track, nullptr, &transceiver));
+
+        EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(pRtcPeerConnection, &offerSdp));
+        EXPECT_EQ(STATUS_SUCCESS, createAnswer(pRtcPeerConnection, &answerSdp));
+
+        std::string answer(answerSdp.sdp);
+
+        // The answer should include both the primary and RTX PTs from the offer
+        EXPECT_NE(std::string::npos, answer.find("m=video 9 UDP/TLS/RTP/SAVPF 96 97"));
+        EXPECT_NE(std::string::npos, answer.find("a=rtpmap:96 VP8/90000"));
+        EXPECT_NE(std::string::npos, answer.find("a=rtpmap:97 rtx/90000"));
+        EXPECT_NE(std::string::npos, answer.find("a=fmtp:97 apt=96"));
+
+        closePeerConnection(pRtcPeerConnection);
+        EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+    });
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Related to #2342

*Why was it changed?*
- Added 4 new unit tests to `tst/SdpApiTest.cpp` that verify RTX payload type parsing and negotiation in the SDP offer/answer flow. These tests prevent future regressions.

*How was it changed?*
- #2342 fixed a bug where the SDP answer was not generated correctly when H.265 was requested in the offer and the offer contained non-default payload types. Specifically, `setPayloadTypesFromOffer` failed to parse RTX fmtp attributes, and `populateSingleMediaSection` unconditionally overwrote the negotiated H265 payload type with the hardcoded default (127). This does not affect the H.264/Opus path.
-  `setPayloadTypesFromOffer_H265RtxParsedFromOffer`: H265 with RTX using non-default PTs from the offer
- `setPayloadTypesFromOffer_H264RtxParsedFromOffer`: H264 with RTX using non-default PTs from the offer
- `setPayloadTypesFromOffer_H265NoRtxInOffer`: H265 without RTX in the offer (ensures no spurious RTX in answer)
- `setPayloadTypesFromOffer_VP8RtxParsedFromOffer`: VP8 with RTX using non-default PTs from the offer

*What testing was done for the changes?*
- All 4 tests pass with the fix from #2342 applied:

```
[ RUN      ] SdpApiTest.setPayloadTypesFromOffer_H265RtxParsedFromOffer
[       OK ] SdpApiTest.setPayloadTypesFromOffer_H265RtxParsedFromOffer (544 ms)
[ RUN      ] SdpApiTest.setPayloadTypesFromOffer_H264RtxParsedFromOffer
[       OK ] SdpApiTest.setPayloadTypesFromOffer_H264RtxParsedFromOffer (539 ms)
[ RUN      ] SdpApiTest.setPayloadTypesFromOffer_H265NoRtxInOffer
[       OK ] SdpApiTest.setPayloadTypesFromOffer_H265NoRtxInOffer (536 ms)
[ RUN      ] SdpApiTest.setPayloadTypesFromOffer_VP8RtxParsedFromOffer
[       OK ] SdpApiTest.setPayloadTypesFromOffer_VP8RtxParsedFromOffer (536 ms)
[  PASSED  ] 4 tests.
```

- All 4 tests fail when the fix is reverted (confirming they catch the bug):

```
[ RUN      ] SdpApiTest.setPayloadTypesFromOffer_H265RtxParsedFromOffer
[  FAILED  ] SdpApiTest.setPayloadTypesFromOffer_H265RtxParsedFromOffer (564 ms)
[ RUN      ] SdpApiTest.setPayloadTypesFromOffer_H264RtxParsedFromOffer
[  FAILED  ] SdpApiTest.setPayloadTypesFromOffer_H264RtxParsedFromOffer (548 ms)
[ RUN      ] SdpApiTest.setPayloadTypesFromOffer_H265NoRtxInOffer
[  FAILED  ] SdpApiTest.setPayloadTypesFromOffer_H265NoRtxInOffer (545 ms)
[ RUN      ] SdpApiTest.setPayloadTypesFromOffer_VP8RtxParsedFromOffer
[  FAILED  ] SdpApiTest.setPayloadTypesFromOffer_VP8RtxParsedFromOffer (547 ms)
[  PASSED  ] 0 tests.
[  FAILED  ] 4 tests, listed below:
[  FAILED  ] SdpApiTest.setPayloadTypesFromOffer_H265RtxParsedFromOffer
[  FAILED  ] SdpApiTest.setPayloadTypesFromOffer_H264RtxParsedFromOffer
[  FAILED  ] SdpApiTest.setPayloadTypesFromOffer_H265NoRtxInOffer
[  FAILED  ] SdpApiTest.setPayloadTypesFromOffer_VP8RtxParsedFromOffer
 4 FAILED TESTS
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
