### PR TITLE
tst: fail instead of crashing when ICE config retrieval fails in the fixture

### DIFF
--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -279,17 +279,21 @@ void WebRtcClientTestBase::addTrackToPeerConnection(PRtcPeerConnection pRtcPeerC
 
 void WebRtcClientTestBase::getIceServers(PRtcConfiguration pRtcConfiguration)
 {
-    UINT32 i, j, iceConfigCount, uriCount;
-    PIceConfigInfo pIceConfigInfo;
+    UINT32 i, j, iceConfigCount = 0, uriCount;
+    PIceConfigInfo pIceConfigInfo = NULL;
 
-    // Assume signaling client is already created
-    EXPECT_EQ(STATUS_SUCCESS, signalingClientGetIceConfigInfoCount(mSignalingClientHandle, &iceConfigCount));
+    // Assume signaling client is already created.
+    // ASSERT (not EXPECT): on failure the out-params are never written, and
+    // continuing would iterate a garbage count / dereference a garbage pointer
+    // and crash the whole test binary instead of failing the test.
+    ASSERT_EQ(STATUS_SUCCESS, signalingClientGetIceConfigInfoCount(mSignalingClientHandle, &iceConfigCount));
 
     // Set the  STUN server
     SNPRINTF(pRtcConfiguration->iceServers[0].urls, MAX_ICE_CONFIG_URI_LEN, KINESIS_VIDEO_STUN_URL, TEST_DEFAULT_REGION, TEST_DEFAULT_STUN_URL_POSTFIX);
 
     for (uriCount = 0, i = 0; i < iceConfigCount; i++) {
-        EXPECT_EQ(STATUS_SUCCESS, signalingClientGetIceConfigInfo(mSignalingClientHandle, i, &pIceConfigInfo));
+        ASSERT_EQ(STATUS_SUCCESS, signalingClientGetIceConfigInfo(mSignalingClientHandle, i, &pIceConfigInfo));
+        ASSERT_NE(nullptr, pIceConfigInfo);
         for (j = 0; j < pIceConfigInfo->uriCount; j++) {
             STRNCPY(pRtcConfiguration->iceServers[uriCount + 1].urls, pIceConfigInfo->uris[j], MAX_ICE_CONFIG_URI_LEN);
             STRNCPY(pRtcConfiguration->iceServers[uriCount + 1].credential, pIceConfigInfo->password, MAX_ICE_CONFIG_CREDENTIAL_LEN);


### PR DESCRIPTION
`WebRtcClientTestBase::getIceServers()` declares `iceConfigCount` / `pIceConfigInfo` uninitialized and checks the signaling calls with `EXPECT_EQ`, which records the failure but keeps executing. When `signalingClientGetIceConfigInfoCount/Info` fail for any environmental reason (network flake, expired credentials, endpoint issue), the out-params are never written — the loop then iterates a garbage count and dereferences a garbage pointer, crashing the whole test binary (SIGSEGV/SIGBUS) and killing the CI job instead of failing the one test.

This is what turned the recent mbedTLS4 Mac job failures into `Bus error: 10` (the underlying connectivity issue there is separate, fixed via warmcat/libwebsockets#3633 and carried on #2325): the fixture converted an ICE-config fetch failure into a crash at `WebRTCClientTestFixture.cpp:286`.

Change: initialize the locals, use `ASSERT_EQ`/`ASSERT_NE` so a failed fetch aborts the helper and the test fails with a readable assertion. Test-only, no product code touched.

Verified on macOS arm64 (mbedTLS build): fixture-using tests pass unchanged; with a simulated fetch failure the test now fails cleanly instead of crashing.