### PR TITLE
C SDK as viewer/recvonly: Fix RTP jitter buffer receive-path double-free

### DIFF
--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -454,7 +454,12 @@ STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOO
         }
     }
 
-    CHK_STATUS(jitterBufferInternalParse(pJitterBuffer, FALSE));
+    // Best-effort: the packet is now owned by the jitter buffer, so a parse failure
+    // must not be returned (the caller would free it -> double free). Log and continue.
+    status = jitterBufferInternalParse(pJitterBuffer, FALSE);
+    if (STATUS_FAILED(status)) {
+        DLOGW("jitterBufferInternalParse failed with 0x%08x", status);
+    }
 
 CleanUp:
 

--- a/tst/JitterBufferFunctionalityTest.cpp
+++ b/tst/JitterBufferFunctionalityTest.cpp
@@ -9,6 +9,95 @@ namespace webrtcclient {
 class JitterBufferFunctionalityTest : public WebRtcClientTestBase {
 };
 
+static STATUS reproFrameReadyFunc(UINT64, UINT16, UINT16, UINT32)
+{
+    return STATUS_SUCCESS;
+}
+
+static STATUS reproFrameDroppedFunc(UINT64, UINT16, UINT16, UINT32)
+{
+    return STATUS_SUCCESS;
+}
+
+// Fails the depay for a "corrupt" packet (first byte 0xEE) to force the parse-failure
+// path inside jitterBufferPush().
+static STATUS reproDepayRtpFunc(PBYTE payload, UINT32 payloadLength, PBYTE outBuffer, PUINT32 pBufferSize, PBOOL pIsStart)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 bufferSize = 0;
+    BOOL sizeCalculationOnly = (outBuffer == NULL);
+
+    CHK(payload != NULL && pBufferSize != NULL, STATUS_NULL_ARG);
+    CHK(payloadLength > 0, retStatus);
+    CHK(payload[0] != 0xEE, STATUS_INVALID_ARG);
+
+    bufferSize = payloadLength;
+    CHK(!sizeCalculationOnly, retStatus);
+    CHK(payloadLength <= *pBufferSize, STATUS_BUFFER_TOO_SMALL);
+    MEMCPY(outBuffer, payload, payloadLength);
+
+CleanUp:
+    if (STATUS_FAILED(retStatus) && sizeCalculationOnly) {
+        bufferSize = 0;
+    }
+    if (pBufferSize != NULL) {
+        *pBufferSize = bufferSize;
+    }
+    if (pIsStart != NULL && payload != NULL && payloadLength > 0) {
+        *pIsStart = (payload[payloadLength] != 0);
+    }
+    return retStatus;
+}
+
+static PRtpPacket reproMakePacket(UINT16 seqNum, UINT32 timestamp, UINT8 firstByte, BOOL isStart)
+{
+    PRtpPacket pRtpPacket = NULL;
+    PBYTE payload = (PBYTE) MEMALLOC(2);
+
+    payload[0] = firstByte;
+    payload[1] = isStart ? 1 : 0;
+    EXPECT_EQ(STATUS_SUCCESS,
+              createRtpPacket(2, FALSE, FALSE, 0, FALSE, 96, seqNum, timestamp, 0x1234ABCD, NULL, 0, 0, NULL, payload, 1, &pRtpPacket));
+    pRtpPacket->pRawPacket = pRtpPacket->payload;
+    return pRtpPacket;
+}
+
+// jitterBufferPush() inserts the packet into the hash table before it parses. If the
+// parse fails, push must not return an error, or sendPacketToRtpReceiver() frees a
+// packet the buffer still owns and a later drop frees it again.
+TEST_F(JitterBufferFunctionalityTest, pushErrorPathDoesNotDoubleFreePacket)
+{
+    PJitterBuffer jitterBuffer = NULL;
+    BOOL ownedByJitterBuffer;
+
+    EXPECT_EQ(STATUS_SUCCESS,
+              createJitterBuffer(reproFrameReadyFunc, reproFrameDroppedFunc, reproDepayRtpFunc, DEFAULT_JITTER_BUFFER_MAX_LATENCY,
+                                 TEST_JITTER_BUFFER_CLOCK_RATE, (UINT64) this, &jitterBuffer));
+
+    PRtpPacket p0 = reproMakePacket(0, 100, 0x01, TRUE);
+    ownedByJitterBuffer = STATUS_SUCCEEDED(jitterBufferPush(jitterBuffer, p0, NULL));
+    if (!ownedByJitterBuffer) {
+        freeRtpPacket(&p0);
+    }
+
+    PRtpPacket p1 = reproMakePacket(1, 200, 0x02, TRUE);
+    ownedByJitterBuffer = STATUS_SUCCEEDED(jitterBufferPush(jitterBuffer, p1, NULL));
+    if (!ownedByJitterBuffer) {
+        freeRtpPacket(&p1);
+    }
+
+    PRtpPacket pPoison = reproMakePacket(2, 300, 0xEE, TRUE);
+    ownedByJitterBuffer = STATUS_SUCCEEDED(jitterBufferPush(jitterBuffer, pPoison, NULL));
+
+    // Mirror sendPacketToRtpReceiver(): free only when push failed.
+    if (!ownedByJitterBuffer) {
+        freeRtpPacket(&pPoison);
+    }
+
+    jitterBufferDropBufferData(jitterBuffer, 2, 2, 300);
+    freeJitterBuffer(&jitterBuffer);
+}
+
 // Also works as closeBufferWithSingleContinousPacket
 TEST_F(JitterBufferFunctionalityTest, continousPacketsComeInOrder)
 {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- `jitterBufferPush()` no longer returns an error once it has taken ownership of the packet: a failure from `jitterBufferInternalParse()` is now logged instead of propagated.
- Added a regression test, `pushErrorPathDoesNotDoubleFreePacket`.

*Why was it changed?*
- `jitterBufferPush()` inserts the packet into the hash table and then calls `jitterBufferInternalParse()`. If the parse fails — for example the depayloader rejects a corrupt packet and `CHK_STATUS` aborts — push returned that error while the packet was still referenced in the buffer. In `sendPacketToRtpReceiver()` the caller sets `ownedByJitterBuffer = TRUE` only after a successful push, so on the error path its `CleanUp` frees the packet. A later `jitterBufferInternalParse()` / `jitterBufferDropBufferData()` then frees the same packet again. On a device this surfaces as a heap double-free (`tlsf_free: block already marked as free`) and a crash, triggered by inbound video with occasional malformed payloads.

*How was it changed?*
- After the packet is inserted, the internal parse is treated as best-effort: on failure it logs and continues instead of returning the status. Push reports success because it has taken the packet, so the caller never frees a buffered packet. The offending packet is removed later as it ages out of the buffer via `maxLatency`.

*What testing was done for the changes?*
- Added `pushErrorPathDoesNotDoubleFreePacket`, which drives the ownership sequence: two good frames, then a packet whose depay fails. Built with AddressSanitizer, the test reports a heap-use-after-free in `freeRtpPacket` before the fix and passes after it. The full `JitterBuffer*` suite passes (mbedTLS build).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
