### PR TITLE
Add multi-track video-only (4Video 0Audio) master sample

### DIFF
--- a/.github/workflows/samples.yaml
+++ b/.github/workflows/samples.yaml
@@ -125,6 +125,72 @@ jobs:
           done
           echo "SUCCESS: 4Video1Audio sample - 4 transceivers added, PeerConnection established, frames sent on all 4 video tracks"
 
+  sample-check-4video0audio:
+    runs-on: ubuntu-latest
+    env:
+      AWS_KVS_LOG_LEVEL: 2
+      CHANNEL_NAME: SampleChannel4Video0Audio
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2.2.0
+        with:
+          cmake-version: '3.x'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build repository
+        run: |
+          mkdir build && cd build
+          cmake .. -DMAX_SDP_SESSION_MEDIA_COUNT=5 -DKVS_SIGNALING_MESSAGE_LEN=40000 -DPARALLEL_BUILD=ON
+          make -j
+      - name: Prepare signaling channel
+        run: |
+          ./scripts/prepare-channel.sh ${{ env.CHANNEL_NAME }}
+      - name: Run 4 video 0 audio master sample
+        run: |
+          set +e
+          cd build/samples
+          ./kvsWebrtcClientMaster_4Video_0Audio ${{ env.CHANNEL_NAME }} > master.log 2>&1 &
+          MASTER_PID=$!
+          sleep 10
+          ./kvsWebrtcClientViewer ${{ env.CHANNEL_NAME }} > viewer.log 2>&1 &
+          VIEWER_PID=$!
+          sleep 20
+          kill -s INT $VIEWER_PID 2>/dev/null
+          sleep 5
+          kill -s INT $MASTER_PID 2>/dev/null
+          sleep 10
+          kill -9 $MASTER_PID $VIEWER_PID 2>/dev/null
+          wait $VIEWER_PID 2>/dev/null
+          wait $MASTER_PID 2>/dev/null
+          set -e
+          if ! grep -q "Successfully added 4 video transceivers" master.log; then
+            echo "FAILURE: 4 video transceivers were not added"
+            cat master.log
+            exit 1
+          fi
+          if ! grep -q "New connection state 3" master.log; then
+            echo "FAILURE: PeerConnection was not established"
+            cat master.log
+            cat viewer.log
+            exit 1
+          fi
+          for t in 0 1 2 3; do
+            if ! grep -q "First frame sent on video track $t" master.log; then
+              echo "FAILURE: No frames sent on video track $t"
+              cat master.log
+              exit 1
+            fi
+          done
+          echo "SUCCESS: 4Video0Audio sample - 4 transceivers added, PeerConnection established, frames sent on all 4 video tracks"
+
   sample-check-no-data-channel:
     runs-on: ubuntu-latest
     env:

--- a/README.md
+++ b/README.md
@@ -446,6 +446,24 @@ To run:
 
 Allowed video-codec: h264 (default codec if nothing is specified), h265
 
+##### Sample: kvsWebrtcClientMaster_4Video_0Audio
+This is the video-only variant of `kvsWebrtcClientMaster_4Video_1Audio`. It sends 4 video tracks (no audio track) over a single PeerConnection using static sample frames. Each video track is a separate RTP transceiver, allowing the viewer to receive 4 independent video streams simultaneously over a single KVS Signaling Channel.
+
+> [!Note]
+> The SDP must accommodate 5 media sections (4 video + 1 data channel when built with `-DENABLE_DATA_CHANNEL=ON`), which fits the default `-DMAX_SDP_SESSION_MEDIA_COUNT=5`. If the offer is rejected, configure the build for a larger SDP:
+> ```shell
+> cmake .. -DMAX_SDP_SESSION_MEDIA_COUNT=5 -DKVS_SIGNALING_MESSAGE_LEN=40000
+> ```
+
+Per-track frames are generated the same way as the audio+video sample above (see `generate_multi_track_frames.sh`); the same `<codec>SampleFrames_track0/` through `<codec>SampleFrames_track3/` directories are used.
+
+To run:
+```shell
+./samples/kvsWebrtcClientMaster_4Video_0Audio <channelName> <video-codec>
+```
+
+Allowed video-codec: h264 (default codec if nothing is specified), h265
+
 #### WebRTC Storage (ingest) samples
 
 ##### Sample: kvsWebrtcStorageAudioVideoMaster and kvsWebrtcStorageVideoOnlyMaster

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -84,6 +84,13 @@ add_executable(
 target_link_libraries(kvsWebrtcClientMaster_4Video_1Audio kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} kvsCommonLws kvspicUtils websockets)
 
 add_executable(
+  kvsWebrtcClientMaster_4Video_0Audio
+        common/Common.c
+        common/StaticMedia.c
+        p2p/multi-track/master_4video_0audio.c)
+target_link_libraries(kvsWebrtcClientMaster_4Video_0Audio kvsWebrtcClient kvsWebrtcSignalingClient ${EXTRA_DEPS} kvsCommonLws kvspicUtils websockets)
+
+add_executable(
         discoverNatBehavior
         discoverNatBehavior.c)
 target_link_libraries(discoverNatBehavior kvsWebrtcClient ${EXTRA_DEPS})
@@ -164,7 +171,7 @@ if(GST_FOUND)
   )
 endif()
 
-install(TARGETS kvsWebrtcClientMaster kvsWebrtcClientViewer kvsWebrtcClientMaster_4Video_1Audio discoverNatBehavior
+install(TARGETS kvsWebrtcClientMaster kvsWebrtcClientViewer kvsWebrtcClientMaster_4Video_1Audio kvsWebrtcClientMaster_4Video_0Audio discoverNatBehavior
   RUNTIME DESTINATION bin
 )
 

--- a/samples/p2p/multi-track/master_4video_0audio.c
+++ b/samples/p2p/multi-track/master_4video_0audio.c
@@ -1,0 +1,283 @@
+#include "../../common/Samples.h"
+#include "../../common/StaticMedia.h"
+
+extern PSampleConfiguration gSampleConfiguration;
+
+#define NUM_VIDEO_TRACKS 4
+
+typedef struct {
+    PRtcRtpTransceiver pVideoRtcRtpTransceivers[NUM_VIDEO_TRACKS];
+} MultiTrackStreamingSession, *PMultiTrackStreamingSession;
+
+static VOID onMultiTrackSessionShutdown(UINT64 customData, PSampleStreamingSession pSampleStreamingSession)
+{
+    UNUSED_PARAM(pSampleStreamingSession);
+    PMultiTrackStreamingSession pMultiTrackSession = (PMultiTrackStreamingSession) customData;
+    SAFE_MEMFREE(pMultiTrackSession);
+}
+
+STATUS addFourVideoTransceivers(PSampleConfiguration pSampleConfiguration, PSampleStreamingSession pSampleStreamingSession)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    RtcRtpTransceiverInit videoRtpTransceiverInit;
+    RtcMediaStreamTrack videoTrack;
+    UINT32 i;
+    CHAR trackId[MAX_MEDIA_STREAM_TRACK_ID_LEN + 1];
+    CHAR streamId[MAX_MEDIA_STREAM_TRACK_ID_LEN + 1];
+    PMultiTrackStreamingSession pMultiTrackSession = NULL;
+
+    CHK(pSampleConfiguration != NULL && pSampleStreamingSession != NULL, STATUS_NULL_ARG);
+
+    pMultiTrackSession = (PMultiTrackStreamingSession) MEMCALLOC(1, SIZEOF(MultiTrackStreamingSession));
+    CHK(pMultiTrackSession != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    for (i = 0; i < NUM_VIDEO_TRACKS; i++) {
+        MEMSET(&videoTrack, 0x00, SIZEOF(RtcMediaStreamTrack));
+        videoTrack.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+        videoTrack.codec = pSampleConfiguration->videoCodec;
+        videoRtpTransceiverInit.direction = RTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;
+
+        SNPRINTF(streamId, MAX_MEDIA_STREAM_TRACK_ID_LEN, "myKvsVideoStream%u", i);
+        SNPRINTF(trackId, MAX_MEDIA_STREAM_TRACK_ID_LEN, "myVideoTrack%u", i);
+        STRCPY(videoTrack.streamId, streamId);
+        STRCPY(videoTrack.trackId, trackId);
+
+        CHK_STATUS(addTransceiver(pSampleStreamingSession->pPeerConnection, &videoTrack, &videoRtpTransceiverInit,
+                                  &pMultiTrackSession->pVideoRtcRtpTransceivers[i]));
+
+        CHK_STATUS(configureTransceiverRollingBuffer(pMultiTrackSession->pVideoRtcRtpTransceivers[i], &videoTrack,
+                                                     pSampleConfiguration->videoRollingBufferDurationSec,
+                                                     pSampleConfiguration->videoRollingBufferBitratebps));
+
+        CHK_STATUS(transceiverOnBandwidthEstimation(pMultiTrackSession->pVideoRtcRtpTransceivers[i], (UINT64) pSampleStreamingSession,
+                                                    sampleBandwidthEstimationHandler));
+    }
+
+    pSampleStreamingSession->pVideoRtcRtpTransceiver = pMultiTrackSession->pVideoRtcRtpTransceivers[0];
+
+    CHK_STATUS(streamingSessionOnShutdown(pSampleStreamingSession, (UINT64) pMultiTrackSession, onMultiTrackSessionShutdown));
+
+    DLOGI("[KVS Master] Successfully added %u video transceivers", NUM_VIDEO_TRACKS);
+
+CleanUp:
+    if (STATUS_FAILED(retStatus)) {
+        SAFE_MEMFREE(pMultiTrackSession);
+    }
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
+}
+
+PVOID sendFourVideoPacketsFromDisk(PVOID args)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PSampleConfiguration pSampleConfiguration = (PSampleConfiguration) args;
+    Frame frame[NUM_VIDEO_TRACKS];
+    UINT32 fileIndex[NUM_VIDEO_TRACKS];
+    UINT32 frameSize;
+    PBYTE pFrameBuffers[NUM_VIDEO_TRACKS];
+    UINT32 frameBufferSizes[NUM_VIDEO_TRACKS];
+    CHAR filePath[MAX_PATH_LEN + 1];
+    STATUS status;
+    UINT32 i, trackIdx;
+    UINT64 startTime, lastFrameTime, elapsed;
+    BOOL usePerTrackDirs = FALSE;
+    BOOL trackSentFirstFrame[NUM_VIDEO_TRACKS];
+    PCHAR codecDir;
+    PCHAR codecExt;
+    UINT32 numFrameFiles;
+
+    MEMSET(trackSentFirstFrame, 0x00, SIZEOF(trackSentFirstFrame));
+    MEMSET(fileIndex, 0x00, SIZEOF(fileIndex));
+    MEMSET(pFrameBuffers, 0x00, SIZEOF(pFrameBuffers));
+    MEMSET(frameBufferSizes, 0x00, SIZEOF(frameBufferSizes));
+    MEMSET(frame, 0x00, SIZEOF(frame));
+    CHK_ERR(pSampleConfiguration != NULL, STATUS_NULL_ARG, "[KVS Master] Streaming session is NULL");
+
+    if (pSampleConfiguration->videoCodec == RTC_CODEC_H265) {
+        codecDir = "h265SampleFrames";
+        codecExt = "h265";
+        numFrameFiles = NUMBER_OF_H265_FRAME_FILES;
+    } else {
+        codecDir = "h264SampleFrames";
+        codecExt = "h264";
+        numFrameFiles = NUMBER_OF_H264_FRAME_FILES;
+    }
+
+    {
+        UINT32 dummySize = 0;
+        STATUS checkStatus;
+        SNPRINTF(filePath, MAX_PATH_LEN, "./%s_track0/frame-0001.%s", codecDir, codecExt);
+        checkStatus = readFrameFromDisk(NULL, &dummySize, filePath);
+        usePerTrackDirs = (checkStatus == STATUS_SUCCESS);
+    }
+
+    if (usePerTrackDirs) {
+        DLOGI("[KVS Master] Using per-track frame directories (%s_track0..3)", codecDir);
+    } else {
+        DLOGW("[KVS Master] Per-track %s frame directories not found. Sending the same frames on all 4 tracks.", codecExt);
+        DLOGW("[KVS Master] To generate unique frames per track, run from the build/samples/ directory:");
+        DLOGW("[KVS Master]   ../../scripts/generate_multi_track_frames.sh %s", codecExt);
+    }
+
+    startTime = GETTIME();
+    lastFrameTime = startTime;
+
+    while (!ATOMIC_LOAD_BOOL(&pSampleConfiguration->appTerminateFlag)) {
+        for (trackIdx = 0; trackIdx < NUM_VIDEO_TRACKS; trackIdx++) {
+            fileIndex[trackIdx] = fileIndex[trackIdx] % numFrameFiles + 1;
+            if (usePerTrackDirs) {
+                SNPRINTF(filePath, MAX_PATH_LEN, "./%s_track%u/frame-%04d.%s", codecDir, trackIdx, fileIndex[trackIdx], codecExt);
+            } else {
+                SNPRINTF(filePath, MAX_PATH_LEN, "./%s/frame-%04d.%s", codecDir, fileIndex[trackIdx], codecExt);
+            }
+
+            frameSize = 0;
+            CHK_STATUS(readFrameFromDisk(NULL, &frameSize, filePath));
+
+            if (frameSize > frameBufferSizes[trackIdx]) {
+                pFrameBuffers[trackIdx] = (PBYTE) MEMREALLOC(pFrameBuffers[trackIdx], frameSize);
+                CHK_ERR(pFrameBuffers[trackIdx] != NULL, STATUS_NOT_ENOUGH_MEMORY, "[KVS Master] Failed to allocate video frame buffer for track %u",
+                        trackIdx);
+                frameBufferSizes[trackIdx] = frameSize;
+            }
+
+            frame[trackIdx].frameData = pFrameBuffers[trackIdx];
+            frame[trackIdx].size = frameSize;
+            CHK_STATUS(readFrameFromDisk(frame[trackIdx].frameData, &frameSize, filePath));
+            frame[trackIdx].presentationTs += SAMPLE_VIDEO_FRAME_DURATION;
+        }
+
+        MUTEX_LOCK(pSampleConfiguration->streamingSessionListReadLock);
+        for (i = 0; i < pSampleConfiguration->streamingSessionCount; ++i) {
+            PMultiTrackStreamingSession pMultiTrackSession =
+                (PMultiTrackStreamingSession) pSampleConfiguration->sampleStreamingSessionList[i]->shutdownCallbackCustomData;
+            if (pMultiTrackSession == NULL) {
+                continue;
+            }
+            for (trackIdx = 0; trackIdx < NUM_VIDEO_TRACKS; trackIdx++) {
+                status = writeFrame(pMultiTrackSession->pVideoRtcRtpTransceivers[trackIdx], &frame[trackIdx]);
+                if (trackIdx == 0 && pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame && status == STATUS_SUCCESS) {
+                    PROFILE_WITH_START_TIME(pSampleConfiguration->sampleStreamingSessionList[i]->offerReceiveTime, "Time to first frame");
+                    pSampleConfiguration->sampleStreamingSessionList[i]->firstFrame = FALSE;
+                }
+                if (status == STATUS_SUCCESS && !trackSentFirstFrame[trackIdx]) {
+                    DLOGI("[KVS Master] First frame sent on video track %u", trackIdx);
+                    trackSentFirstFrame[trackIdx] = TRUE;
+                } else if (status == STATUS_SRTP_NOT_READY_YET) {
+                    fileIndex[trackIdx] = 0;
+                } else if (status != STATUS_SUCCESS) {
+                    DLOGV("writeFrame() for track %u failed with 0x%08x", trackIdx, status);
+                }
+            }
+        }
+        MUTEX_UNLOCK(pSampleConfiguration->streamingSessionListReadLock);
+
+        elapsed = lastFrameTime - startTime;
+        THREAD_SLEEP(SAMPLE_VIDEO_FRAME_DURATION - elapsed % SAMPLE_VIDEO_FRAME_DURATION);
+        lastFrameTime = GETTIME();
+    }
+
+CleanUp:
+    for (trackIdx = 0; trackIdx < NUM_VIDEO_TRACKS; trackIdx++) {
+        SAFE_MEMFREE(pFrameBuffers[trackIdx]);
+    }
+    DLOGI("Closing video thread");
+    CHK_LOG_ERR(retStatus);
+    return (PVOID) (ULONG_PTR) retStatus;
+}
+
+INT32 main(INT32 argc, CHAR* argv[])
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PSampleConfiguration pSampleConfiguration = NULL;
+    PCHAR pChannelName;
+    SignalingClientMetrics signalingClientMetrics;
+    signalingClientMetrics.version = SIGNALING_CLIENT_METRICS_CURRENT_VERSION;
+    RTC_CODEC videoCodec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+
+    SET_INSTRUMENTED_ALLOCATORS();
+    UINT32 logLevel = setLogLevel();
+
+#ifndef _WIN32
+    signal(SIGINT, sigintHandler);
+#endif
+
+#ifdef IOT_CORE_ENABLE_CREDENTIALS
+    CHK_ERR((pChannelName = argc > 1 ? argv[1] : GETENV(IOT_CORE_THING_NAME)) != NULL, STATUS_INVALID_OPERATION,
+            "AWS_IOT_CORE_THING_NAME must be set");
+#else
+    pChannelName = argc > 1 ? argv[1] : SAMPLE_CHANNEL_NAME;
+#endif
+
+    CHK_STATUS(createSampleConfiguration(pChannelName, SIGNALING_CHANNEL_ROLE_TYPE_MASTER, TRUE, TRUE, logLevel, &pSampleConfiguration));
+
+    if (argc > 2) {
+        if (!STRCMP(argv[2], VIDEO_CODEC_NAME_H265)) {
+            videoCodec = RTC_CODEC_H265;
+        } else {
+            DLOGI("[KVS Master] Defaulting to H264 as the specified codec's sample frames may not be available");
+        }
+    }
+
+    CHK_STATUS(useStaticFramePresets(pSampleConfiguration, videoCodec));
+    pSampleConfiguration->videoSource = sendFourVideoPacketsFromDisk;
+
+#ifdef ENABLE_DATA_CHANNEL
+    pSampleConfiguration->onDataChannel = onDataChannel;
+#endif
+    pSampleConfiguration->mediaType = SAMPLE_STREAMING_VIDEO_ONLY;
+    pSampleConfiguration->addTransceiversCallback = addFourVideoTransceivers;
+    DLOGI("[KVS Master] Finished setting up four video track handlers");
+
+    CHK_STATUS(initKvsWebRtc());
+    DLOGI("[KVS Master] KVS WebRTC initialization completed successfully");
+
+    PROFILE_CALL_WITH_START_END_T_OBJ(
+        retStatus = initSignaling(pSampleConfiguration, SAMPLE_MASTER_CLIENT_ID), pSampleConfiguration->signalingClientMetrics.signalingStartTime,
+        pSampleConfiguration->signalingClientMetrics.signalingEndTime, pSampleConfiguration->signalingClientMetrics.signalingCallTime,
+        "Initialize signaling client and connect to the signaling channel");
+
+    DLOGI("[KVS Master] Channel %s set up done ", pChannelName);
+
+    CHK_STATUS(sessionCleanupWait(pSampleConfiguration));
+    DLOGI("[KVS Master] Streaming session terminated");
+
+CleanUp:
+
+    if (retStatus != STATUS_SUCCESS) {
+        DLOGE("[KVS Master] Terminated with status code 0x%08x", retStatus);
+    }
+
+    DLOGI("[KVS Master] Cleaning up....");
+    if (pSampleConfiguration != NULL) {
+        ATOMIC_STORE_BOOL(&pSampleConfiguration->appTerminateFlag, TRUE);
+
+        if (pSampleConfiguration->mediaSenderTid != INVALID_TID_VALUE) {
+            THREAD_JOIN(pSampleConfiguration->mediaSenderTid, NULL);
+        }
+
+        retStatus = signalingClientGetMetrics(pSampleConfiguration->signalingClientHandle, &signalingClientMetrics);
+        if (retStatus == STATUS_SUCCESS) {
+            logSignalingClientStats(&signalingClientMetrics);
+        } else {
+            DLOGE("[KVS Master] signalingClientGetMetrics() operation returned status code: 0x%08x", retStatus);
+        }
+        retStatus = freeSignalingClient(&pSampleConfiguration->signalingClientHandle);
+        if (retStatus != STATUS_SUCCESS) {
+            DLOGE("[KVS Master] freeSignalingClient(): operation returned status code: 0x%08x", retStatus);
+        }
+
+        retStatus = freeSampleConfiguration(&pSampleConfiguration);
+        if (retStatus != STATUS_SUCCESS) {
+            DLOGE("[KVS Master] freeSampleConfiguration(): operation returned status code: 0x%08x", retStatus);
+        }
+    }
+    DLOGI("[KVS Master] Cleanup done");
+    CHK_LOG_ERR(retStatus);
+
+    RESET_INSTRUMENTED_ALLOCATORS();
+
+    return STATUS_FAILED(retStatus) ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added a video-only multi-track sample, `kvsWebrtcClientMaster_4Video_0Audio` (`samples/p2p/multi-track/master_4video_0audio.c`): 4 video tracks, no audio track, each on its own RTP transceiver over a single PeerConnection.
- Wired it into `samples/CMakeLists.txt` (new executable + install target) and documented it in `README.md`.
- Added a `sample-check-4video0audio` CI job in `.github/workflows/samples.yaml`.

*Why was it changed?*
- Complements the audio+video multi-track sample (`kvsWebrtcClientMaster_4Video_1Audio`, #2371) with a video-only variant for testing 4 independent video streams without an audio track.
- The video-only case needs only 5 media sections (4 video + 1 data channel), so it fits the default `-DMAX_SDP_SESSION_MEDIA_COUNT=5` and demonstrates the multi-track path without increasing the track count limit.

*How was it changed?*
- The sample mirrors `master_4video_1audio.c` but drops the audio transceiver, sets `mediaType = SAMPLE_STREAMING_VIDEO_ONLY`, and skips the Opus frame preset. It reuses the same per-track frame directories (`<codec>SampleFrames_track0..3/`) produced by `scripts/generate_multi_track_frames.sh`.
- The CI job builds with `-DMAX_SDP_SESSION_MEDIA_COUNT=5`, runs master + viewer, and asserts 4 video transceivers are added, the PeerConnection reaches connected, and a first frame is sent on each of the 4 tracks.

*What testing was done for the changes?*
- Built locally (`cmake` + `make kvsWebrtcClientMaster_4Video_0Audio`) — compiles and links cleanly.
- Automated runtime is exercised by the new `sample-check-4video0audio` CI job (master/viewer handshake, 4 transceivers, per-track first-frame checks).

Tested with the new multi-track JS sample option in H265 mode:
<img width="953" height="724" alt="image" src="https://github.com/user-attachments/assets/133c894d-3ac7-4663-aff8-5b5d6476850a" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.