### PR TITLE
Fix FU-B depayloader OOB read for non-starting packets

### DIFF
--- a/src/source/Rtp/Codecs/RtpH264Payloader.c
+++ b/src/source/Rtp/Codecs/RtpH264Payloader.c
@@ -264,7 +264,15 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
         case FU_B_INDICATOR:
             // FU-B indicator
             CHK(packetLength > FU_B_HEADER_SIZE, STATUS_RTP_INPUT_PACKET_TOO_SMALL);
-            naluLength = packetLength - FU_B_HEADER_SIZE + 1;
+            naluRefIdc = *pCurPtr & 0x60;
+            pCurPtr++;
+            naluType = *pCurPtr & 0x1f;
+            isStartingPacket = (*pCurPtr & (1 << 7)) != 0;
+            if (isStartingPacket) {
+                naluLength = packetLength - FU_B_HEADER_SIZE + 1;
+            } else {
+                naluLength = packetLength - FU_B_HEADER_SIZE;
+            }
             break;
         case STAP_A_INDICATOR:
             pCurPtr += STAP_A_HEADER_SIZE;

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -896,6 +896,64 @@ TEST_F(RtpFunctionalityTest, depayH265FuRejectsTooSmallPacket)
     EXPECT_EQ(0u, naluLength);
 }
 
+// FU-B non-starting packet must not over-read source buffer.
+// naluLength should be packetLength - FU_B_HEADER_SIZE (not +1) for continuation packets.
+TEST_F(RtpFunctionalityTest, depayH264FuBNonStartNoOverread)
+{
+    UINT32 naluLength = 0;
+    BOOL isStart = FALSE;
+
+    // Crash input from fuzzer: FU-B indicator (0xdd & 0x1F = 0x1D = 29),
+    // FU header byte 0x7c has start bit = 0 (non-starting packet).
+    // 12 bytes total. Without fix, naluLength = 12 - 4 + 1 = 9, but only 8 bytes
+    // are available after the 4-byte header → OOB read.
+    BYTE fuBPacket[] = {0xdd, 0x7c, 0x85, 0x7c, 0x05, 0x00, 0x7c, 0x85, 0x00, 0x00, 0x00, 0x4c};
+
+    // Size calculation: should be 8 (not 9)
+    EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(fuBPacket, SIZEOF(fuBPacket), NULL, &naluLength, &isStart));
+    EXPECT_FALSE(isStart);
+    EXPECT_EQ(8u, naluLength);
+
+    // Copy pass: should succeed without OOB
+    BYTE output[8];
+    UINT32 outputLen = SIZEOF(output);
+    EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(fuBPacket, SIZEOF(fuBPacket), output, &outputLen, &isStart));
+    EXPECT_EQ(8u, outputLen);
+}
+
+// FU-B starting packet should produce naluLength = packetLength - FU_B_HEADER_SIZE + 1
+TEST_F(RtpFunctionalityTest, depayH264FuBStartingPacket)
+{
+    UINT32 naluLength = 0;
+    BOOL isStart = FALSE;
+
+    // FU-B with start bit set: indicator=0x1D|0x60=0x7D, FU header=0x85 (S=1, type=5)
+    // DON=0x00 0x01, payload=0xAA 0xBB 0xCC
+    BYTE fuBStart[] = {0x7d, 0x85, 0x00, 0x01, 0xAA, 0xBB, 0xCC};
+
+    // naluLength = 7 - 4 + 1 = 4 (3 payload bytes + 1 reconstructed NAL byte)
+    // Plus start4ByteCode: total = 4 + 4 = 8
+    EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(fuBStart, SIZEOF(fuBStart), NULL, &naluLength, &isStart));
+    EXPECT_TRUE(isStart);
+    EXPECT_EQ(8u, naluLength);
+
+    // Copy pass
+    BYTE output[8];
+    UINT32 outputLen = SIZEOF(output);
+    EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(fuBStart, SIZEOF(fuBStart), output, &outputLen, &isStart));
+    // First 4 bytes: start code
+    EXPECT_EQ(0x00, output[0]);
+    EXPECT_EQ(0x00, output[1]);
+    EXPECT_EQ(0x00, output[2]);
+    EXPECT_EQ(0x01, output[3]);
+    // Byte 4: reconstructed NAL (naluRefIdc | naluType = 0x60 | 0x05 = 0x65)
+    EXPECT_EQ(0x65, output[4]);
+    // Bytes 5-7: payload
+    EXPECT_EQ(0xAA, output[5]);
+    EXPECT_EQ(0xBB, output[6]);
+    EXPECT_EQ(0xCC, output[7]);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fixed out-of-bounds heap read in `depayH264FromRtpPayload()` for FU-B non-starting packets.

*Why was it changed?*
- The FU-B sizing pass unconditionally computed `naluLength = packetLength - FU_B_HEADER_SIZE + 1`, adding +1 for a reconstructed NAL header byte. Per RFC 3984 §5.8, FU-B MUST only be used for the first fragment (S=1), so the +1 is correct for spec-compliant packets. However, a remote attacker can send a malformed FU-B with the start bit cleared. In that case, the copy pass does `MEMCPY(pNaluData, pRawPacket + FU_B_HEADER_SIZE, naluLength)` — copying `naluLength` bytes from the source buffer. Since only `packetLength - FU_B_HEADER_SIZE` bytes actually exist after the header, the extra +1 causes a 1-byte out-of-bounds read. Parsers must handle malformed input gracefully regardless of spec conformance.

*How was it changed?*
- FU-B now parses the FU header byte to determine `isStartingPacket` (start bit at bit 7), matching FU-A's existing pattern. The `+1` is only applied for starting packets where the extra byte is the reconstructed NAL header written to output, not read from source.
- Also extracts `naluRefIdc` and `naluType` from the FU-B header, which were previously unset for FU-B packets (used in the copy pass for NAL byte reconstruction).

*What testing was done for the changes?*
- Reproduced crash with fuzzer input (12 bytes: `dd 7c 85 7c 05 00 7c 85 00 00 00 4c`) — confirmed ASan heap-buffer-overflow before fix.
- Verified same input runs cleanly after fix (no ASan error, exit code 0).
- Added unit tests: `depayH264FuBNonStartNoOverread` (verifies naluLength=8 for 12-byte non-starting packet), `depayH264FuBStartingPacket` (verifies correct NAL reconstruction and start code prefix for starting packets).
- Both tests pass with `ASAN_OPTIONS=detect_container_overflow=0` (gtest+ASan macOS false positive unrelated to this change).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
