### PR TITLE
Add multi-track sample: 4 video + 1 audio master (kvsWebrtcClientMaster4Video1Audio)

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -59,6 +59,72 @@ jobs:
         run: |
           ./scripts/check-sample.sh
 
+  sample-check-4video1audio:
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      CHANNEL_NAME: SampleChannel4Video1Audio
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2.2.0
+        with:
+          cmake-version: '3.x'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DMAX_SDP_SESSION_MEDIA_COUNT=6 -DKVS_SIGNALING_MESSAGE_LEN=40000 -DPARALLEL_BUILD=ON
+          make -j
+      - name: Prepare signaling channel
+        run: |
+          ./scripts/prepare-channel.sh ${{ env.CHANNEL_NAME }}
+      - name: Run 4 video 1 audio master sample
+        run: |
+          set +e
+          cd build/samples
+          ./kvsWebrtcClientMaster4Video1Audio ${{ env.CHANNEL_NAME }} > master.log 2>&1 &
+          MASTER_PID=$!
+          sleep 10
+          ./kvsWebrtcClientViewer ${{ env.CHANNEL_NAME }} > viewer.log 2>&1 &
+          VIEWER_PID=$!
+          sleep 20
+          kill -s INT $VIEWER_PID 2>/dev/null
+          sleep 5
+          kill -s INT $MASTER_PID 2>/dev/null
+          sleep 10
+          kill -9 $MASTER_PID $VIEWER_PID 2>/dev/null
+          wait $VIEWER_PID 2>/dev/null
+          wait $MASTER_PID 2>/dev/null
+          set -e
+          if ! grep -q "Successfully added 4 video transceivers" master.log; then
+            echo "FAILURE: 4 video transceivers were not added"
+            cat master.log
+            exit 1
+          fi
+          if ! grep -q "New connection state 3" master.log; then
+            echo "FAILURE: PeerConnection was not established"
+            cat master.log
+            cat viewer.log
+            exit 1
+          fi
+          for t in 0 1 2 3; do
+            if ! grep -q "First frame sent on video track $t" master.log; then
+              echo "FAILURE: No frames sent on video track $t"
+              cat master.log
+              exit 1
+            fi
+          done
+          echo "SUCCESS: 4Video1Audio sample - 4 transceivers added, PeerConnection established, frames sent on all 4 video tracks"
+
   sample-check-no-data-channel:
     runs-on: ubuntu-latest
     env:

--- a/README.md
+++ b/README.md
@@ -379,6 +379,28 @@ To run:
 Allowed audio-codec: opus (default codec if nothing is specified)
 Allowed video-codec: h264 (default codec if nothing is specified), h265
 
+##### Sample: kvsWebrtcClientMaster4Video1Audio
+This application sends 4 H264 video tracks and 1 Opus audio track over a single PeerConnection using static sample frames. Each video track is a separate RTP transceiver, allowing the viewer to receive 4 independent video streams simultaneously over a single KVS Signaling Channel.
+
+> [!Note]
+> The SDP must accommodate 6 media sections (4 video + 1 audio + 1 data channel when built with `-DENABLE_DATA_CHANNEL=ON`). Configure the build accordingly for larger SDP sizes:
+> ```shell
+> cmake .. -DMAX_SDP_SESSION_MEDIA_COUNT=6 -DKVS_SIGNALING_MESSAGE_LEN=40000
+> ```
+> Without the proper configuration, the SDP offer will be rejected and the connection will not be established.
+
+By default, all 4 tracks send the same frames from `h264SampleFrames/`. To send **unique** frames per track (recommended for testing), generate per-track frame sets using the provided script. It requires GStreamer to be installed.
+```shell
+cd build/samples
+../../scripts/generate_multi_track_frames.sh
+```
+The sample auto-detects the `h264SampleFrames_track0/` through `h264SampleFrames_track3/` directories at runtime and prints a warning with instructions if they are not found.
+
+To run:
+```shell
+./samples/kvsWebrtcClientMaster4Video1Audio <channelName>
+```
+
 #### WebRTC Storage (ingest) samples
 
 ##### Sample: kvsWebrtcStorageAudioVideoMaster and kvsWebrtcStorageVideoOnlyMaster

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -77,6 +77,13 @@ add_executable(
 target_link_libraries(kvsWebrtcClientViewer kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} kvsCommonLws kvspicUtils websockets)
 
 add_executable(
+  kvsWebrtcClientMaster4Video1Audio
+        common/Common.c
+        common/StaticMedia.c
+        p2p/kvsWebRTCClientMaster4Video1Audio.c)
+target_link_libraries(kvsWebrtcClientMaster4Video1Audio kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} kvsCommonLws kvspicUtils websockets)
+
+add_executable(
         discoverNatBehavior
         discoverNatBehavior.c)
 target_link_libraries(discoverNatBehavior kvsWebrtcClient ${EXTRA_DEPS})
@@ -157,7 +164,7 @@ if(GST_FOUND)
   )
 endif()
 
-install(TARGETS kvsWebrtcClientMaster kvsWebrtcClientViewer discoverNatBehavior
+install(TARGETS kvsWebrtcClientMaster kvsWebrtcClientViewer kvsWebrtcClientMaster4Video1Audio discoverNatBehavior
   RUNTIME DESTINATION bin
 )
 

--- a/samples/p2p/kvsWebRTCClientMaster4Video1Audio.c
+++ b/samples/p2p/kvsWebRTCClientMaster4Video1Audio.c
@@ -1,0 +1,256 @@
+#include "../common/Samples.h"
+#include "../common/StaticMedia.h"
+
+extern PSampleConfiguration gSampleConfiguration;
+
+#define NUM_VIDEO_TRACKS 4
+
+typedef struct {
+    PRtcRtpTransceiver pVideoRtcRtpTransceivers[NUM_VIDEO_TRACKS];
+} MultiTrackStreamingSession, *PMultiTrackStreamingSession;
+
+static MultiTrackStreamingSession gMultiTrackSessions[DEFAULT_MAX_CONCURRENT_STREAMING_SESSION];
+
+STATUS addFourVideoTransceivers(PSampleConfiguration pSampleConfiguration, PSampleStreamingSession pSampleStreamingSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    RtcRtpTransceiverInit videoRtpTransceiverInit;
+    RtcMediaStreamTrack videoTrack;
+    UINT32 i;
+    CHAR trackId[MAX_MEDIA_STREAM_TRACK_ID_LEN + 1];
+    CHAR streamId[MAX_MEDIA_STREAM_TRACK_ID_LEN + 1];
+
+    CHK(pSampleConfiguration != NULL && pSampleStreamingSession != NULL, STATUS_NULL_ARG);
+
+    UINT32 sessionIndex = pSampleConfiguration->streamingSessionCount;
+    CHK(sessionIndex < DEFAULT_MAX_CONCURRENT_STREAMING_SESSION, STATUS_INVALID_OPERATION);
+
+    for (i = 0; i < NUM_VIDEO_TRACKS; i++) {
+        MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        videoTrack.codec = pSampleConfiguration->videoCodec;
+        videoRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;
+
+        SNPRINTF(streamId, MAX_MEDIA_STREAM_TRACK_ID_LEN, "myKvsVideoStream%u", i);
+        SNPRINTF(trackId, MAX_MEDIA_STREAM_TRACK_ID_LEN, "myVideoTrack%u", i);
+        STRCPY(videoTrack.streamId, streamId);
+        STRCPY(videoTrack.trackId, trackId);
+
+        CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &videoTrack, &videoRtpTransceiverInit,
+                                  &gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[i]));
+
+        CHK_STATUS(configureTransceiverRollingBuffer(gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[i], &videoTrack,
+                                                     pSampleConfiguration->videoRollingBufferDurationSec,
+                                                     pSampleConfiguration->videoRollingBufferBitratebps));
+
+        CHK_STATUS(transceiverOnBandwidthEstimation(gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[i],
+                                                    (UINT64) pSampleStreamingSession, sampleBandwidthEstimationHandler));
+    }
+
+    pSampleStreamingSession->pVideoRtcRtpTransceiver = gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[0];
+
+    RtcRtpTransceiverInit audioRtpTransceiverInit;
+    RtcMediaStreamTrack audioTrack;
+    MEMSET(&audioTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+    audioTrack.kind = MEDIA_STREAM_TRACK_KIND_AUDIO;
+    audioTrack.codec = pSampleConfiguration->audioCodec;
+    audioRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;
+    STRCPY(audioTrack.streamId, "myKvsAudioStream");
+    STRCPY(audioTrack.trackId, "myAudioTrack");
+
+    CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &audioTrack, &audioRtpTransceiverInit,
+                              &pSampleStreamingSession->pAudioRtcRtpTransceiver));
+
+    CHK_STATUS(configureTransceiverRollingBuffer(pSampleStreamingSession->pAudioRtcRtpTransceiver, &audioTrack,
+                                                 pSampleConfiguration->audioRollingBufferDurationSec,
+                                                 pSampleConfiguration->audioRollingBufferBitratebps));
+
+    CHK_STATUS(transceiverOnBandwidthEstimation(pSampleStreamingSession->pAudioRtcRtpTransceiver, (UINT64) pSampleStreamingSession,
+                                                sampleBandwidthEstimationHandler));
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+PVOID sendFourVideoPacketsFromDisk(PVOID args)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) args;
+    Frame frame[NUM_VIDEO_TRACKS];
+    UINT32 fileIndex[NUM_VIDEO_TRACKS];
+    UINT32 frameSize;
+    PBYTE pFrameBuffers[NUM_VIDEO_TRACKS];
+    UINT32 frameBufferSizes[NUM_VIDEO_TRACKS];
+    CHAR filePath[MAX_PATH_LEN + 1];
+    STATUS status;
+    UINT32 i, trackIdx;
+    UINT64 startTime, lastFrameTime, elapsed;
+    BOOL usePerTrackDirs = FALSE;
+
+    MEMSET(fileIndex, 0x00, SIZEOF(fileIndex));
+    MEMSET(pFrameBuffers, 0x00, SIZEOF(pFrameBuffers));
+    MEMSET(frameBufferSizes, 0x00, SIZEOF(frameBufferSizes));
+    MEMSET(frame, 0x00, SIZEOF(frame));
+    CHK_ERR(pSampleConfiguration != NULL, STATUS_NULL_ARG, "[KVS Master] Streaming session is NULL");
+
+    {
+        UINT32 dummySize = 0;
+        STATUS checkStatus = readFrameFromDisk(NULL, &dummySize, "./h264SampleFrames_track0/frame-0001.h264");
+        usePerTrackDirs = (checkStatus == STATUS_SUCCESS);
+    }
+
+    if (usePerTrackDirs) {
+        DLOGI("[KVS Master] Using per-track frame directories (h264SampleFrames_track0..3)");
+    } else {
+        DLOGW("[KVS Master] Per-track frame directories not found. Sending the same frames on all 4 tracks.");
+        DLOGW("[KVS Master] To generate unique frames per track, run from the build/samples/ directory:");
+        DLOGW("[KVS Master]   ../../scripts/generate_multi_track_frames.sh");
+    }
+
+    startTime = GETTIME();
+    lastFrameTime = startTime;
+
+    while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->appTerminateFlag)) {
+        for (trackIdx = 0; trackIdx < NUM_VIDEO_TRACKS; trackIdx++) {
+            fileIndex[trackIdx] = fileIndex[trackIdx] % NUMBER_OF_H264_FRAME_FILES + 1;
+            if (usePerTrackDirs) {
+                SNPRINTF(filePath, MAX_PATH_LEN, "./h264SampleFrames_track%u/frame-%04d.h264", trackIdx, fileIndex[trackIdx]);
+            } else {
+                SNPRINTF(filePath, MAX_PATH_LEN, "./h264SampleFrames/frame-%04d.h264", fileIndex[trackIdx]);
+            }
+
+            frameSize = 0;
+            CHK_STATUS(readFrameFromDisk(NULL, &frameSize, filePath));
+
+            if (frameSize > frameBufferSizes[trackIdx]) {
+                pFrameBuffers[trackIdx] = (PBYTE) MEMREALLOC(pFrameBuffers[trackIdx], frameSize);
+                CHK_ERR(pFrameBuffers[trackIdx] != NULL, STATUS_NOT_ENOUGH_MEMORY,
+                        "[KVS Master] Failed to allocate video frame buffer for track %u", trackIdx);
+                frameBufferSizes[trackIdx] = frameSize;
+            }
+
+            frame[trackIdx].frameData = pFrameBuffers[trackIdx];
+            frame[trackIdx].size = frameSize;
+            CHK_STATUS(readFrameFromDisk(frame[trackIdx].frameData, &frameSize, filePath));
+            frame[trackIdx].presentationTs += SAMPLE_VIDEO_FRAME_DURATION;
+        }
+
+        MUTEX_LOCK(pSampleConfiguration->streamingSessionListReadLock);
+        for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
+            for (trackIdx = 0; trackIdx < NUM_VIDEO_TRACKS; trackIdx++) {
+                status = writeFrame(gMultiTrackSessions[i].pVideoRtcRtpTransceivers[trackIdx], &frame[trackIdx]);
+                if (trackIdx == 0 && pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame && status == STATUS_SUCCESS) {
+                    PROFILE_WITH_START_TIME(pSampleConfiguration->sampleStreamingSessionList[i]->offerReceiveTime, "Time to first frame");
+                    pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame = FALSE;
+                }
+                if (status == STATUS_SRTP_NOT_READY_YET) {
+                    fileIndex[trackIdx] = 0;
+                } else if (status != STATUS_SUCCESS) {
+                    DLOGV("writeFrame() for track %u failed with 0x%08x", trackIdx, status);
+                }
+            }
+        }
+        MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);
+
+        elapsed = lastFrameTime - startTime;
+        THREAD_SLEEP(SAMPLE_VIDEO_FRAME_DURATION - elapsed % SAMPLE_VIDEO_FRAME_DURATION);
+        lastFrameTime = GETTIME();
+    }
+
+CleanUp:
+    for (trackIdx = 0; trackIdx < NUM_VIDEO_TRACKS; trackIdx++) {
+        SAFE_MEMFREE(pFrameBuffers[trackIdx]);
+    }
+    DLOGI("Closing video thread");
+    CHK_LOG_ERR(retStatus);
+    return (PVOID) (ULONG_PTR) retStatus;
+}
+
+INT32 main(INT32 argc, CHAR* argv[])
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PSampleConfiguration pSampleConfiguration = NULL;
+    PCHAR pChannelName;
+    SignalingClientMetrics signalingClientMetrics;
+    signalingClientMetrics.version = SIGNALING_CLIENT_METRICS_CURRENT_VERSION;
+
+    SET_INSTRUMENTED_ALLOCATORS();
+    UINT32 logLevel = setLogLevel();
+
+#ifndef _WIN32
+    signal(SIGINT, sigintHandler);
+#endif
+
+#ifdef IOT_CORE_ENABLE_CREDENTIALS
+    CHK_ERR((pChannelName = argc > 1 ? argv[1] : GETENV(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION,
+            "AWS_IOT_CORE_THING_NAME must be set");
+#else
+    pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
+#endif
+
+    CHK_STATUS(createSampleConfiguration(pChannelName, SIGNALING_CHANNEL_ROLE_TYPE_MASTER, TRUE, TRUE, logLevel, &pSampleConfiguration));
+
+    CHK_STATUS(useStaticFramePresets(pSampleConfiguration, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+    CHK_STATUS(useStaticFramePresets(pSampleConfiguration, RTC_CODEC_OPUS));
+    pSampleConfiguration->videoSource = sendFourVideoPacketsFromDisk;
+
+#ifdef ENABLE_DATA_CHANNEL
+    pSampleConfiguration->onDataChannel = onDataChannel;
+#endif
+    pSampleConfiguration->mediaType = SAMPLE_STREAMING_AUDIO_VIDEO;
+    pSampleConfiguration->addTransceiversCallback = addFourVideoTransceivers;
+    DLOGI("[KVS Master] Finished setting up four video track handlers");
+
+    CHK_STATUS(initKvsWebRtc());
+    DLOGI("[KVS Master] KVS WebRTC initialization completed successfully");
+
+    PROFILE_CALL_WITH_START_END_T_OBJ(
+        retStatus = initSignaling(pSampleConfiguration, SAMPLE_MASTER_CLIENT_ID), pSampleConfiguration->signalingClientMetrics.signalingStartTime,
+        pSampleConfiguration->signalingClientMetrics.signalingEndTime, pSampleConfiguration->signalingClientMetrics.signalingCallTime,
+        "Initialize signaling client and connect to the signaling channel");
+
+    DLOGI("[KVS Master] Channel %s set up done ", pChannelName);
+
+    CHK_STATUS(sessionCleanupWait(pSampleConfiguration));
+    DLOGI("[KVS Master] Streaming session terminated");
+
+CleanUp:
+
+    if (retStatus != STATUS_SUCCESS) {
+        DLOGE("[KVS Master] Terminated with status code 0x%08x", retStatus);
+    }
+
+    DLOGI("[KVS Master] Cleaning up....");
+    if (pSampleConfiguration != NULL) {
+        ATOMIC_STORE_BOOL(&pSampleConfiguration->appTerminateFlag, TRUE);
+
+        if (pSampleConfiguration->mediaSenderTid != INVALID_TID_VALUE) {
+            THREAD_JOIN(pSampleConfiguration->mediaSenderTid, NULL);
+        }
+
+        retStatus = signalingClientGetMetrics(pSampleConfiguration->signalingClientHandle, &signalingClientMetrics);
+        if (retStatus == STATUS_SUCCESS) {
+            logSignalingClientStats(&signalingClientMetrics);
+        } else {
+            DLOGE("[KVS Master] signalingClientGetMetrics() operation returned status code: 0x%08x", retStatus);
+        }
+        retStatus = freeSignalingClient(&pSampleConfiguration->signalingClientHandle);
+        if (retStatus != STATUS_SUCCESS) {
+            DLOGE("[KVS Master] freeSignalingClient(): operation returned status code: 0x%08x", retStatus);
+        }
+
+        retStatus = freeSampleConfiguration(&pSampleConfiguration);
+        if (retStatus != STATUS_SUCCESS) {
+            DLOGE("[KVS Master] freeSampleConfiguration(): operation returned status code: 0x%08x", retStatus);
+        }
+    }
+    DLOGI("[KVS Master] Cleanup done");
+    CHK_LOG_ERR(retStatus);
+
+    RESET_INSTRUMENTED_ALLOCATORS();
+
+    return STATUS_FAILED(retStatus) ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/samples/p2p/kvsWebRTCClientMaster4Video1Audio.c
+++ b/samples/p2p/kvsWebRTCClientMaster4Video1Audio.c
@@ -9,7 +9,12 @@ typedef struct {
     PRtcRtpTransceiver pVideoRtcRtpTransceivers[NUM_VIDEO_TRACKS];
 } MultiTrackStreamingSession, *PMultiTrackStreamingSession;
 
-static MultiTrackStreamingSession gMultiTrackSessions[DEFAULT_MAX_CONCURRENT_STREAMING_SESSION];
+static VOID onMultiTrackSessionShutdown(UINT64 customData, PSampleStreamingSession pSampleStreamingSession)
+{
+    UNUSED_PARAM(pSampleStreamingSession);
+    PMultiTrackStreamingSession pMultiTrackSession = (PMultiTrackStreamingSession) customData;
+    SAFE_MEMFREE(pMultiTrackSession);
+}
 
 STATUS addFourVideoTransceivers(PSampleConfiguration pSampleConfiguration, PSampleStreamingSession pSampleStreamingSession)
 {
@@ -20,11 +25,12 @@ STATUS addFourVideoTransceivers(PSampleConfiguration pSampleConfiguration, PSamp
     UINT32 i;
     CHAR trackId[MAX_MEDIA_STREAM_TRACK_ID_LEN + 1];
     CHAR streamId[MAX_MEDIA_STREAM_TRACK_ID_LEN + 1];
+    PMultiTrackStreamingSession pMultiTrackSession = NULL;
 
     CHK(pSampleConfiguration != NULL && pSampleStreamingSession != NULL, STATUS_NULL_ARG);
 
-    UINT32 sessionIndex = pSampleConfiguration->streamingSessionCount;
-    CHK(sessionIndex < DEFAULT_MAX_CONCURRENT_STREAMING_SESSION, STATUS_INVALID_OPERATION);
+    pMultiTrackSession = (PMultiTrackStreamingSession) MEMCALLOC(1, SIZEOF(MultiTrackStreamingSession));
+    CHK(pMultiTrackSession != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
     for (i = 0; i < NUM_VIDEO_TRACKS; i++) {
         MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
@@ -38,17 +44,19 @@ STATUS addFourVideoTransceivers(PSampleConfiguration pSampleConfiguration, PSamp
         STRCPY(videoTrack.trackId, trackId);
 
         CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &videoTrack, &videoRtpTransceiverInit,
-                                  &gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[i]));
+                                  &pMultiTrackSession->pVideoRtcRtpTransceivers[i]));
 
-        CHK_STATUS(configureTransceiverRollingBuffer(gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[i], &videoTrack,
+        CHK_STATUS(configureTransceiverRollingBuffer(pMultiTrackSession->pVideoRtcRtpTransceivers[i], &videoTrack,
                                                      pSampleConfiguration->videoRollingBufferDurationSec,
                                                      pSampleConfiguration->videoRollingBufferBitratebps));
 
-        CHK_STATUS(transceiverOnBandwidthEstimation(gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[i], (UINT64) pSampleStreamingSession,
+        CHK_STATUS(transceiverOnBandwidthEstimation(pMultiTrackSession->pVideoRtcRtpTransceivers[i], (UINT64) pSampleStreamingSession,
                                                     sampleBandwidthEstimationHandler));
     }
 
-    pSampleStreamingSession->pVideoRtcRtpTransceiver = gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[0];
+    pSampleStreamingSession->pVideoRtcRtpTransceiver = pMultiTrackSession->pVideoRtcRtpTransceivers[0];
+
+    CHK_STATUS(streamingSessionOnShutdown(pSampleStreamingSession, (UINT64) pMultiTrackSession, onMultiTrackSessionShutdown));
 
     RtcRtpTransceiverInit audioRtpTransceiverInit;
     RtcMediaStreamTrack audioTrack;
@@ -69,7 +77,12 @@ STATUS addFourVideoTransceivers(PSampleConfiguration pSampleConfiguration, PSamp
     CHK_STATUS(transceiverOnBandwidthEstimation(pSampleStreamingSession->pAudioRtcRtpTransceiver, (UINT64) pSampleStreamingSession,
                                                 sampleBandwidthEstimationHandler));
 
+    DLOGI("[KVS Master] Successfully added %u video transceivers and 1 audio transceiver", NUM_VIDEO_TRACKS);
+
 CleanUp:
+    if (STATUS_FAILED(retStatus)) {
+        SAFE_MEMFREE(pMultiTrackSession);
+    }
     CHK_LOG_ERR(retStatus);
     LEAVES();
     return retStatus;
@@ -89,7 +102,9 @@ PVOID sendFourVideoPacketsFromDisk(PVOID args)
     UINT32 i, trackIdx;
     UINT64 startTime, lastFrameTime, elapsed;
     BOOL usePerTrackDirs = FALSE;
+    BOOL trackSentFirstFrame[NUM_VIDEO_TRACKS];
 
+    MEMSET(trackSentFirstFrame, 0x00, SIZEOF(trackSentFirstFrame));
     MEMSET(fileIndex, 0x00, SIZEOF(fileIndex));
     MEMSET(pFrameBuffers, 0x00, SIZEOF(pFrameBuffers));
     MEMSET(frameBufferSizes, 0x00, SIZEOF(frameBufferSizes));
@@ -140,13 +155,21 @@ PVOID sendFourVideoPacketsFromDisk(PVOID args)
 
         MUTEX_LOCK(pSampleConfiguration->streamingSessionListReadLock);
         for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
+            PMultiTrackStreamingSession pMultiTrackSession =
+                (PMultiTrackStreamingSession) pSampleConfiguration->sampleStreamingSessionList[i]->shutdownCallbackCustomData;
+            if (pMultiTrackSession == NULL) {
+                continue;
+            }
             for (trackIdx = 0; trackIdx < NUM_VIDEO_TRACKS; trackIdx++) {
-                status = writeFrame(gMultiTrackSessions[i].pVideoRtcRtpTransceivers[trackIdx], &frame[trackIdx]);
+                status = writeFrame(pMultiTrackSession->pVideoRtcRtpTransceivers[trackIdx], &frame[trackIdx]);
                 if (trackIdx == 0 && pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame && status == STATUS_SUCCESS) {
                     PROFILE_WITH_START_TIME(pSampleConfiguration->sampleStreamingSessionList[i]->offerReceiveTime, "Time to first frame");
                     pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame = FALSE;
                 }
-                if (status == STATUS_SRTP_NOT_READY_YET) {
+                if (status == STATUS_SUCCESS && !trackSentFirstFrame[trackIdx]) {
+                    DLOGI("[KVS Master] First frame sent on video track %u", trackIdx);
+                    trackSentFirstFrame[trackIdx] = TRUE;
+                } else if (status == STATUS_SRTP_NOT_READY_YET) {
                     fileIndex[trackIdx] = 0;
                 } else if (status != STATUS_SUCCESS) {
                     DLOGV("writeFrame() for track %u failed with 0x%08x", trackIdx, status);

--- a/samples/p2p/kvsWebRTCClientMaster4Video1Audio.c
+++ b/samples/p2p/kvsWebRTCClientMaster4Video1Audio.c
@@ -44,8 +44,8 @@ STATUS addFourVideoTransceivers(PSampleConfiguration pSampleConfiguration, PSamp
                                                      pSampleConfiguration->videoRollingBufferDurationSec,
                                                      pSampleConfiguration->videoRollingBufferBitratebps));
 
-        CHK_STATUS(transceiverOnBandwidthEstimation(gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[i],
-                                                    (UINT64) pSampleStreamingSession, sampleBandwidthEstimationHandler));
+        CHK_STATUS(transceiverOnBandwidthEstimation(gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[i], (UINT64) pSampleStreamingSession,
+                                                    sampleBandwidthEstimationHandler));
     }
 
     pSampleStreamingSession->pVideoRtcRtpTransceiver = gMultiTrackSessions[sessionIndex].pVideoRtcRtpTransceivers[0];
@@ -127,8 +127,8 @@ PVOID sendFourVideoPacketsFromDisk(PVOID args)
 
             if (frameSize > frameBufferSizes[trackIdx]) {
                 pFrameBuffers[trackIdx] = (PBYTE) MEMREALLOC(pFrameBuffers[trackIdx], frameSize);
-                CHK_ERR(pFrameBuffers[trackIdx] != NULL, STATUS_NOT_ENOUGH_MEMORY,
-                        "[KVS Master] Failed to allocate video frame buffer for track %u", trackIdx);
+                CHK_ERR(pFrameBuffers[trackIdx] != NULL, STATUS_NOT_ENOUGH_MEMORY, "[KVS Master] Failed to allocate video frame buffer for track %u",
+                        trackIdx);
                 frameBufferSizes[trackIdx] = frameSize;
             }
 

--- a/scripts/generate_multi_track_frames.sh
+++ b/scripts/generate_multi_track_frames.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Generate 4 sets of H264 sample frames with different videotestsrc patterns
+# and a large centered "Track #N" text overlay for multi-track demo.
+#
+# Requires: gstreamer, gst-plugins-base, gst-plugins-good, gst-plugins-ugly (x264enc),
+#           gst-plugins-bad (for some patterns), and the pango text overlay plugin.
+#
+# Usage: Run from the build/samples/ directory:
+#   cd build/samples && ../../scripts/generate_multi_track_frames.sh
+
+set -e
+
+PATTERNS=("ball" "smpte" "snow" "circular")
+NUM_BUFFERS=1500
+WIDTH=1280
+HEIGHT=720
+FPS=25
+BITRATE=512
+
+for i in 0 1 2 3; do
+    DIR="h264SampleFrames_track${i}"
+    PATTERN="${PATTERNS[$i]}"
+
+    echo "Generating track ${i} frames with pattern '${PATTERN}' into ${DIR}/"
+    mkdir -p "${DIR}"
+
+    gst-launch-1.0 -e \
+        videotestsrc pattern="${PATTERN}" num-buffers=${NUM_BUFFERS} ! \
+        videoconvert ! \
+        video/x-raw,format=I420,width=${WIDTH},height=${HEIGHT},framerate=${FPS}/1 ! \
+        textoverlay text="Track #${i}" valignment=center halignment=center font-desc="Sans Bold 72" ! \
+        videoconvert ! \
+        video/x-raw,format=I420 ! \
+        queue ! \
+        x264enc bframes=0 speed-preset=veryfast bitrate=${BITRATE} byte-stream=TRUE tune=zerolatency key-int-max=25 ! \
+        video/x-h264,stream-format=byte-stream,alignment=au,profile=baseline ! \
+        multifilesink location="${DIR}/frame-%04d.h264" index=1
+
+    echo "Track ${i} done: $(ls ${DIR}/frame-*.h264 | wc -l) frames generated."
+done
+
+echo ""
+echo "All 4 track frame sets generated successfully."

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1085,6 +1085,20 @@ STATUS populateSessionDescriptionMedia(PKvsPeerConnection pKvsPeerConnection, PS
         // if an m-line does not have a corresponding transceiver created by the user, we create a fake transceiver
         CHK_STATUS(findTransceiversByRemoteDescription(pKvsPeerConnection, pRemoteSessionDescription, pUnknownCodecPayloadTypesTable,
                                                        pUnknownCodecRtpmapTable));
+
+        {
+            UINT32 localTransceiverCount = 0, answerTransceiverCount = 0;
+            doubleListGetNodeCount(pKvsPeerConnection->pTransceivers, &localTransceiverCount);
+            doubleListGetNodeCount(pKvsPeerConnection->pAnswerTransceivers, &answerTransceiverCount);
+            if (localTransceiverCount > answerTransceiverCount) {
+                DLOGW("Only %u of %u local transceivers matched remote offer m-lines (%u media). "
+                      "%u transceivers will not be negotiated. "
+                      "Ensure the remote peer's offer includes a matching number of m-lines (e.g. addTransceiver() calls).",
+                      answerTransceiverCount, localTransceiverCount, pRemoteSessionDescription->mediaCount,
+                      localTransceiverCount - answerTransceiverCount);
+            }
+        }
+
         // pAnswerTransceivers contains transceivers created by the user as well as fake transceivers
         CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pAnswerTransceivers, &pCurNode));
         while (pCurNode != NULL) {
@@ -1518,6 +1532,8 @@ STATUS findTransceiversByRemoteDescription(PKvsPeerConnection pKvsPeerConnection
 
         // if we have not found a transceiver for an m-line or if the codec is unsupported, got to this section to generate a fake transceiver
         if (!foundMediaSectionWithCodec && (streamKind == MEDIA_STREAM_TRACK_KIND_AUDIO || streamKind == MEDIA_STREAM_TRACK_KIND_VIDEO)) {
+            DLOGW("No matching local transceiver for remote %s m-line %u, responding with inactive direction",
+                  streamKind == MEDIA_STREAM_TRACK_KIND_AUDIO ? "audio" : "video", currentMedia);
             MEMSET(&track, 0x00, SIZEOF(RtcMediaStreamTrack));
             track.kind = streamKind;
             track.codec = RTC_CODEC_UNKNOWN;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added a new p2p master sample (`kvsWebrtcClientMaster4Video1Audio`) that sends 4 H264 video tracks and 1 Opus audio track over a single PeerConnection.
- Added `scripts/generate_multi_track_frames.sh` to generate unique per-track H264 sample frames using GStreamer with distinct videotestsrc patterns (ball, smpte, snow, circular) and "Track #N" text overlays.
- Updated `samples/CMakeLists.txt` to build and install the new sample target.
- Updated `README.md` with documentation for the new sample, including build configuration requirements and usage instructions.

*Why was it changed?*
- To provide a reference sample for multi-track video streaming over a single KVS signaling channel and PeerConnection. This enables testing and demonstration of scenarios that require multiple simultaneous video streams (e.g., multi-camera setups).

*How was it changed?*
- The new sample creates 4 send-only video transceivers (each on its own stream/track ID) and 1 send-only audio transceiver.
- A custom `AddTransceiversCallback` replaces the default single-video setup with the 4-video setup.
- The video sender reads H264 frames from per-track directories (`h264SampleFrames_track0/` through `_track3/`) when available. If those directories are not found, it falls back to sending the same frames from `h264SampleFrames/` on all 4 tracks and prints a warning with instructions to generate unique frames.
- The sample hard-codes H264 and Opus codecs with a single `channelName` argument for simplicity.
- Requires `-DMAX_SDP_SESSION_MEDIA_COUNT=6 -DKVS_SIGNALING_MESSAGE_LEN=40000` at cmake configure time to accommodate the 6 media sections (4 video + 1 audio + 1 data channel).

*What testing was done for the changes?*
- Ran the new sample against the updated JS test page (internal demo)
- Added new CI to run the job, which passes on my fork

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.