### PR TITLE
Free non-selected local candidate sockets on nomination

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2503,6 +2503,8 @@ STATUS iceAgentReadyStateSetup(PIceAgent pIceAgent)
     PIceCandidatePair pIceCandidatePair = NULL;
     BOOL locked = FALSE;
     PIceCandidate pIceCandidate = NULL;
+    PIceCandidate freeSocketCandidates[KVS_ICE_MAX_LOCAL_CANDIDATE_COUNT];
+    UINT32 freeSocketCandidateCount = 0, freeIdx = 0;
 
     CHK(pIceAgent != NULL, STATUS_NULL_ARG);
 
@@ -2554,11 +2556,16 @@ STATUS iceAgentReadyStateSetup(PIceAgent pIceAgent)
         pIceCandidate = (PIceCandidate) pCurNode->data;
         pCurNode = pCurNode->pNext;
 
-        if (pIceCandidate != pIceAgent->pDataSendingIceCandidatePair->local) {
+        if (pIceCandidate != pIceAgent->pDataSendingIceCandidatePair->local && pIceCandidate->state != ICE_CANDIDATE_STATE_INVALID) {
             if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_RELAYED) {
                 CHK_STATUS(turnConnectionShutdown(pIceCandidate->pTurnConnection, 0));
             }
             pIceCandidate->state = ICE_CANDIDATE_STATE_INVALID;
+            // Its socket is still open (only the candidate was invalidated).
+            // Collect it and free it in CleanUp, after pIceAgent->lock is dropped.
+            if (freeSocketCandidateCount < KVS_ICE_MAX_LOCAL_CANDIDATE_COUNT) {
+                freeSocketCandidates[freeSocketCandidateCount++] = pIceCandidate;
+            }
         }
     }
     CHK_STATUS(iceAgentInvalidateCandidatePair(pIceAgent));
@@ -2582,6 +2589,23 @@ CleanUp:
 
     if (locked) {
         MUTEX_UNLOCK(pIceAgent->lock);
+        locked = FALSE;
+    }
+
+    // Free the collected candidates' sockets here, outside pIceAgent->lock
+    // (connectionListenerRemoveConnection must not run under it). The structs stay
+    // in localCandidates and are freed at teardown; the frees are NULL-safe, so
+    // NULLing the pointers here avoids a double-free.
+    for (freeIdx = 0; freeIdx < freeSocketCandidateCount; ++freeIdx) {
+        pIceCandidate = freeSocketCandidates[freeIdx];
+        if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_RELAYED) {
+            if (pIceCandidate->pTurnConnection != NULL) {
+                CHK_LOG_ERR(freeTurnConnection(&pIceCandidate->pTurnConnection));
+            }
+        } else if (pIceCandidate->pSocketConnection != NULL) {
+            CHK_LOG_ERR(connectionListenerRemoveConnection(pIceAgent->pConnectionListener, pIceCandidate->pSocketConnection));
+            CHK_LOG_ERR(freeSocketConnection(&pIceCandidate->pSocketConnection));
+        }
     }
 
     if (STATUS_FAILED(retStatus)) {


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- `iceAgentReadyStateSetup()` now closes the sockets of the non-selected local candidates once a pair is nominated, instead of leaving them open until the whole ICE agent is freed.

*Why was it changed?*
- After nomination the agent already retires the non-selected candidates (shuts down their TURN allocations and marks them `ICE_CANDIDATE_STATE_INVALID`), but it keeps their sockets open for the connection's entire lifetime. That's roughly 3-4 unused fds per session (host, srflx, non-selected relay). On a regular host it goes unnoticed, but on fd-constrained embedded builds (small `LWIP_MAX_SOCKETS`) two concurrent sessions exhaust the pool and new sockets fail with "Too many open files", so no further peer connections can be set up until a restart.

*How was it changed?*
- The non-selected candidates are already invalidated in the existing loop, so this collects them and frees each one after the agent lock is dropped (`connectionListenerRemoveConnection` must not run under `pIceAgent->lock`): relayed via `freeTurnConnection`, host/srflx via `connectionListenerRemoveConnection` + `freeSocketConnection`. The candidate structs stay in `localCandidates` and are still freed at teardown; only the socket/TURN connection is released and the pointer NULLed, so teardown does not double-free (both frees are NULL-safe). This mirrors what the ICE-restart path already does. Connectivity is unchanged: all candidate types are still gathered and eligible, so a host/direct pair can still be selected — only the losing candidates' fds are reclaimed once a pair is nominated.

*What testing was done for the changes?*
- On an ESP32-P4 (`LWIP_MAX_SOCKETS=16`) camera: rapid start/stop soaks that used to hit "Too many open files" after a handful of sessions now run clean, and a single established 1080p stream still connects and flows normally. Also verified there is no double-free at teardown (the freed candidates' pointers are NULLed and the frees are idempotent).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.