### PR TITLE
Add video-only and audio+video option for the kvsWebrtcClientMaster sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,9 +328,10 @@ After executing `make` you will have sample applications in your `build/samples`
 ##### Sample: kvsWebrtcClientMaster
 This application sends sample H264/Opus frames (path: `/samples/h264SampleFrames` and `/samples/opusSampleFrames`) via WebRTC. It also accepts incoming audio, if enabled in the browser. When checked in the browser, it prints the metadata of the received audio packets in your terminal. To run:
 ```shell
-./samples/kvsWebrtcClientMaster <channelName> <audio-codec> <video-codec>
+./samples/kvsWebrtcClientMaster <channelName> <mediaType> <audio-codec> <video-codec>
 ```
 
+Allowed mediaType: audio-video (default if nothing is specified), video-only
 Allowed audio-codec: opus (default codec if nothing is specified)
 Allowed video-codec: h264 (default codec if nothing is specified), h265
 

--- a/samples/p2p/kvsWebRTCClientMaster.c
+++ b/samples/p2p/kvsWebRTCClientMaster.c
@@ -30,6 +30,19 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     CHK_STATUS(createSampleConfiguration(pChannelName, SIGNALING_CHANNEL_ROLE_TYPE_MASTER, TRUE, TRUE, logLevel, &pSampleConfiguration));
 
+    pSampleConfiguration->mediaType = SAMPLE_STREAMING_AUDIO_VIDEO;
+    if (argc > 2) {
+        if (!STRCMP(argv[2], "video-only")) {
+            pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
+            DLOGI("[KVS Master] Streaming video only");
+        } else if (!STRCMP(argv[2], "audio-video")) {
+            pSampleConfiguration->mediaType = SAMPLE_STREAMING_AUDIO_VIDEO;
+            DLOGI("[KVS Master] Streaming audio and video");
+        } else {
+            DLOGW("[KVS Master] Unrecognized streaming type. Defaulting to audio-video");
+        }
+    }
+
     if (argc > 3) {
         if (!STRCMP(argv[3], AUDIO_CODEC_NAME_OPUS)) {
             audioCodec = RTC_CODEC_OPUS;
@@ -39,8 +52,9 @@ INT32 main(INT32 argc, CHAR* argv[])
     if (argc > 4) {
         if (!STRCMP(argv[4], VIDEO_CODEC_NAME_H265)) {
             videoCodec = RTC_CODEC_H265;
+            DLOGI("[KVS Master] Using H265 frames");
         } else {
-            DLOGI("[KVS Master] Defaulting to H264 as the specified codec's sample frames may not be available");
+            DLOGW("[KVS Master] Defaulting to H264 as the specified codec's sample frames may not be available");
         }
     }
 
@@ -51,7 +65,6 @@ INT32 main(INT32 argc, CHAR* argv[])
 #ifdef ENABLE_DATA_CHANNEL
     pSampleConfiguration->onDataChannel = onDataChannel;
 #endif
-    pSampleConfiguration->mediaType = SAMPLE_STREAMING_AUDIO_VIDEO;
     DLOGI("[KVS Master] Finished setting handlers");
 
     // Initialize KVS WebRTC. This must be done before anything else, and must only be done once.


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fixed the documented usage for the `kvsWebrtcClientMaster` sample in `README.md`. The signature now reads `<channelName> <mediaType> <audio-codec> <video-codec>` and documents the allowed `mediaType` values (`audio-video`, `video-only`).
- Implemented `mediaType` argument parsing (`argv[2]`) in `samples/p2p/kvsWebRTCClientMaster.c` so the `audio-video` / `video-only` option actually takes effect, and removed the now-redundant hardcoded `mediaType` assignment.

*Why was it changed?*
- The README was off by one relative to the code: it documented `kvsWebrtcClientMaster <channelName> <audio-codec> <video-codec>`, but the sample reads the audio codec from `argv[3]` and the video codec from `argv[4]`. `argv[2]` was undocumented and never read, so following the README (e.g. `kvsWebrtcClientMaster demo-channel opus h265`) would place the codecs in the wrong slots and instead use H264 instead of the intended H265.

*How was it changed?*
- `samples/p2p/kvsWebRTCClientMaster.c`: added parsing of `argv[2]` for `audio-video` / `video-only`, defaulting to `audio-video` (the sample's prior behavior) and logging an unrecognized value. This mirrors the existing pattern in `kvsWebRTCClientMasterGstSample.c`. Removed the later hardcoded `pSampleConfiguration->mediaType = SAMPLE_STREAMING_AUDIO_VIDEO;` line since it's now set from the argument. `Common.c` already keys audio/video sender thread creation off `mediaType`, so `video-only` now takes effect.
- `README.md`: corrected the `kvsWebrtcClientMaster` usage string to include `<mediaType>` and documented the allowed values.

*What testing was done for the changes?*
- Ran: `./samples/kvsWebrtcClientMaster demo-channel-7 video-only opus h265` against the [Android viewer](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android) using [M144](https://github.com/webrtc-sdk/android/releases/tag/v144.7559.09) and verified H265 frames are being sent and playable on the Android viewer side.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
