### PR TITLE
Fix silent SDP media attribute counter overflow

### DIFF
--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -193,7 +193,7 @@ STATUS setPayloadTypesFromOffer(PHashTable codecTable, PHashTable rtxTable, PSes
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PSdpMediaDescription pMediaDescription = NULL;
-    UINT8 currentAttribute;
+    UINT16 currentAttribute;
     UINT16 currentMedia;
     PCHAR attributeValue, end;
     UINT64 parsedPayloadType, hashmapPayloadType, fmtpVal, aptVal;

--- a/src/source/Sdp/Sdp.h
+++ b/src/source/Sdp/Sdp.h
@@ -187,7 +187,9 @@ typedef struct {
 
     SdpAttributes sdpAttributes[MAX_SDP_ATTRIBUTES_COUNT];
 
-    UINT8 mediaAttributesCount;
+    // Must be able to represent MAX_SDP_ATTRIBUTES_COUNT. With a narrower type the bounds check in parseMediaAttributes() can never fail
+    // and the counter wraps to 0, silently overwriting the attributes already parsed for this media section.
+    UINT16 mediaAttributesCount;
 
     UINT8 mediaBandwidthCount;
 } SdpMediaDescription, *PSdpMediaDescription;

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -173,6 +173,35 @@ TEST_F(SdpApiTest, deserializeSessionDescription_PhoneNumberTruncatedAtMaxLength
     EXPECT_EQ(STRLEN(sessionDescription.phoneNumber), (UINT32) MAX_SDP_SESSION_PHONE_NUMBER_LENGTH);
 }
 
+TEST_F(SdpApiTest, deserializeSessionDescription_MediaAttributesAtMaxCount)
+{
+    // "a=mid" plus (MAX_SDP_ATTRIBUTES_COUNT - 1) filler attributes fills the media section exactly to capacity.
+    std::string sdpStr = "v=0\nm=video 9 UDP/TLS/RTP/SAVPF 96\na=mid:1\n";
+    for (UINT32 i = 1; i < MAX_SDP_ATTRIBUTES_COUNT; i++) {
+        sdpStr += "a=rtcp-fb:" + std::to_string(i) + " rrtr\n";
+    }
+
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SUCCESS, deserializeSessionDescription(&sessionDescription, (PCHAR) sdpStr.c_str()));
+    EXPECT_EQ(sessionDescription.mediaDescriptions[0].mediaAttributesCount, (UINT32) MAX_SDP_ATTRIBUTES_COUNT);
+    EXPECT_STREQ(sessionDescription.mediaDescriptions[0].sdpAttributes[0].attributeName, "mid");
+}
+
+TEST_F(SdpApiTest, deserializeSessionDescription_MediaAttributesExceedingMaxCountIsRejected)
+{
+    // One attribute more than the media section can hold must be reported instead of wrapping the counter back onto index 0.
+    std::string sdpStr = "v=0\nm=video 9 UDP/TLS/RTP/SAVPF 96\na=mid:1\n";
+    for (UINT32 i = 1; i <= MAX_SDP_ATTRIBUTES_COUNT; i++) {
+        sdpStr += "a=rtcp-fb:" + std::to_string(i) + " rrtr\n";
+    }
+
+    SessionDescription sessionDescription;
+    MEMSET(&sessionDescription, 0x00, SIZEOF(SessionDescription));
+    EXPECT_EQ(STATUS_SDP_ATTRIBUTE_MAX_EXCEEDED, deserializeSessionDescription(&sessionDescription, (PCHAR) sdpStr.c_str()));
+    EXPECT_STREQ(sessionDescription.mediaDescriptions[0].sdpAttributes[0].attributeName, "mid");
+}
+
 auto populate_session_description = [](PSessionDescription pSessionDescription) {
     MEMSET(pSessionDescription, 0x00, SIZEOF(SessionDescription));
 


### PR DESCRIPTION
*Issue #, if available:*
- #2373

*What was changed?*
- `SdpMediaDescription.mediaAttributesCount` is now `UINT16` instead of `UINT8`.
- The `currentAttribute` loop counter in `setPayloadTypesFromOffer()` is now `UINT16` too. Every other consumer of `mediaAttributesCount` already used `UINT32`.
- Added two regression tests to `tst/SdpApiTest.cpp`.

*Why was it changed?*
- `MAX_SDP_ATTRIBUTES_COUNT` is 256, but `mediaAttributesCount` could only represent 0..255, so `CHK(currentMediaAttributesCount < MAX_SDP_ATTRIBUTES_COUNT, ...)` in `parseMediaAttributes()` could never fail. Once 256 attributes had been stored the counter wrapped to 0 and the next attribute overwrote `sdpAttributes[0]`, where browser offers keep the ICE and DTLS parameters. `deserializeSessionDescription()` still returned `STATUS_SUCCESS`.
- The guard worked while the limit was 128, so this looks like something the v1.7.1 fix for #1389 missed when it raised the limit to 256.

*How was it changed?*
- Only the counter widths changed; the 256-attribute capacity is untouched, so `SdpMediaDescription` grows by at most 2 bytes after alignment.
- `Sdp.h` is internal, not under `src/include/`, so the public API is unchanged. Consumers linking a prebuilt library only need to rebuild.

*What testing was done for the changes?*
- Built and ran the unit tests on macOS 15.6.1 (arm64, Apple clang 17.0.0). `SdpApiTest`, `SdpFunctionalityTest` and `SdpBufferSizeConfigTest` pass 90 tests, including the two new ones.
- With the source change reverted and only the tests applied, both fail: `mediaAttributesCount` reads `0` instead of `256`, and the over-limit case returns `STATUS_SUCCESS` with `sdpAttributes[0].attributeName` set to `rtcp-fb` instead of `mid`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
