### PR TITLE
Configurable SDP Track Count

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ option(PARALLEL_BUILD "Build dependencies with parallel flag" OFF)
 
 # Tuning
 set(MAX_SDP_SESSION_MEDIA_COUNT "5" CACHE STRING "Maximum number of SDP media sections (m= lines). Range: 1-6. Each slot adds ~140 KB to stack-allocated SessionDescription. See docs/SDP_MEDIA_COUNT.md.")
+if (NOT "${MAX_SDP_SESSION_MEDIA_COUNT}" MATCHES "^[0-9]+$")
+  message(FATAL_ERROR "MAX_SDP_SESSION_MEDIA_COUNT must be a number, got '${MAX_SDP_SESSION_MEDIA_COUNT}'.")
+endif()
 if (NOT "${MAX_SDP_SESSION_MEDIA_COUNT}" STREQUAL "5")
   message(STATUS "MAX_SDP_SESSION_MEDIA_COUNT overridden to ${MAX_SDP_SESSION_MEDIA_COUNT} (default: 5)")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,20 @@ option(BUILD_OLD_MBEDTLS_VERSION "Use MbedTLS version 2.28.8." OFF)
 option(INCREASE_PRECISION_TIMING_LOGS "PROFILE-level timing logs have 2 decimals of milliseconds (otherwise truncated to whole millisecond)" ON)
 option(PARALLEL_BUILD "Build dependencies with parallel flag" OFF)
 
+# Tuning
+set(MAX_SDP_SESSION_MEDIA_COUNT "5" CACHE STRING "Maximum number of SDP media sections (m= lines). Range: 1-6. Each slot adds ~140 KB to stack-allocated SessionDescription. See docs/SDP_MEDIA_COUNT.md.")
+if (NOT "${MAX_SDP_SESSION_MEDIA_COUNT}" STREQUAL "5")
+  message(STATUS "MAX_SDP_SESSION_MEDIA_COUNT overridden to ${MAX_SDP_SESSION_MEDIA_COUNT} (default: 5)")
+endif()
+if (MAX_SDP_SESSION_MEDIA_COUNT LESS 1)
+  message(FATAL_ERROR "MAX_SDP_SESSION_MEDIA_COUNT=${MAX_SDP_SESSION_MEDIA_COUNT} is below the minimum of 1.")
+endif()
+if (MAX_SDP_SESSION_MEDIA_COUNT GREATER 6)
+  message(FATAL_ERROR "MAX_SDP_SESSION_MEDIA_COUNT=${MAX_SDP_SESSION_MEDIA_COUNT} exceeds the maximum of 6. "
+    "The KVS TURN relay hard-limits bandwidth to 5 Mbps, which cannot sustain more than 6 concurrent media streams. "
+    "See docs/SDP_MEDIA_COUNT.md for details.")
+endif()
+
 # Developer Flags
 option(BUILD_TEST "Build the testing tree." OFF)
 option(BUILD_BENCHMARK "Build the benchmark tree." OFF)
@@ -436,6 +450,10 @@ endif()
 
 # Uncomment below line for very verbose logging
 # add_definitions(-DLOG_STREAMING)
+
+if (NOT "${MAX_SDP_SESSION_MEDIA_COUNT}" STREQUAL "5")
+  add_definitions(-DMAX_SDP_SESSION_MEDIA_COUNT=${MAX_SDP_SESSION_MEDIA_COUNT})
+endif()
 
 if (ENABLE_DATA_CHANNEL)
   add_definitions(-DENABLE_DATA_CHANNEL)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ You can pass the following options to `cmake ..`:
 * `-DBUILD_SAMPLE` -- Build the sample executables. ON by default.
 * `-DIOT_CORE_ENABLE_CREDENTIALS` -- Build the sample applications using IoT credentials. OFF by default.
 * `-DENABLE_DATA_CHANNEL` -- Build SDK & samples with data channel. ON by default.
+* `-DMAX_SDP_SESSION_MEDIA_COUNT=N` -- Maximum number of SDP media sections (m= lines). Default: 5. Each slot adds ~140 KB to the stack-allocated `SessionDescription` struct. See [docs/SDP_MEDIA_COUNT.md](docs/SDP_MEDIA_COUNT.md) for details on what counts toward this limit and stack sizing guidance.
 * `-DBUILD_STATIC_LIBS` -- Build all KVS WebRTC and third-party libraries as static libraries. Default: OFF (shared build).
 * `-DADD_MUCLIBC`  -- Add -muclibc c flag
 * `-DBUILD_DEPENDENCIES` -- Whether or not to build depending libraries from source. ON by default.

--- a/docs/SDP_MEDIA_COUNT.md
+++ b/docs/SDP_MEDIA_COUNT.md
@@ -1,0 +1,120 @@
+# SDP Media Count Limit (`MAX_SDP_SESSION_MEDIA_COUNT`)
+
+## Configuration
+
+`MAX_SDP_SESSION_MEDIA_COUNT` controls how many `m=` lines (media sections) an SDP can hold. The allowed range is **1 to 6**.
+
+**Default:** 5
+
+**Override:** Pass `-DMAX_SDP_SESSION_MEDIA_COUNT=N` to CMake:
+
+```bash
+cmake .. -DMAX_SDP_SESSION_MEDIA_COUNT=6
+```
+
+- **5 (default):** Supports standard configuration of 1 video + 1 audio transceiver + data channel with extra slots to spare. Also supports 4 video + 1 audio + no data channel.
+- **6 (maximum):** Supports 4 video + 1 audio + data channel.
+
+**Note**: [KVS TURN relay has a hard bandwidth limit](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/kvswebrtc-limits.html#limits-turn-service), which cannot sustain that many video streams at reasonable quality.
+
+Ensure your thread stack sizes are sufficient when increasing the number of slots.
+
+---
+
+## What is it?
+
+In WebRTC, every audio stream, video stream, and data channel gets its own "media section" (an `m=` line) in the SDP. The KVS WebRTC-C SDK stores these in a fixed-size array inside the `SessionDescription` struct, which is stack-allocated. `MAX_SDP_SESSION_MEDIA_COUNT` controls how many of these media sections the array can hold.
+
+### Why there's a limit
+
+Each media slot adds approximately **140 KB** to the `SessionDescription` struct. At the default of 5 slots, the struct is already ~825 KB - close to the 1 MB stack limit on Windows. Making this limit dynamic or overly large would cause stack overflows on constrained platforms.
+
+### Tracks and transceivers
+
+A **track** represents a single media source - one camera feed, one microphone, etc. A **transceiver** is the bidirectional pipeline associated with that media type. A single transceiver can send, receive, or both (controlled by its direction: `sendrecv`, `sendonly`, `recvonly`, or `inactive`). In the KVS WebRTC-C SDK, you create a transceiver by calling `addTransceiver` with a track attached. Each transceiver produces exactly one `m=` line in the SDP.
+
+Think of it like a walkie-talkie channel: each channel can transmit, listen, or both - but you need a separate channel for each independent media stream (one for video, one for audio, etc.).
+
+---
+
+## What Consumes a Slot
+
+Every `m=` line in the local SDP offer or answer counts toward this limit:
+
+| Source | When it's created | Example m= line |
+|--------|-------------------|-----------------|
+| User-added audio transceiver | You call `addTransceiver` with an audio track | `m=audio 9 UDP/TLS/RTP/SAVPF 111` |
+| User-added video transceiver | You call `addTransceiver` with a video track | `m=video 9 UDP/TLS/RTP/SAVPF 96` |
+| Fake transceiver | Answering a remote m-line with no matching local transceiver | `m=video 9 UDP/TLS/RTP/SAVPF 96` (direction=inactive) |
+| Data channel | `ENABLE_DATA_CHANNEL` is ON (the default) | `m=application 9 UDP/DTLS/SCTP webrtc-datachannel` |
+
+### Fake transceivers
+
+When the KVS WebRTC-C SDK generates an SDP answer, it must include one m-line for each m-line in the remote offer (per RFC 3264). If you haven't created a transceiver matching a remote m-line, the KVS WebRTC-C SDK creates a "fake transceiver" with `direction=inactive` to fill that slot.
+
+This means if a remote peer offers 3 video streams but you only added 1 video transceiver, the KVS WebRTC-C SDK still uses 3 video slots (1 real + 2 fake).
+
+### Data channel
+
+When `ENABLE_DATA_CHANNEL` is `ON`, the data channel m-line is always appended last, after all transceivers. With the default limit of 5, this leaves 4 slots for video and audio transceivers.
+
+---
+
+## Stack Size Implications
+
+The `SessionDescription` struct is stack-allocated in several SDK functions. Its size grows linearly with the media count:
+
+```
+Per-slot size = MAX_SDP_ATTRIBUTES_COUNT (256) x sizeof(SdpAttributes) (546 bytes)
+             + other fields (~978 bytes)
+             ~ 140,754 bytes per slot
+
+Total struct ~ (N x 140 KB) + 137 KB fixed overhead
+```
+
+| `MAX_SDP_SESSION_MEDIA_COUNT` | Approximate struct size |
+|-------------------------------|------------------------|
+| 5 (default) | ~825 KB |
+| 6 | ~962 KB |
+
+**Why not heap-allocate `SessionDescription`?** 
+
+The struct is part of the public API - SDK consumers stack-allocate it directly (e.g., `SessionDescription sd; deserializeSessionDescription(&sd, ...)`) and existing applications depend on this pattern. Changing it to a heap-allocated opaque type would be a breaking API change.
+
+---
+
+## Troubleshooting
+
+### `STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT` error (0x5500000A)
+
+The KVS WebRTC-C SDK returns this error when the number of m-lines would exceed `MAX_SDP_SESSION_MEDIA_COUNT`. This can happen during `createOffer`, `createAnswer`, or `setRemoteDescription` (when parsing the remote SDP).
+
+Check the ERROR log message to see which operation hit the limit (see [Useful log messages](#useful-log-messages) below).
+
+**Resolution:** Increase `MAX_SDP_SESSION_MEDIA_COUNT` via CMake and ensure your stack is large enough (see sizing table above).
+
+### SEH exception `0xc0000005` when creating offer/answer
+
+On Windows, a stack overflow caused by a `SessionDescription` that is too large for the thread's stack manifests as **SEH exception `0xc0000005`** (`STATUS_ACCESS_VIOLATION`) - this is a [Windows NTSTATUS code](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55), not a KVS SDK error code.
+
+**Resolution (pick one):**
+
+- Reduce `MAX_SDP_SESSION_MEDIA_COUNT` if you don't need 6 slots.
+- Increase the thread stack size
+
+### Remote peer's extra m-lines rejected
+
+If a remote offer has more m-lines than `MAX_SDP_SESSION_MEDIA_COUNT`, the KVS WebRTC-C SDK will reject the SDP and return `STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT` during `setRemoteDescription` along with logging an ERROR log.
+
+**Resolution:** Increase `MAX_SDP_SESSION_MEDIA_COUNT` to accommodate the remote peer's offer size.
+
+### Useful log messages
+
+The KVS WebRTC-C SDK logs ERROR-level messages when the media count limit is hit. Look for these in your logs:
+
+| Log message | What it means |
+|-------------|---------------|
+| `Exceeded max media count. Max: %u, current: %u` | A remote SDP being parsed has more m-lines than `MAX_SDP_SESSION_MEDIA_COUNT`. The SDP will be rejected. |
+| `Exceeded max media count while creating offer. Max: %u, current: %u` | You added more transceivers than the limit allows. The `createOffer` call will fail. |
+| `Exceeded max media count while creating answer. Max: %u, current: %u` | The answer being generated (real + fake transceivers) exceeds the limit. |
+| `Exceeded max media count while adding data channel. Max: %u, current: %u` | All slots are consumed by transceivers, leaving no room for the data channel m-line. Reduce your transceiver count by 1 or increase the limit. |

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1057,7 +1057,9 @@ STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PS
             pCurNode = pCurNode->pNext;
             pKvsRtpTransceiver = (PKvsRtpTransceiver) data;
             if (pKvsRtpTransceiver != NULL) {
-                CHK(pLocalSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT);
+                CHK_ERR(pLocalSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT,
+                        "Exceeded max media count while creating offer. Max: %u, current: %u", MAX_SDP_SESSION_MEDIA_COUNT,
+                        pLocalSessionDescription->mediaCount);
                 // If generating answer, need to check if Local Description is present in remote -- if not, we don't need to create a local
                 // description for it or else our Answer will have an extra m-line, for offer the local is the offer itself, don't care about remote
                 CHK_STATUS(populateSingleMediaSection(
@@ -1086,7 +1088,9 @@ STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PS
             pCurNode = pCurNode->pNext;
             pKvsRtpTransceiver = (PKvsRtpTransceiver) data;
             if (pKvsRtpTransceiver != NULL) {
-                CHK(pLocalSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT);
+                CHK_ERR(pLocalSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT,
+                        "Exceeded max media count while creating answer. Max: %u, current: %u", MAX_SDP_SESSION_MEDIA_COUNT,
+                        pLocalSessionDescription->mediaCount);
                 if (isPresentInRemote(pKvsRtpTransceiver, pRemoteSessionDescription)) {
                     if (pKvsRtpTransceiver->sender.track.codec == RTC_CODEC_UNKNOWN) {
                         CHK_STATUS(populateSingleMediaSection(pKvsPeerConnection, pKvsRtpTransceiver,
@@ -1113,7 +1117,9 @@ STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PS
     }
 
     if (ATOMIC_LOAD_BOOL(&pKvsPeerConnection->sctpIsEnabled)) {
-        CHK(pLocalSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT);
+        CHK_ERR(pLocalSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT,
+                "Exceeded max media count while adding data channel. Max: %u, current: %u", MAX_SDP_SESSION_MEDIA_COUNT,
+                pLocalSessionDescription->mediaCount);
         CHK_STATUS(populateSessionDescriptionDataChannel(pKvsPeerConnection,
                                                          &(pLocalSessionDescription->mediaDescriptions[pLocalSessionDescription->mediaCount]),
                                                          certificateFingerprint, pLocalSessionDescription->mediaCount, pDtlsRole));

--- a/src/source/Sdp/Deserialize.c
+++ b/src/source/Sdp/Deserialize.c
@@ -5,7 +5,8 @@ STATUS parseMediaName(PSessionDescription pSessionDescription, PCHAR pch, UINT32
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    CHK(pSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT);
+    CHK_ERR(pSessionDescription->mediaCount < MAX_SDP_SESSION_MEDIA_COUNT, STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT,
+            "Exceeded max media count. Max: %u, current: %u", MAX_SDP_SESSION_MEDIA_COUNT, pSessionDescription->mediaCount);
 
     STRNCPY(pSessionDescription->mediaDescriptions[pSessionDescription->mediaCount].mediaName, (pch + SDP_ATTRIBUTE_LENGTH),
             MIN(MAX_SDP_MEDIA_NAME_LENGTH, lineLen - SDP_ATTRIBUTE_LENGTH));

--- a/src/source/Sdp/Sdp.h
+++ b/src/source/Sdp/Sdp.h
@@ -96,12 +96,20 @@ extern "C" {
 
 #define MAX_SDP_SESSION_TIME_DESCRIPTION_COUNT 2
 #define MAX_SDP_SESSION_TIMEZONE_COUNT         2
+
 /**
  * https://tools.ietf.org/html/rfc4566#section-5.14
  *
- * reserving enough for audio, video, text, application and message for now
+ * When data channels are enabled (ENABLE_DATA_CHANNEL), the SDK automatically
+ * adds an m=application line, consuming one slot. The remaining slots are
+ * available for user-added audio/video transceivers.
  */
-#define MAX_SDP_SESSION_MEDIA_COUNT   5
+#ifdef ENABLE_DATA_CHANNEL
+#define MAX_SDP_SESSION_MEDIA_COUNT 6
+#else
+#define MAX_SDP_SESSION_MEDIA_COUNT 5
+#endif
+
 #define MAX_SDP_MEDIA_BANDWIDTH_COUNT 2
 
 #define MAX_SDP_ATTRIBUTES_COUNT 256

--- a/src/source/Sdp/Sdp.h
+++ b/src/source/Sdp/Sdp.h
@@ -100,13 +100,15 @@ extern "C" {
 /**
  * https://tools.ietf.org/html/rfc4566#section-5.14
  *
- * When data channels are enabled (ENABLE_DATA_CHANNEL), the SDK automatically
- * adds an m=application line, consuming one slot. The remaining slots are
- * available for user-added audio/video transceivers.
+ * Maximum number of m= lines (media sections) in an SDP. This limit applies
+ * to all media slots: user-added audio/video transceivers, fake transceivers
+ * (created for unmatched remote m-lines), and the data channel m=application
+ * line (when ENABLE_DATA_CHANNEL is on).
+ *
+ * Override at build time via CMake: -DMAX_SDP_SESSION_MEDIA_COUNT=N
+ * See docs/SDP_MEDIA_COUNT.md for sizing guidance and stack implications.
  */
-#ifdef ENABLE_DATA_CHANNEL
-#define MAX_SDP_SESSION_MEDIA_COUNT 6
-#else
+#ifndef MAX_SDP_SESSION_MEDIA_COUNT
 #define MAX_SDP_SESSION_MEDIA_COUNT 5
 #endif
 

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -48,3 +48,10 @@ target_link_libraries(webrtc_client_test
     kvspicUtils
     ${GTEST_LIBNAME}
     ${AWS_SDK_TEST_LIBS})
+
+# SessionDescription is ~140 KB per media slot (256 attributes x 546 bytes each).
+# At MAX_SDP_SESSION_MEDIA_COUNT=6, a single stack-allocated SessionDescription is ~984 KB,
+# which exceeds the Windows default stack size of 1 MB. Set to 2 MB (2097152 bytes).
+if(MSVC)
+    target_link_options(webrtc_client_test PRIVATE /STACK:2097152)
+endif()

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -49,9 +49,3 @@ target_link_libraries(webrtc_client_test
     ${GTEST_LIBNAME}
     ${AWS_SDK_TEST_LIBS})
 
-# SessionDescription is ~140 KB per media slot (256 attributes x 546 bytes each).
-# At MAX_SDP_SESSION_MEDIA_COUNT=6, a single stack-allocated SessionDescription is ~984 KB,
-# which exceeds the Windows default stack size of 1 MB. Set to 2 MB (2097152 bytes).
-if(MSVC)
-    target_link_options(webrtc_client_test PRIVATE /STACK:2097152)
-endif()

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -463,8 +463,9 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendRecvMaxTransceivers)
 }
 
 #ifdef ENABLE_DATA_CHANNEL
-// Validates that 4 video + 1 audio transceivers succeed with data channel enabled (total 6 = MAX_SDP_SESSION_MEDIA_COUNT)
-TEST_F(SdpApiTest, populateSingleMediaSection_FiveTransceiversWithDataChannel)
+// Validates that (MAX_SDP_SESSION_MEDIA_COUNT - 1) transceivers succeed with data channel enabled,
+// since data channel consumes 1 slot. Adding one more should exceed the limit.
+TEST_F(SdpApiTest, populateSingleMediaSection_MaxTransceiversWithDataChannel)
 {
     PRtcPeerConnection offerPc = NULL;
     RtcConfiguration configuration;
@@ -480,31 +481,22 @@ TEST_F(SdpApiTest, populateSingleMediaSection_FiveTransceiversWithDataChannel)
     rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
 
     MEMSET(&track, 0x00, SIZEOF(RtcMediaStreamTrack));
-    STRCPY(track.streamId, "myKvsStream");
-
-    // Add 4 video transceivers
     track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
     track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    STRCPY(track.streamId, "myKvsStream");
     STRCPY(track.trackId, "videoTrack");
-    for (UINT32 i = 0; i < 4; i++) {
+
+    // Fill all slots except one reserved for data channel
+    for (UINT32 i = 0; i < MAX_SDP_SESSION_MEDIA_COUNT - 1; i++) {
         EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
     }
 
-    // Add 1 audio transceiver
-    track.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
-    track.codec = RTC_CODEC_OPUS;
-    STRCPY(track.trackId, "audioTrack");
-    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
-
-    // 5 transceivers + 1 data channel = 6 = MAX_SDP_SESSION_MEDIA_COUNT, should succeed
+    // (MAX_SDP_SESSION_MEDIA_COUNT - 1) transceivers + 1 data channel = MAX_SDP_SESSION_MEDIA_COUNT
     EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "m=video", sessionDescriptionInit.sdp);
-    EXPECT_PRED_FORMAT2(testing::IsSubstring, "m=audio", sessionDescriptionInit.sdp);
     EXPECT_PRED_FORMAT2(testing::IsSubstring, "m=application", sessionDescriptionInit.sdp);
 
     // Adding one more transceiver should exceed the limit
-    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
-    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
     STRCPY(track.trackId, "extraTrack");
     EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
     EXPECT_EQ(STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT, createOffer(offerPc, &sessionDescriptionInit));

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -462,6 +462,58 @@ TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendRecvMaxTransceivers)
     freePeerConnection(&offerPc);
 }
 
+#ifdef ENABLE_DATA_CHANNEL
+// Validates that 4 video + 1 audio transceivers succeed with data channel enabled (total 6 = MAX_SDP_SESSION_MEDIA_COUNT)
+TEST_F(SdpApiTest, populateSingleMediaSection_FiveTransceiversWithDataChannel)
+{
+    PRtcPeerConnection offerPc = NULL;
+    RtcConfiguration configuration;
+    RtcSessionDescriptionInit sessionDescriptionInit;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+
+    RtcMediaStreamTrack track;
+    PRtcRtpTransceiver pTransceiver;
+    RtcRtpTransceiverInit rtcRtpTransceiverInit;
+    rtcRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDRECV;
+
+    MEMSET(&track, 0x00, SIZEOF(RtcMediaStreamTrack));
+    STRCPY(track.streamId, "myKvsStream");
+
+    // Add 4 video transceivers
+    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    STRCPY(track.trackId, "videoTrack");
+    for (UINT32 i = 0; i < 4; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
+    }
+
+    // Add 1 audio transceiver
+    track.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
+    track.codec = RTC_CODEC_OPUS;
+    STRCPY(track.trackId, "audioTrack");
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
+
+    // 5 transceivers + 1 data channel = 6 = MAX_SDP_SESSION_MEDIA_COUNT, should succeed
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sessionDescriptionInit));
+    EXPECT_PRED_FORMAT2(testing::IsSubstring, "m=video", sessionDescriptionInit.sdp);
+    EXPECT_PRED_FORMAT2(testing::IsSubstring, "m=audio", sessionDescriptionInit.sdp);
+    EXPECT_PRED_FORMAT2(testing::IsSubstring, "m=application", sessionDescriptionInit.sdp);
+
+    // Adding one more transceiver should exceed the limit
+    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    STRCPY(track.trackId, "extraTrack");
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, &rtcRtpTransceiverInit, &pTransceiver));
+    EXPECT_EQ(STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT, createOffer(offerPc, &sessionDescriptionInit));
+
+    closePeerConnection(offerPc);
+    freePeerConnection(&offerPc);
+}
+#endif
+
 TEST_F(SdpApiTest, populateSingleMediaSection_TestTxSendOnly)
 {
     PRtcPeerConnection offerPc = NULL;
@@ -708,34 +760,42 @@ a=rtpmap:111 opus/48000/2
 a=fmtp:111 minptime=10;useinbandfec=1
 a=rtcp-fb:111 nack)";
 
-TEST_F(SdpApiTest, threeVideoTracksWithSameCodec)
+TEST_F(SdpApiTest, maxVideoTracksWithSameCodec)
 {
-    auto offer3 = std::string(R"(v=0
-o=- 481034601 1588366671 IN IP4 0.0.0.0
-s=-
-t=0 0
-a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5
-a=group:BUNDLE 0 1 2 3
-)");
-    offer3 += sdpdata;
-    offer3 += "\n";
-    offer3 += sdpvideo;
-    offer3 += "\n";
-    offer3 += sdpvideo;
-    offer3 += "\n";
-    offer3 += sdpvideo;
-    offer3 += "\n";
-    offer3 += sdpvideo;
-    offer3 += "\n";
-    offer3 += sdpvideo;
-    offer3 += "\n";
+    auto buildSdp = [](UINT32 mediaCount) {
+        auto sdp = std::string("v=0\r\n"
+                               "o=- 481034601 1588366671 IN IP4 0.0.0.0\r\n"
+                               "s=-\r\n"
+                               "t=0 0\r\n"
+                               "a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5\r\n"
+                               "a=group:BUNDLE");
+        for (UINT32 i = 0; i < mediaCount; i++) {
+            sdp += " " + std::to_string(i);
+        }
+        sdp += "\r\n";
+        for (UINT32 i = 0; i < mediaCount; i++) {
+            sdp += sdpvideo;
+            sdp += "\r\n";
+        }
+        return sdp;
+    };
 
-    assertLFAndCRLF((PCHAR) offer3.c_str(), offer3.size(), [](PCHAR sdp) {
+    // Build an SDP with exactly MAX_SDP_SESSION_MEDIA_COUNT media lines - should succeed
+    auto offerAtLimit = buildSdp(MAX_SDP_SESSION_MEDIA_COUNT);
+    {
         SessionDescription sessionDescription;
         MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
-        // as log as Sdp.h  MAX_SDP_SESSION_MEDIA_COUNT 5 this should fail instead of overwriting memory
-        EXPECT_EQ(STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT, deserializeSessionDescription(&sessionDescription, (PCHAR) sdp));
-    });
+        EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) offerAtLimit.c_str()));
+        EXPECT_EQ(sessionDescription.mediaCount, MAX_SDP_SESSION_MEDIA_COUNT);
+    }
+
+    // Build an SDP with MAX_SDP_SESSION_MEDIA_COUNT + 1 media lines - should fail
+    auto offerOverLimit = buildSdp(MAX_SDP_SESSION_MEDIA_COUNT + 1);
+    {
+        SessionDescription sessionDescription;
+        MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+        EXPECT_EQ(STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT, deserializeSessionDescription(&sessionDescription, (PCHAR) offerOverLimit.c_str()));
+    }
 }
 
 // if offer is recvonly answer must be sendonly
@@ -1015,6 +1075,9 @@ a=ssrc:331864867 msid:2e3ca9ff-0c7e-4b9d-9471-2ce80de74b84 757d07a0-892a-46e7-a1
         EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
     });
 
+    // Add more media lines to exceed MAX_SDP_SESSION_MEDIA_COUNT
+    offerBase += unsupportedAudioSdp;
+    offerBase += "\n";
     offerBase += unsupportedAudioSdp;
     offerBase += "\n";
 

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -752,42 +752,40 @@ a=rtpmap:111 opus/48000/2
 a=fmtp:111 minptime=10;useinbandfec=1
 a=rtcp-fb:111 nack)";
 
-TEST_F(SdpApiTest, maxVideoTracksWithSameCodec)
+static std::string buildSdpWithMediaCount(UINT32 mediaCount)
 {
-    auto buildSdp = [](UINT32 mediaCount) {
-        auto sdp = std::string("v=0\r\n"
-                               "o=- 481034601 1588366671 IN IP4 0.0.0.0\r\n"
-                               "s=-\r\n"
-                               "t=0 0\r\n"
-                               "a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5\r\n"
-                               "a=group:BUNDLE");
-        for (UINT32 i = 0; i < mediaCount; i++) {
-            sdp += " " + std::to_string(i);
-        }
+    auto sdp = std::string("v=0\r\n"
+                           "o=- 481034601 1588366671 IN IP4 0.0.0.0\r\n"
+                           "s=-\r\n"
+                           "t=0 0\r\n"
+                           "a=fingerprint:sha-256 87:E6:EC:59:93:76:9F:42:7D:15:17:F6:8F:C4:29:AB:EA:3F:28:B6:DF:F8:14:2F:96:62:2F:16:98:F5:76:E5\r\n"
+                           "a=group:BUNDLE");
+    for (UINT32 i = 0; i < mediaCount; i++) {
+        sdp += " " + std::to_string(i);
+    }
+    sdp += "\r\n";
+    for (UINT32 i = 0; i < mediaCount; i++) {
+        sdp += sdpvideo;
         sdp += "\r\n";
-        for (UINT32 i = 0; i < mediaCount; i++) {
-            sdp += sdpvideo;
-            sdp += "\r\n";
-        }
-        return sdp;
-    };
-
-    // Build an SDP with exactly MAX_SDP_SESSION_MEDIA_COUNT media lines - should succeed
-    auto offerAtLimit = buildSdp(MAX_SDP_SESSION_MEDIA_COUNT);
-    {
-        SessionDescription sessionDescription;
-        MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
-        EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) offerAtLimit.c_str()));
-        EXPECT_EQ(sessionDescription.mediaCount, MAX_SDP_SESSION_MEDIA_COUNT);
     }
+    return sdp;
+}
 
-    // Build an SDP with MAX_SDP_SESSION_MEDIA_COUNT + 1 media lines - should fail
-    auto offerOverLimit = buildSdp(MAX_SDP_SESSION_MEDIA_COUNT + 1);
-    {
-        SessionDescription sessionDescription;
-        MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
-        EXPECT_EQ(STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT, deserializeSessionDescription(&sessionDescription, (PCHAR) offerOverLimit.c_str()));
-    }
+TEST_F(SdpApiTest, maxVideoTracksWithSameCodec_AtLimit)
+{
+    auto offer = buildSdpWithMediaCount(MAX_SDP_SESSION_MEDIA_COUNT);
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) offer.c_str()));
+    EXPECT_EQ(sessionDescription.mediaCount, MAX_SDP_SESSION_MEDIA_COUNT);
+}
+
+TEST_F(SdpApiTest, maxVideoTracksWithSameCodec_OverLimit)
+{
+    auto offer = buildSdpWithMediaCount(MAX_SDP_SESSION_MEDIA_COUNT + 1);
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT, deserializeSessionDescription(&sessionDescription, (PCHAR) offer.c_str()));
 }
 
 // if offer is recvonly answer must be sendonly


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Made `MAX_SDP_SESSION_MEDIA_COUNT` a CMake-configurable parameter (default: 5/unchanged, range: 1-6) instead of a hardcoded value.
- Replaced `CHK` with `CHK_ERR` at all media count limit checks for observability; to log the max and current count on failure.
- Added `docs/SDP_MEDIA_COUNT.md` documenting what consumes slots, stack size implications, and troubleshooting.

*Why was it changed?*
- Adding support for 4 video track + 1 audio track + data channel use case, which consumes 6 slots.
- Keeping it backwards compatible for existing users in terms of memory consumption.

*How was it changed?*
- `Sdp.h`: Replaced `#ifdef ENABLE_DATA_CHANNEL` (5 vs 6) with a single `#ifndef MAX_SDP_SESSION_MEDIA_COUNT` guard defaulting to 5.
- `CMakeLists.txt`: Added `MAX_SDP_SESSION_MEDIA_COUNT` cache variable with range validation (1-6) and conditional `add_definitions`.
- `README.md`: Added the new `-DMAX_SDP_SESSION_MEDIA_COUNT=N` flag entry linking to the doc.
- `Deserialize.c`: Replaced `CHK` with `CHK_ERR` to log max and current count on failure.
- Added `docs/SDP_MEDIA_COUNT.md` with configuration, slot breakdown, stack sizing, and troubleshooting.

*What testing was done for the changes?*
- Tested with `MAX_SDP_SESSION_MEDIA_COUNT=6` on macOS: all 53 SDP tests pass.
- Tested with `MAX_SDP_SESSION_MEDIA_COUNT=6` end-to-end against the JS test page via an internal demo.
- Tested with `MAX_SDP_SESSION_MEDIA_COUNT=1` on macOS: the SDK errors gracefully with `STATUS_SESSION_DESCRIPTION_MAX_MEDIA_COUNT` (0x5500000A) and does not crash.
- Verified CMake rejects out-of-range values (0 and 7).
- Unit tests cover deserialization and offer generation boundary conditions at the limit.
- Data channel test validates `MAX_SDP_SESSION_MEDIA_COUNT - 1` transceivers + data channel succeeds, and one more fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.