### PR TITLE
Samples: Log the invocation command (argc/argv) at startup

### DIFF
--- a/samples/common/Common.c
+++ b/samples/common/Common.c
@@ -24,6 +24,18 @@ UINT32 setLogLevel()
     return logLevel;
 }
 
+VOID logSampleInvocation(INT32 argc, CHAR* argv[])
+{
+    INT32 i;
+    // Log the exact command line used to launch the sample. This makes it unambiguous from the
+    // logs alone which sample binary and arguments were run (e.g. static-frame vs. GStreamer
+    // source), which is otherwise easy to misattribute when triaging.
+    DLOGI("Sample invocation: argc=%d", argc);
+    for (i = 0; i < argc; i++) {
+        DLOGI("  argv[%d]: %s", i, argv[i] != NULL ? argv[i] : "(null)");
+    }
+}
+
 STATUS signalingCallFailed(STATUS status)
 {
     return (STATUS_SIGNALING_GET_TOKEN_CALL_FAILED == status || STATUS_SIGNALING_DESCRIBE_CALL_FAILED == status ||

--- a/samples/common/Samples.h
+++ b/samples/common/Samples.h
@@ -311,6 +311,7 @@ STATUS getPendingMessageQueueForHash(PStackQueue, UINT64, BOOL, PPendingMessageQ
 STATUS initSignaling(PSampleConfiguration, PCHAR);
 BOOL sampleFilterNetworkInterfaces(UINT64, PCHAR);
 UINT32 setLogLevel();
+VOID logSampleInvocation(INT32, CHAR*[]);
 STATUS checkSampleFramesExist(RTC_CODEC);
 STATUS addSendrecvVideoAndAudioTransceivers(PSampleConfiguration, PSampleStreamingSession);
 STATUS addSendOnlyVideoRecvOnlyAudioTransceivers(PSampleConfiguration, PSampleStreamingSession);

--- a/samples/p2p/kvsWebRTCClientMaster.c
+++ b/samples/p2p/kvsWebRTCClientMaster.c
@@ -16,6 +16,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
 #ifndef _WIN32
     signal(SIGINT, sigintHandler);

--- a/samples/p2p/kvsWebRTCClientMaster4Video1Audio.c
+++ b/samples/p2p/kvsWebRTCClientMaster4Video1Audio.c
@@ -202,6 +202,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
 #ifndef _WIN32
     signal(SIGINT, sigintHandler);

--- a/samples/p2p/kvsWebRTCClientMasterGstSample.c
+++ b/samples/p2p/kvsWebRTCClientMasterGstSample.c
@@ -13,6 +13,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
     signal(SIGINT, sigintHandler);
 

--- a/samples/p2p/kvsWebRTCClientViewer.c
+++ b/samples/p2p/kvsWebRTCClientViewer.c
@@ -47,6 +47,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
 #ifndef _WIN32
     signal(SIGINT, sigintHandler);

--- a/samples/p2p/kvsWebRTCClientViewerGstSample.c
+++ b/samples/p2p/kvsWebRTCClientViewerGstSample.c
@@ -47,6 +47,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
 #ifndef _WIN32
     signal(SIGINT, sigintHandler);

--- a/samples/webrtcstorage/kvsWebRTCStorageAudioVideoMasterGstSample.c
+++ b/samples/webrtcstorage/kvsWebRTCStorageAudioVideoMasterGstSample.c
@@ -11,6 +11,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
     signal(SIGINT, sigintHandler);
 

--- a/samples/webrtcstorage/kvsWebRTCStorageAudioVideoMasterSample.c
+++ b/samples/webrtcstorage/kvsWebRTCStorageAudioVideoMasterSample.c
@@ -20,6 +20,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
 #ifndef _WIN32
     signal(SIGINT, sigintHandler);

--- a/samples/webrtcstorage/kvsWebRTCStorageVideoOnlyMasterGstSample.c
+++ b/samples/webrtcstorage/kvsWebRTCStorageVideoOnlyMasterGstSample.c
@@ -11,6 +11,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
     signal(SIGINT, sigintHandler);
 

--- a/samples/webrtcstorage/kvsWebRTCStorageVideoOnlyMasterSample.c
+++ b/samples/webrtcstorage/kvsWebRTCStorageVideoOnlyMasterSample.c
@@ -18,6 +18,7 @@ INT32 main(INT32 argc, CHAR* argv[])
 
     SET_INSTRUMENTED_ALLOCATORS();
     UINT32 logLevel = setLogLevel();
+    logSampleInvocation(argc, argv);
 
 #ifndef _WIN32
     signal(SIGINT, sigintHandler);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Every streaming sample now logs the exact command line it was launched with (`argc` and each `argv[i]`) as the first lines of `main()`, at `INFO` level.
- Added a shared helper `logSampleInvocation(INT32 argc, CHAR* argv[])` in `samples/common/Common.c`, declared in `samples/common/Samples.h`.

*Why was it changed?*
- The static-frame and GStreamer variants of a sample are separate binaries with similar names but different media sources — the static-frame samples send pre-encoded frames from disk, while the GStreamer samples use a live pipeline.
- When triaging logs, it was easy to misattribute observed behavior (e.g. "a file-based source was used") to the wrong sample, because the logs did not record which binary or arguments were actually run.
- Logging the invocation up front removes that ambiguity: the binary name (`argv[0]`) and its arguments are now visible directly in the log, with no need to ask the operator for shell history.

*How was it changed?*
- `logSampleInvocation()` iterates `argv` and emits one `DLOGI` line for `argc` and one per argument (null-safe).
- It is called immediately after `setLogLevel()` so the invocation is logged at the very start of the run, before any signaling or media setup.
- The declaration lives in `Samples.h` and the definition in `Common.c`, matching the existing pattern for shared sample helpers like `setLogLevel()`.

*What testing was done for the changes?*
- Built the samples locally (`cmake --build`) — compiles and links cleanly.
- Ran `kvsWebrtcStorageVideoOnlyMaster testchannel-xyz` and confirmed the log now begins with:
  ```
  INFO logSampleInvocation(): Sample invocation: argc=2
  INFO logSampleInvocation():   argv[0]: ./kvsWebrtcStorageVideoOnlyMaster
  INFO logSampleInvocation():   argv[1]: testchannel-xyz
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
