### PR TITLE
TurnConnection: Improve observability on stale TURN credentials + fail fast

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -400,6 +400,7 @@ extern "C" {
 #define STATUS_TURN_INVALID_STATE                                          STATUS_ICE_BASE + 0x0000002b
 #define STATUS_TURN_CONNECTION_GET_CREDENTIALS_FAILED                      STATUS_ICE_BASE + 0x0000002c
 #define STATUS_FAILED_TO_INIT_RELAY_CANDIDATES                             STATUS_ICE_BASE + 0x0000002d
+#define STATUS_TURN_CONNECTION_CREDENTIALS_REJECTED                        STATUS_ICE_BASE + 0x0000002e
 
 /*!@} */
 

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -95,9 +95,11 @@ STATUS createTurnConnection(PIceServer pTurnServer, TIMER_QUEUE_HANDLE timerQueu
     pTurnConnection->dataTransferMode = dataTransferMode;
     pTurnConnection->protocol = protocol;
     pTurnConnection->relayAddressReported = FALSE;
+    pTurnConnection->authTransactionIdSet = FALSE;
     pTurnConnection->pControlChannel = pTurnSocket;
 
     ATOMIC_STORE_BOOL(&pTurnConnection->stopTurnConnection, FALSE);
+    ATOMIC_STORE_BOOL(&pTurnConnection->credentialsRejected, FALSE);
     ATOMIC_STORE_BOOL(&pTurnConnection->hasAllocation, FALSE);
     ATOMIC_STORE_BOOL(&pTurnConnection->shutdownComplete, FALSE);
 
@@ -473,6 +475,31 @@ STATUS turnConnectionHandleStunError(PTurnConnection pTurnConnection, PBYTE pBuf
 
     switch (pStunAttributeErrorCode->errorCode) {
         case STUN_ERROR_UNAUTHORIZED:
+            // TURN reuses 401 for two distinct meanings: the initial nonce challenge (in response to our
+            // unauthenticated Allocate) and a credential rejection (in response to an Allocate we signed with
+            // MESSAGE-INTEGRITY). Since the transport is UDP, a stale/duplicated challenge response can also
+            // arrive after we have already authenticated. Correlate by transaction id to tell them apart.
+            if (pTurnConnection->authTransactionIdSet &&
+                MEMCMP(pBuffer + STUN_PACKET_TRANSACTION_ID_OFFSET, pTurnConnection->authTransactionId, STUN_TRANSACTION_ID_LEN) == 0) {
+                // 401 for the request we authenticated: the credentials are being rejected. The long term key
+                // does not change between retransmits, so retrying is futile. Flag it and let the state machine
+                // timer fail fast rather than retransmitting until the allocation timeout.
+                if (!ATOMIC_LOAD_BOOL(&pTurnConnection->credentialsRejected)) {
+                    DLOGE("TURN server rejected credentials for server %s (username %s). Error Code: %u, Error detail: %s",
+                          pTurnConnection->turnServer.url, pTurnConnection->turnServer.username, pStunAttributeErrorCode->errorCode,
+                          pStunAttributeErrorCode->errorPhrase);
+                    ATOMIC_STORE_BOOL(&pTurnConnection->credentialsRejected, TRUE);
+                }
+                break;
+            }
+
+            if (pTurnConnection->credentialObtained) {
+                // We already consumed a nonce challenge and this 401 does not match our authenticated request,
+                // so it is a stale/duplicated challenge for a superseded request. Ignore it.
+                DLOGD("Ignoring stale 401 Unauthorized response (nonce challenge already processed).");
+                break;
+            }
+
             CHK_STATUS(getStunAttribute(pStunPacket, STUN_ATTRIBUTE_TYPE_NONCE, &pStunAttr));
             CHK_WARN(pStunAttr != NULL, retStatus, "No Nonce attribute found in Allocate Error response. Dropping Packet");
             pStunAttributeNonce = (PStunAttributeNonce) pStunAttr;

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -131,6 +131,19 @@ struct __TurnConnection {
     BOOL credentialObtained;
     BOOL relayAddressReported;
 
+    // Transaction id of the authenticated Allocate request (the one we signed with MESSAGE-INTEGRITY).
+    // Used to correlate incoming 401 responses: a 401 matching this id is a genuine credential rejection,
+    // whereas a 401 for any other (e.g. duplicated/late unauthenticated) request must be ignored. This is
+    // required because TURN reuses 401 for both the initial nonce challenge and credential rejection, and
+    // UDP allows stale challenge responses to arrive after we have already authenticated.
+    // Note: retransmits of the authenticated Allocate reuse the same packet, hence the same transaction id,
+    // so a single stored id correctly matches the 401 for any of those retransmits.
+    BYTE authTransactionId[STUN_TRANSACTION_ID_LEN];
+    BOOL authTransactionIdSet;
+    // Set by the receive path when the server rejects our authenticated credentials; read by the state
+    // machine timer to fail fast instead of retransmitting until the allocation timeout.
+    volatile ATOMIC_BOOL credentialsRejected;
+
     PSocketConnection pControlChannel;
 
     TurnPeer turnPeerList[DEFAULT_TURN_MAX_PEER_COUNT];

--- a/src/source/Ice/TurnConnectionStateMachine.c
+++ b/src/source/Ice/TurnConnectionStateMachine.c
@@ -335,6 +335,11 @@ STATUS executeAllocationTurnState(UINT64 customData, UINT64 time)
 
     CHK(pTurnConnection != NULL, STATUS_NULL_ARG);
 
+    // The server rejected the credentials we signed our Allocate with (401 matching our authenticated
+    // request). The long term key does not change between retransmits, so retrying would just yield the
+    // same 401. Fail fast with a specific status instead of retransmitting until the allocation timeout.
+    CHK(!ATOMIC_LOAD_BOOL(&pTurnConnection->credentialsRejected), STATUS_TURN_CONNECTION_CREDENTIALS_REJECTED);
+
     currentTime = GETTIME();
     if (pTurnConnection->state != TURN_STATE_ALLOCATION) {
         DLOGV("Updated turn allocation request credential after receiving 401");
@@ -347,6 +352,9 @@ STATUS executeAllocationTurnState(UINT64 customData, UINT64 time)
         CHK_STATUS(turnConnectionPackageTurnAllocationRequest(
             pTurnConnection->turnServer.username, pTurnConnection->turnRealm, pTurnConnection->turnNonce, pTurnConnection->nonceLen,
             DEFAULT_TURN_ALLOCATION_LIFETIME_SECONDS, &pTurnConnection->pTurnPacket, pTurnConnection->ipFamilyType));
+        // Remember the transaction id of this authenticated request so we can correlate a 401 rejection to it.
+        MEMCPY(pTurnConnection->authTransactionId, pTurnConnection->pTurnPacket->header.transactionId, STUN_TRANSACTION_ID_LEN);
+        pTurnConnection->authTransactionIdSet = TRUE;
         pTurnConnection->state = TURN_STATE_ALLOCATION;
     } else {
         CHK(currentTime <= pTurnConnection->stateTimeoutTime, STATUS_TURN_CONNECTION_ALLOCATION_FAILED);

--- a/tst/TurnConnectionFunctionalityTest.cpp
+++ b/tst/TurnConnectionFunctionalityTest.cpp
@@ -78,6 +78,74 @@ class TurnConnectionFunctionalityTest : public WebRtcClientTestBase {
         EXPECT_EQ(STATUS_SUCCESS, connectionListenerStart(pConnectionListener));
     }
 
+    // Same as initializeTestTurnConnection, but corrupts the TURN credential before creating the
+    // turn connection so the TURN server rejects the authenticated Allocate with 401 UNAUTHORIZED.
+    VOID initializeTestTurnConnectionWithBadCredential()
+    {
+        UINT32 i, j, iceConfigCount, uriCount;
+        IceServer iceServers[MAX_ICE_SERVERS_COUNT];
+        PIceServer pTurnServer = NULL;
+        KvsIpAddress localIpInterfaces[MAX_LOCAL_NETWORK_INTERFACE_COUNT];
+        UINT32 localIpInterfaceCount = ARRAY_SIZE(localIpInterfaces);
+        PKvsIpAddress pTurnSocketAddr = NULL;
+        PSocketConnection pTurnSocket = NULL;
+
+        ASSERT_EQ(STATUS_SUCCESS, initializeSignalingClient());
+
+        EXPECT_EQ(STATUS_SUCCESS, signalingClientGetIceConfigInfoCount(mSignalingClientHandle, &iceConfigCount));
+
+        for (uriCount = 0, i = 0; i < iceConfigCount; i++) {
+            EXPECT_EQ(STATUS_SUCCESS, signalingClientGetIceConfigInfo(mSignalingClientHandle, i, &pIceConfigInfo));
+            for (j = 0; j < pIceConfigInfo->uriCount; j++) {
+                iceServers[uriCount].setIpFn = NULL;
+                EXPECT_EQ(STATUS_SUCCESS,
+                          parseIceServer(&iceServers[uriCount++], pIceConfigInfo->uris[j], pIceConfigInfo->userName, pIceConfigInfo->password));
+            }
+        }
+
+        for (i = 0; i < uriCount && pTurnServer == NULL; ++i) {
+            if (iceServers[i].isTurn) {
+                pTurnServer = &iceServers[i];
+            }
+        }
+
+        EXPECT_TRUE(pTurnServer != NULL);
+
+        // Corrupt the credential: keep a valid username so the server issues a nonce/realm challenge,
+        // but make the password wrong so the authenticated Allocate is rejected with 401 UNAUTHORIZED.
+        STRCPY(pTurnServer->credential, "this-is-an-invalid-turn-credential");
+
+        EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+        EXPECT_EQ(STATUS_SUCCESS, createConnectionListener(&pConnectionListener));
+
+        EXPECT_EQ(STATUS_SUCCESS, getLocalhostIpAddresses(localIpInterfaces, &localIpInterfaceCount, NULL, 0));
+        for (i = 0; i < localIpInterfaceCount; ++i) {
+            if (localIpInterfaces[i].family == pTurnServer->ipAddresses.ipv4Address.family && (pTurnSocketAddr == NULL || localIpInterfaces[i].isPointToPoint)) {
+                pTurnSocketAddr = &localIpInterfaces[i];
+            }
+        }
+
+        auto onDataHandler = [](UINT64 customData, PSocketConnection pSocketConnection, PBYTE pBuffer, UINT32 bufferLen, PKvsIpAddress pSrc,
+                                PKvsIpAddress pDest) -> STATUS {
+            UNUSED_PARAM(pSocketConnection);
+            TurnConnectionFunctionalityTest* pTestBase = (TurnConnectionFunctionalityTest*) customData;
+            pTestBase->turnChannelDataCount = ARRAY_SIZE(pTestBase->turnChannelData);
+            EXPECT_EQ(STATUS_SUCCESS,
+                      turnConnectionIncomingDataHandler(pTestBase->pTurnConnection, pBuffer, bufferLen, pSrc, pDest, pTestBase->turnChannelData,
+                                                        &pTestBase->turnChannelDataCount));
+
+            return STATUS_SUCCESS;
+        };
+        EXPECT_EQ(STATUS_SUCCESS,
+                  createSocketConnection((KVS_IP_FAMILY_TYPE) pTurnServer->ipAddresses.ipv4Address.family, KVS_ICE_DEFAULT_TURN_PROTOCOL, NULL,
+                                         &pTurnServer->ipAddresses.ipv4Address, (UINT64) this, onDataHandler, 0, &pTurnSocket));
+        EXPECT_EQ(STATUS_SUCCESS, connectionListenerAddConnection(pConnectionListener, pTurnSocket));
+        ASSERT_EQ(STATUS_SUCCESS,
+                  createTurnConnection(pTurnServer, timerQueueHandle, TURN_CONNECTION_DATA_TRANSFER_MODE_DATA_CHANNEL, KVS_ICE_DEFAULT_TURN_PROTOCOL,
+                                       NULL, pTurnSocket, pConnectionListener, KVS_IP_FAMILY_TYPE_IPV4, &pTurnConnection));
+        EXPECT_EQ(STATUS_SUCCESS, connectionListenerStart(pConnectionListener));
+    }
+
     VOID freeTestTurnConnection()
     {
         EXPECT_TRUE(pTurnConnection != NULL);
@@ -203,6 +271,66 @@ TEST_F(TurnConnectionFunctionalityTest, turnConnectionRefreshPermissionTest)
     MUTEX_LOCK(pTurnConnection->lock);
     EXPECT_GE(pTurnConnection->allocationExpirationTime, GETTIME());
     MUTEX_UNLOCK(pTurnConnection->lock);
+
+    freeTestTurnConnection();
+}
+
+/*
+ * Regression test for the TURN 401 handling. With a stale/invalid TURN credential the server rejects the
+ * authenticated Allocate with 401 UNAUTHORIZED. The connection must never reach READY, and rather than
+ * retransmitting until the 5s allocation timeout it must fail fast (correlating the 401 to our authenticated
+ * request by transaction id) with the specific STATUS_TURN_CONNECTION_CREDENTIALS_REJECTED status.
+ */
+TEST_F(TurnConnectionFunctionalityTest, turnConnectionBadCredentialFailsFast)
+{
+    if (!mAccessKeyIdSet) {
+        return;
+    }
+
+    BOOL turnReady = FALSE, turnFailed = FALSE;
+    KvsIpAddress turnPeerAddr;
+    UINT64 startTime, elapsed;
+    // Bound well under the 5s allocation timeout: fail-fast should trip within a couple of timer ticks.
+    UINT64 failFastBudget = 3 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    // Overall wait can exceed the allocation timeout so a regression (loop-until-timeout) is still observed.
+    UINT64 timeout = GETTIME() + 20 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+
+    initializeTestTurnConnectionWithBadCredential();
+
+    turnPeerAddr.port = (UINT16) getInt16(8080);
+    turnPeerAddr.family = KVS_IP_FAMILY_TYPE_IPV4;
+    turnPeerAddr.isPointToPoint = FALSE;
+    /* random peer 77.1.1.1, we are not actually sending anything to it. */
+    turnPeerAddr.address[0] = 0x4d;
+    turnPeerAddr.address[1] = 0x01;
+    turnPeerAddr.address[2] = 0x01;
+    turnPeerAddr.address[3] = 0x01;
+
+    EXPECT_EQ(STATUS_SUCCESS, turnConnectionAddPeer(pTurnConnection, &turnPeerAddr));
+    startTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, turnConnectionStart(pTurnConnection));
+
+    while (!turnReady && !turnFailed && GETTIME() < timeout) {
+        THREAD_SLEEP(50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        MUTEX_LOCK(pTurnConnection->lock);
+        if (pTurnConnection->state == TURN_STATE_READY) {
+            turnReady = TRUE;
+        } else if (pTurnConnection->state == TURN_STATE_FAILED) {
+            turnFailed = TRUE;
+        }
+        MUTEX_UNLOCK(pTurnConnection->lock);
+    }
+    elapsed = GETTIME() - startTime;
+
+    // With a bad credential we must never become ready.
+    EXPECT_FALSE(turnReady);
+    // We must fail, and with the specific credential-rejection status (not a generic allocation timeout).
+    EXPECT_TRUE(turnFailed);
+    MUTEX_LOCK(pTurnConnection->lock);
+    EXPECT_EQ(STATUS_TURN_CONNECTION_CREDENTIALS_REJECTED, pTurnConnection->errorStatus);
+    MUTEX_UNLOCK(pTurnConnection->lock);
+    // And it must happen fast, well before the allocation timeout would have expired.
+    EXPECT_LT(elapsed, failFastBudget);
 
     freeTestTurnConnection();
 }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- TURN connections now fail fast when the server rejects the authenticated Allocate with `401 Unauthorized`, instead of retransmitting until the 5s allocation timeout.
- The failure now surfaces a specific `STATUS_TURN_CONNECTION_CREDENTIALS_REJECTED` status (and a clear logging with actionable feedback), so the application can distinguish stale/invalid TURN credentials from a generic allocation timeout and react accordingly (e.g. refresh credentials).

*Why was it changed?*
- TURN reuses same `401` response code and "Unauthorized" message for both the initial nonce challenge and credential rejection (same response for two different requests in the TURN sequence).
- Observed behavior: with stale/invalid TURN credentials, the SDK treated every `401` identically and kept retrying (local testing: ~95 retransmits over 5s per connection, expected since it loops each 50ms), flooding logs with `turnConnectionHandleStunError` PROFILE lines.
- Under normal use (signaling client → peer connection directly), this does not happen: the SDK only accepts an ICE config whose min TTL exceeds a 30s grace period (`ICE_CONFIGURATION_REFRESH_GRACE_PERIOD`) and refreshes 30s early, so credentials sourced through the signaling client are not stale by the time TURN allocates. The exposure is applications that supply TURN credentials via their own logic (their own credential/rotation flow), where stale or invalid credentials can be passed in — a common integration pattern.
- Bandwidth impact per rejected connection: the authenticated Allocate is 232 bytes (measured) and each `401` reply is ~110 bytes, so ~95 round-trips wasted ~32 KB over 5s. After the fix a rejection costs a single round-trip (~0.3 KB), a ~99% reduction. This is per connection and STUN-payload only (actual bytes are higher with IP/UDP or TCP/TLS framing); a single ICE config expands to multiple TURN connections sharing one credential, so the aggregate saving scales with that count.
- Beyond bandwidth, the doomed connection stops churning CPU/logs for the full 5s and is marked failed in <100ms. (Relay/host/srflx candidates are gathered and connectivity-checked in parallel — each TURN connection has its own timer — so a stuck allocation does not block other candidates; this is not about unblocking a serial round-robin. The latency win matters most in relay-only paths, where the 5s stall was effectively the whole connection's delay.)

*How was it changed?*
- Record the transaction id of the authenticated Allocate request (`authTransactionId`), then correlate incoming `401`s in `turnConnectionHandleStunError`:
  - matches our authenticated request → credential rejection: flag `credentialsRejected` (logged once); the state machine timer fails fast.
  - `credentialObtained` already set but no id match → stale/duplicate/late challenge (UDP): ignored.
  - otherwise → genuine nonce challenge: consume realm/nonce as before.
- Added `STATUS_TURN_CONNECTION_CREDENTIALS_REJECTED`.

*Design consideration — why track the transaction id (not just a flag)?*
- The TURN connection can run over UDP, so responses can be duplicated, delayed, or reordered. A duplicate/late `401` for the *initial nonce challenge* (the unauthenticated request) can arrive *after* we've already authenticated.
- A naive "fail on any `401` once `credentialObtained` is true" rule would misclassify that stale challenge as a credential rejection and abort a healthy handshake.
- The unauthenticated request and the authenticated (signed) request carry **different** transaction ids. By recording the signed request's id (`authTransactionId`) and matching it against each `401`, we reliably tell a true rejection (matches the signed request) from a stale challenge (does not) — robust to UDP loss/duplication/reordering.
- We store a dedicated `authTransactionId` rather than comparing against the live outstanding packet, which also closes the brief window where we've authenticated but not yet repackaged the outgoing request.

*What testing was done for the changes?*
- Added new integration test: `turnConnectionBadCredentialFailsFast`, which uses an invalid credential against the TURN server and asserts the connection fails with `STATUS_TURN_CONNECTION_CREDENTIALS_REJECTED` well under the allocation timeout (never reaching READY). To run:
  ```
  ./tst/webrtc_client_test --gtest_filter='TurnConnectionFunctionalityTest.turnConnectionBadCredentialFailsFast'
  ```
- All 11 `TurnConnectionFunctionalityTest` cases pass. A successful-path run confirmed the stale-`401` ignore branch handles real duplicate/late `401`s over UDP without regressing (connection still reaches READY). Result: fail-fast in <100ms (in local testing) vs 5s, and 95→1 log lines per rejected connection.
- The single rejection log now identifies the offending server, so the failing one can be spotted when multiple TURN servers are configured:
  ```
  ERROR turnConnectionHandleStunError(): TURN server rejected credentials for server <turn-host> (username <username>). Error Code: 401, Error detail: Unauthorized
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
