### PR TITLE
Add additional parseRtcpTwccPacket test

### DIFF
--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1461,6 +1461,55 @@ TEST_F(RtcpFunctionalityTest, parseRtcpTwccPacketRejectsTruncatedChunks)
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+TEST_F(RtcpFunctionalityTest, parseRtcpTwccPacketSecondWalkChunkOverread)
+{
+    // Uses packetStatusCount=200 (below the 2048 clamp) with a
+    // single run-length chunk using reserved status symbol 3. The reserved symbol
+    // hits the switch default case — no recv-delta is consumed — so the chunk's
+    // run length (5) only decrements packetsRemaining by 5. After one chunk,
+    // packetsRemaining is 195 and chunkOffset advances past the payload. Without
+    // the chunkOffset < payloadLength guard on the second walk, the next iteration
+    // reads a chunk 2 bytes past the payload.
+
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    PKvsPeerConnection pKvsPeerConnection = nullptr;
+    RtcConfiguration config{};
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnSenderBandwidthEstimation(pRtcPeerConnection, 0, testBwHandler));
+
+    // TWCC payload: 16-byte header + ONE 2-byte chunk = 18 bytes total.
+    // packetStatusCount = 200 (fits under 2048, no clamp).
+    // Chunk = 0x6005: run-length (bit15=0), status symbol=3 (bits14:13), run length=5 (bits12:0).
+    // Symbol 3 is reserved — the switch default case runs, no delta consumed,
+    // packetsRemaining decremented by 5 only → 195 remain after this single chunk.
+    const UINT32 payloadLen = 18;
+    PBYTE pHeapPayload = (PBYTE) MEMCALLOC(1, payloadLen);
+    ASSERT_TRUE(pHeapPayload != NULL);
+
+    // base sequence number at offset 8
+    putInt16((PINT16) (pHeapPayload + 8), 0x0001);
+    // packetStatusCount at offset 10 = 200 (below clamp threshold)
+    putInt16((PINT16) (pHeapPayload + 10), (INT16) 200);
+    // Single run-length chunk at offset 16: symbol=3 (reserved), runLength=5
+    // Binary: 0 11 0000000000101 = 0x6005
+    pHeapPayload[16] = 0x60;
+    pHeapPayload[17] = 0x05;
+
+    RtcpPacket rtcpPacket{};
+    rtcpPacket.payload = pHeapPayload;
+    rtcpPacket.payloadLength = payloadLen;
+    rtcpPacket.header.packetLength = payloadLen / 4;
+
+    // The second walk's chunkOffset < payloadLength guard stops the loop
+    // before reading past the payload. The call completes without over-reading.
+    EXPECT_EQ(STATUS_SUCCESS, parseRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection->pTwccManager));
+
+    SAFE_MEMFREE(pHeapPayload);
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 TEST_F(RtcpFunctionalityTest, parseRtcpTwccPacketRejectsTruncatedDeltas)
 {
     /** Construct a TWCC feedback packet where packetStatusCount claims more


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added additional unit test for #2348 

*Why was it changed?*
- Unit test added in #2348 did not cover the fix, it was caught by #2318
- Added new test with a Rtcp packet that has 1 chunk, but declares it has 200 chunks and a run length
 of 5. After reading the first chunk, `packetStatusCount` will be at 195, but chunkOffset will be at the end of the payload. Without the added bounds check `chunkOffset < pRtcpPacket->payloadLength`, it would result in an OOB read.

*How was it changed?*
- Refer to referenced PR

*What testing was done for the changes?*
- Without #2348, the unit test fails when running with Address Sanitizer:
```
AddressSanitizer:DEADLYSIGNAL
==84031==ERROR: AddressSanitizer: BUS on unknown address (pc 0x00010572376c bp 0x00016b75d5f0 sp 0x00016b75d0d0 T0)
==84031==The signal is caused by a READ memory access.
    #0 0x00010572376c in getUnalignedInt16Be Endianness.c:98
    #1 0x00010486563c in ...RtcpFunctionalityTest_parseRtcpTwccPacketSecondWalkChunkOverread_Test::TestBody() RtcpFunctionalityTest.cpp:1511
SUMMARY: AddressSanitizer: BUS Endianness.c:98 in getUnalignedInt16Be
```
- CI/CD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
