### PR TITLE
New Feature: parse reception report blocks embedded in RTCP sender reports(follow-up to #2367)

### DIFF
--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -49,37 +49,13 @@ CleanUp:
     return retStatus;
 }
 
-// TODO better sender report handling https://tools.ietf.org/html/rfc3550#section-6.4.1
-static STATUS onRtcpSenderReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
-{
-    STATUS retStatus = STATUS_SUCCESS;
-    UINT32 senderSSRC;
-    PKvsRtpTransceiver pTransceiver = NULL;
-
-    CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
-
-    if (pRtcpPacket->payloadLength != RTCP_PACKET_SENDER_REPORT_MINLEN) {
-        // TODO: handle sender report containing receiver report blocks
-        return STATUS_SUCCESS;
-    }
-
-    senderSSRC = getUnalignedInt32BigEndian(pRtcpPacket->payload);
-    if (STATUS_SUCCEEDED(findTransceiverBySsrc(pKvsPeerConnection, &pTransceiver, senderSSRC))) {
-        UINT64 ntpTime = getUnalignedInt64BigEndian(pRtcpPacket->payload + 4);
-        UINT32 rtpTs = getUnalignedInt32BigEndian(pRtcpPacket->payload + 12);
-        UINT32 packetCnt = getUnalignedInt32BigEndian(pRtcpPacket->payload + 16);
-        UINT32 octetCnt = getUnalignedInt32BigEndian(pRtcpPacket->payload + 20);
-        DLOGV("RTCP_PACKET_TYPE_SENDER_REPORT %d %" PRIu64 " rtpTs: %u %u pkts %u bytes", senderSSRC, ntpTime, rtpTs, packetCnt, octetCnt);
-    } else {
-        DLOGW("Received sender report for non existing ssrc: %u", senderSSRC);
-    }
-
-CleanUp:
-
-    return retStatus;
-}
-
-static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
+// Parses the reception report blocks carried in a receiver report or a sender report and updates
+// remoteInboundStats on the transceiver matching each block's source SSRC.
+// https://tools.ietf.org/html/rfc3550#section-6.4.1 (SR), https://tools.ietf.org/html/rfc3550#section-6.4.2 (RR)
+// The block format is identical in both packet types; only the offset of the first block differs:
+//   RR: 4 bytes  (after the sender SSRC)
+//   SR: 24 bytes (after the sender SSRC and the 20-byte sender info section)
+static STATUS parseRtcpReceptionReportBlocks(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection, UINT32 firstReportBlockOffset)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PKvsRtpTransceiver pTransceiver = NULL;
@@ -90,28 +66,29 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     UINT8 reportBlockCount, i;
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
-    // https://tools.ietf.org/html/rfc3550#section-6.4.2
-    // A receiver report contains the sender SSRC followed by receptionReportCount report blocks. The media
-    // storage backend reports on all streams (audio + video) in a single RR, so all blocks must be processed.
+
+    // The report contains receptionReportCount report blocks. The media storage backend reports on
+    // all streams (audio + video) in a single packet, so all blocks must be processed.
     reportBlockCount = pRtcpPacket->header.receptionReportCount;
     if (reportBlockCount > RTCP_PACKET_RECEIVER_REPORT_MAX_BLOCKS) {
-        DLOGW("Receiver report contains %u report blocks, processing only the first %u", reportBlockCount, RTCP_PACKET_RECEIVER_REPORT_MAX_BLOCKS);
+        DLOGW("Report contains %u report blocks, processing only the first %u", reportBlockCount, RTCP_PACKET_RECEIVER_REPORT_MAX_BLOCKS);
         reportBlockCount = RTCP_PACKET_RECEIVER_REPORT_MAX_BLOCKS;
     }
-    if (pRtcpPacket->payloadLength < SIZEOF(UINT32) + (UINT32) reportBlockCount * RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN) {
-        DLOGW("Malformed receiver report: payloadLength %u too small for %u report block(s)", pRtcpPacket->payloadLength, reportBlockCount);
+    if (pRtcpPacket->payloadLength < firstReportBlockOffset + (UINT32) reportBlockCount * RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN) {
+        DLOGW("Malformed report: payloadLength %u too small for %u report block(s) at offset %u", pRtcpPacket->payloadLength, reportBlockCount,
+              firstReportBlockOffset);
         return STATUS_SUCCESS;
     }
 
     senderSSRC = getUnalignedInt32BigEndian(pRtcpPacket->payload);
 
     for (i = 0; i < reportBlockCount; i++) {
-        reportBlockOffset = SIZEOF(UINT32) + i * RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN;
+        reportBlockOffset = firstReportBlockOffset + i * RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN;
         ssrc = getUnalignedInt32BigEndian(pRtcpPacket->payload + reportBlockOffset);
 
         pTransceiver = NULL;
         if (STATUS_FAILED(findTransceiverBySsrc(pKvsPeerConnection, &pTransceiver, ssrc))) {
-            DLOGW("Received receiver report for non existing ssrc: %u", ssrc);
+            DLOGW("Received reception report for non existing ssrc: %u", ssrc);
             continue;
         }
 
@@ -122,7 +99,7 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
         lastSR = getUnalignedInt32BigEndian(pRtcpPacket->payload + reportBlockOffset + 16);
         delaySinceLastSR = getUnalignedInt32BigEndian(pRtcpPacket->payload + reportBlockOffset + 20);
 
-        DLOGV("RTCP inbound: RECEIVER_REPORT block %u/%u - senderSSRC=%u ssrc=%u fractionLost=%.3f cumulativeLost=%u extHiSeq=%u jitter=%u "
+        DLOGV("RTCP inbound: reception report block %u/%u - senderSSRC=%u ssrc=%u fractionLost=%.3f cumulativeLost=%u extHiSeq=%u jitter=%u "
               "lsr=%u dlsr=%u",
               i + 1, reportBlockCount, senderSSRC, ssrc, fractionLost, cumulativeLost, extHiSeqNumReceived, interarrivalJitter, lastSR,
               delaySinceLastSR);
@@ -144,7 +121,7 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
             //      leave the round-trip propagation delay as (A - LSR - DLSR).
             rttPropDelay = MID_NTP(currentTimeNTP) - lastSR - delaySinceLastSR;
             rttPropDelayMsec = KVS_CONVERT_TIMESCALE(rttPropDelay, DLSR_TIMESCALE, 1000);
-            DLOGS("RTCP_PACKET_TYPE_RECEIVER_REPORT rttPropDelay %u msec", rttPropDelayMsec);
+            DLOGS("RTCP reception report rttPropDelay %u msec", rttPropDelayMsec);
 
             pTransceiver->remoteInboundStats.roundTripTimeMeasurements++;
             pTransceiver->remoteInboundStats.totalRoundTripTime += rttPropDelayMsec;
@@ -156,6 +133,47 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
 CleanUp:
 
     return retStatus;
+}
+
+static STATUS onRtcpSenderReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 senderSSRC;
+    PKvsRtpTransceiver pTransceiver = NULL;
+
+    CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
+
+    // https://tools.ietf.org/html/rfc3550#section-6.4.1
+    if (pRtcpPacket->payloadLength < RTCP_PACKET_SENDER_REPORT_MINLEN) {
+        DLOGW("Malformed sender report: payloadLength %u too small", pRtcpPacket->payloadLength);
+        return STATUS_SUCCESS;
+    }
+
+    senderSSRC = getUnalignedInt32BigEndian(pRtcpPacket->payload);
+    if (STATUS_SUCCEEDED(findTransceiverBySsrc(pKvsPeerConnection, &pTransceiver, senderSSRC))) {
+        UINT64 ntpTime = getUnalignedInt64BigEndian(pRtcpPacket->payload + 4);
+        UINT32 rtpTs = getUnalignedInt32BigEndian(pRtcpPacket->payload + 12);
+        UINT32 packetCnt = getUnalignedInt32BigEndian(pRtcpPacket->payload + 16);
+        UINT32 octetCnt = getUnalignedInt32BigEndian(pRtcpPacket->payload + 20);
+        DLOGV("RTCP_PACKET_TYPE_SENDER_REPORT %d %" PRIu64 " rtpTs: %u %u pkts %u bytes", senderSSRC, ntpTime, rtpTs, packetCnt, octetCnt);
+    } else {
+        DLOGW("Received sender report for non existing ssrc: %u", senderSSRC);
+    }
+
+    // A remote peer that both sends and receives embeds its reception report blocks in the SR after
+    // the sender info instead of sending a separate RR (RFC 3550 section 6.4.1). The media storage
+    // backend does this as soon as it starts sending media; process the blocks exactly like RR blocks.
+    CHK_STATUS(parseRtcpReceptionReportBlocks(pRtcpPacket, pKvsPeerConnection, RTCP_PACKET_SENDER_REPORT_MINLEN));
+
+CleanUp:
+
+    return retStatus;
+}
+
+static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
+{
+    // https://tools.ietf.org/html/rfc3550#section-6.4.2
+    return parseRtcpReceptionReportBlocks(pRtcpPacket, pKvsPeerConnection, SIZEOF(UINT32));
 }
 
 // After this function executes, the twccManager saves the indexes of the packets

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -65,7 +65,12 @@ static STATUS parseRtcpReceptionReportBlocks(PRtcpPacket pRtcpPacket, PKvsPeerCo
     UINT32 reportBlockOffset;
     UINT8 reportBlockCount, i;
 
-    CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
+    CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL && pRtcpPacket->payload != NULL, STATUS_NULL_ARG);
+
+    // firstReportBlockOffset must be the byte offset of the first report block within the payload:
+    // SIZEOF(UINT32) for RR (after the sender SSRC), RTCP_PACKET_SENDER_REPORT_MINLEN for SR (after
+    // the sender SSRC and the sender info section).
+    CHK(firstReportBlockOffset >= SIZEOF(UINT32) && firstReportBlockOffset <= RTCP_PACKET_SENDER_REPORT_MINLEN, STATUS_INVALID_ARG);
 
     // The report contains receptionReportCount report blocks. The media storage backend reports on
     // all streams (audio + video) in a single packet, so all blocks must be processed.
@@ -77,7 +82,8 @@ static STATUS parseRtcpReceptionReportBlocks(PRtcpPacket pRtcpPacket, PKvsPeerCo
     if (pRtcpPacket->payloadLength < firstReportBlockOffset + (UINT32) reportBlockCount * RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN) {
         DLOGW("Malformed report: payloadLength %u too small for %u report block(s) at offset %u", pRtcpPacket->payloadLength, reportBlockCount,
               firstReportBlockOffset);
-        return STATUS_SUCCESS;
+        // Drop the malformed packet without failing the session; route through CleanUp per the KVS idiom.
+        CHK(FALSE, STATUS_SUCCESS);
     }
 
     senderSSRC = getUnalignedInt32BigEndian(pRtcpPacket->payload);
@@ -132,6 +138,8 @@ static STATUS parseRtcpReceptionReportBlocks(PRtcpPacket pRtcpPacket, PKvsPeerCo
 
 CleanUp:
 
+    CHK_LOG_ERR(retStatus);
+
     return retStatus;
 }
 
@@ -141,12 +149,13 @@ static STATUS onRtcpSenderReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKv
     UINT32 senderSSRC;
     PKvsRtpTransceiver pTransceiver = NULL;
 
-    CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
+    CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL && pRtcpPacket->payload != NULL, STATUS_NULL_ARG);
 
     // https://tools.ietf.org/html/rfc3550#section-6.4.1
     if (pRtcpPacket->payloadLength < RTCP_PACKET_SENDER_REPORT_MINLEN) {
         DLOGW("Malformed sender report: payloadLength %u too small", pRtcpPacket->payloadLength);
-        return STATUS_SUCCESS;
+        // Drop the malformed packet without failing the session; route through CleanUp per the KVS idiom.
+        CHK(FALSE, STATUS_SUCCESS);
     }
 
     senderSSRC = getUnalignedInt32BigEndian(pRtcpPacket->payload);
@@ -166,6 +175,8 @@ static STATUS onRtcpSenderReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKv
     CHK_STATUS(parseRtcpReceptionReportBlocks(pRtcpPacket, pKvsPeerConnection, RTCP_PACKET_SENDER_REPORT_MINLEN));
 
 CleanUp:
+
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }

--- a/src/source/Rtcp/RtcpPacket.h
+++ b/src/source/Rtcp/RtcpPacket.h
@@ -26,7 +26,12 @@ extern "C" {
 #define RTCP_PACKET_REMB_IDENTIFIER_OFFSET 8
 #define RTCP_PACKET_REMB_MANTISSA_BITMASK  0x3FFFF
 
-#define RTCP_PACKET_SENDER_REPORT_MINLEN      24
+// Minimum sender report payload: sender SSRC (4) + NTP timestamp (8) + RTP timestamp (4) +
+// sender's packet count (4) + sender's octet count (4) = 24 bytes (RFC 3550 section 6.4.1).
+// Reception report blocks, when present, follow this fixed-size sender info section.
+#define RTCP_PACKET_SENDER_REPORT_MINLEN 24
+// Each reception report block: source SSRC (4) + fraction lost (1) + cumulative lost (3) +
+// extended highest seq (4) + interarrival jitter (4) + LSR (4) + DLSR (4) = 24 bytes.
 #define RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN 24
 // No longer used by the SDK: receiver report length is now validated dynamically against the
 // report block count (4 + RC * RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN in onRtcpReceiverReport).

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -521,6 +521,115 @@ TEST_F(RtcpFunctionalityTest, onRtcpPacketReceiverReportMalformedBlockCount)
     freePeerConnection(&pRtcPeerConnection);
 }
 
+// fractionLost boundary values: 0x00 must map to exactly 0.0 and 0xFF to exactly 255/255 = 1.0
+// (the field is an 8-bit fixed-point fraction, computed as N / 255.0).
+TEST_F(RtcpFunctionalityTest, onRtcpPacketReceiverReportFractionLostBoundaries)
+{
+    initTransceiver(0x11111111);
+
+    // fractionLost = 0x00 (no loss)
+    auto hexpacketZero = (PCHAR) "81C90007"
+                                 "01020304"
+                                 "111111110000000000000100000000640000000000000000";
+    BYTE rawpacket[64] = {0};
+    UINT32 rawpacketSize = 64;
+    EXPECT_EQ(STATUS_SUCCESS, hexDecode(hexpacketZero, strlen(hexpacketZero), rawpacket, &rawpacketSize));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, rawpacket, rawpacketSize));
+
+    RtcRemoteInboundRtpStreamStats stats{};
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+    EXPECT_EQ(1, stats.reportsReceived);
+    EXPECT_EQ(0.0, stats.fractionLost);
+
+    // fractionLost = 0xFF (maximum representable loss fraction)
+    auto hexpacketMax = (PCHAR) "81C90007"
+                                "01020304"
+                                "11111111FF00000000000100000000640000000000000000";
+    rawpacketSize = 64;
+    EXPECT_EQ(STATUS_SUCCESS, hexDecode(hexpacketMax, strlen(hexpacketMax), rawpacket, &rawpacketSize));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, rawpacket, rawpacketSize));
+
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+    EXPECT_EQ(2, stats.reportsReceived);
+    EXPECT_EQ(255.0 / 255.0, stats.fractionLost);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+// RTT accuracy: build the report block's lsr/dlsr from the current clock so the expected RTT is
+// deterministic. With lsr = MID_NTP(now) - dlsr - X, the computed RTT must be X (in DLSR_TIMESCALE
+// units, converted to ms), plus however long the test takes between packet construction and
+// parsing - hence the tolerance window.
+TEST_F(RtcpFunctionalityTest, onRtcpPacketReceiverReportRoundTripTimeAccuracy)
+{
+    constexpr UINT32 expectedRttMsec = 500;
+    constexpr UINT32 toleranceMsec = 200; // generous upper bound for test execution time between GETTIME() calls
+
+    initTransceiver(0x11111111);
+
+    // Header: RC=1, PT=201, length 7 words; payload: senderSSRC + one report block
+    BYTE rawpacket[64] = {0};
+    UINT32 rawpacketSize = 64;
+    auto hexpacket = (PCHAR) "81C90007"
+                             "01020304"
+                             "111111110400000000000100000000640000000000000000";
+    EXPECT_EQ(STATUS_SUCCESS, hexDecode(hexpacket, strlen(hexpacket), rawpacket, &rawpacketSize));
+
+    // Overwrite lsr/dlsr (offsets within payload block: 16 and 20; +8 for the RTCP header and
+    // sender SSRC preceding the block in the raw packet: header(4) + senderSSRC(4) + blockSSRC-relative offsets)
+    UINT64 currentTimeNTP = convertTimestampToNTP(GETTIME());
+    UINT32 dlsr = 65536; // 1 second in DLSR_TIMESCALE (1/65536s) units
+    UINT32 expectedRttDlsrUnits = KVS_CONVERT_TIMESCALE(expectedRttMsec, 1000, DLSR_TIMESCALE);
+    UINT32 lsr = MID_NTP(currentTimeNTP) - dlsr - expectedRttDlsrUnits;
+    putUnalignedInt32BigEndian(rawpacket + 4 /* header */ + 4 /* senderSSRC */ + 16, lsr);
+    putUnalignedInt32BigEndian(rawpacket + 4 /* header */ + 4 /* senderSSRC */ + 20, dlsr);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, rawpacket, rawpacketSize));
+
+    RtcRemoteInboundRtpStreamStats stats{};
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+    EXPECT_EQ(1, stats.reportsReceived);
+    EXPECT_EQ(1, stats.roundTripTimeMeasurements);
+    EXPECT_GE(stats.roundTripTime, expectedRttMsec);
+    EXPECT_LT(stats.roundTripTime, expectedRttMsec + toleranceMsec);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+// reportsReceived must accumulate across successive receiver reports for the same SSRC, and
+// fractionLost must reflect the most recent report.
+TEST_F(RtcpFunctionalityTest, onRtcpPacketReceiverReportCumulativeAcrossPackets)
+{
+    initTransceiver(0x11111111);
+
+    auto hexpacketFirst = (PCHAR) "81C90007"
+                                  "01020304"
+                                  "111111110400000000000100000000640000000000000000";
+    auto hexpacketSecond = (PCHAR) "81C90007"
+                                   "01020304"
+                                   "111111110800000000000200000000C80000000000000000";
+    BYTE rawpacket[64] = {0};
+    UINT32 rawpacketSize = 64;
+
+    EXPECT_EQ(STATUS_SUCCESS, hexDecode(hexpacketFirst, strlen(hexpacketFirst), rawpacket, &rawpacketSize));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, rawpacket, rawpacketSize));
+
+    RtcRemoteInboundRtpStreamStats stats{};
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+    EXPECT_EQ(1, stats.reportsReceived);
+    EXPECT_EQ(4.0 / 255.0, stats.fractionLost);
+
+    rawpacketSize = 64;
+    EXPECT_EQ(STATUS_SUCCESS, hexDecode(hexpacketSecond, strlen(hexpacketSecond), rawpacket, &rawpacketSize));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, rawpacket, rawpacketSize));
+
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+    EXPECT_EQ(2, stats.reportsReceived);
+    EXPECT_EQ(8.0 / 255.0, stats.fractionLost);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
 TEST_F(RtcpFunctionalityTest, rembValueGet)
 {
     BYTE rawRtcpPacket[] = {0x8f, 0xce, 0x00, 0x05, 0x61, 0x7a, 0x37, 0x43, 0x00, 0x00, 0x00, 0x00,

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -260,6 +260,92 @@ TEST_F(RtcpFunctionalityTest, onRtcpPacketSingleBlockReceiverReportNoLsr)
     freePeerConnection(&pRtcPeerConnection);
 }
 
+// SR with one embedded reception report block, as sent by a remote peer that both sends and
+// receives (RFC 3550 section 6.4.1) - observed live from the media storage backend once it starts
+// sending media (type=200, rc=1, payload 48 = 24-byte sender info + 24-byte block). The embedded
+// block must update remoteInboundStats exactly like an RR block.
+TEST_F(RtcpFunctionalityTest, onRtcpPacketSenderReportWithEmbeddedReportBlock)
+{
+    // 81 C8 000C | senderSSRC 01020304 | ntp 8B + rtpTs 4B + pktCnt 4B + octetCnt 4B (sender info)
+    // block: ssrc 11111111, fractionLost 04, cumLost 000000, extHiSeq 00000100, jitter 00000064, lsr 01020304, dlsr 00000001
+    auto hexpacket = (PCHAR) "81C8000C"
+                             "01020304"
+                             "0000000000000000000000000000000000000000"
+                             "111111110400000000000100000000640102030400000001";
+    BYTE rawpacket[64] = {0};
+    UINT32 rawpacketSize = 64;
+    EXPECT_EQ(STATUS_SUCCESS, hexDecode(hexpacket, strlen(hexpacket), rawpacket, &rawpacketSize));
+
+    initTransceiver(0x11111111);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, rawpacket, rawpacketSize));
+
+    RtcRemoteInboundRtpStreamStats stats{};
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+    EXPECT_EQ(1, stats.reportsReceived);
+    EXPECT_EQ(4.0 / 255.0, stats.fractionLost);
+    EXPECT_EQ(1, stats.roundTripTimeMeasurements);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+// SR with two embedded reception report blocks (audio + video): both transceivers' stats must be
+// updated from a single SR.
+TEST_F(RtcpFunctionalityTest, onRtcpPacketSenderReportWithTwoEmbeddedReportBlocks)
+{
+    // 82 C8 0012 | senderSSRC + sender info | block1 ssrc 11111111 lsr=0 | block2 ssrc 22222222 lsr=0
+    auto hexpacket = (PCHAR) "82C80012"
+                             "01020304"
+                             "0000000000000000000000000000000000000000"
+                             "111111110400000000000100000000640000000000000000"
+                             "222222220800000000000200000000C80000000000000000";
+    BYTE rawpacket[96] = {0};
+    UINT32 rawpacketSize = 96;
+    EXPECT_EQ(STATUS_SUCCESS, hexDecode(hexpacket, strlen(hexpacket), rawpacket, &rawpacketSize));
+
+    initTransceiver(0x11111111);
+    auto audioTransceiver = addTransceiver(0x22222222);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, rawpacket, rawpacketSize));
+
+    RtcRemoteInboundRtpStreamStats videoStats{};
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &videoStats));
+    EXPECT_EQ(1, videoStats.reportsReceived);
+    EXPECT_EQ(4.0 / 255.0, videoStats.fractionLost);
+    EXPECT_EQ(0, videoStats.roundTripTimeMeasurements);
+
+    RtcRemoteInboundRtpStreamStats audioStats{};
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, audioTransceiver, &audioStats));
+    EXPECT_EQ(1, audioStats.reportsReceived);
+    EXPECT_EQ(8.0 / 255.0, audioStats.fractionLost);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+// A malformed SR claiming 2 report blocks but carrying only one must be dropped by the length
+// validation without reading out of bounds or updating stats.
+TEST_F(RtcpFunctionalityTest, onRtcpPacketSenderReportMalformedBlockCount)
+{
+    // rc=2 but length (12 words -> 48-byte payload) only fits sender info + one block
+    auto hexpacket = (PCHAR) "82C8000C"
+                             "01020304"
+                             "0000000000000000000000000000000000000000"
+                             "111111110400000000000100000000640000000000000000";
+    BYTE rawpacket[64] = {0};
+    UINT32 rawpacketSize = 64;
+    EXPECT_EQ(STATUS_SUCCESS, hexDecode(hexpacket, strlen(hexpacket), rawpacket, &rawpacketSize));
+
+    initTransceiver(0x11111111);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, rawpacket, rawpacketSize));
+
+    RtcRemoteInboundRtpStreamStats stats{};
+    EXPECT_EQ(STATUS_SUCCESS, getRtpRemoteInboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+    EXPECT_EQ(0, stats.reportsReceived);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
 // RR with two report blocks (video + audio SSRC), as sent by the media storage backend during ingestion.
 // Both transceivers' stats must be populated from a single RR. LSR is 0 in both blocks, so no RTT
 // measurements should be recorded (Stats.h: roundTripTimeMeasurements counts blocks with a valid RTT).


### PR DESCRIPTION
*Issue #, if available:*
- N/A (follow-up to #2367)

*What was changed?*
- `src/source/PeerConnection/Rtcp.c` — `onRtcpSenderReport()` now parses the reception report blocks embedded in RTCP Sender Reports and updates each matching transceiver's `remoteInboundStats`, instead of silently discarding any SR whose payload is larger than the 24-byte sender-info section.
- The report-block parsing loop is extracted into a shared helper, `parseRtcpReceptionReportBlocks()`, used by both `onRtcpReceiverReport()` and `onRtcpSenderReport()`. The block-count cap (`RTCP_PACKET_RECEIVER_REPORT_MAX_BLOCKS`, keyed to `MAX_SDP_SESSION_MEDIA_COUNT`) and payload-length validation from #2367 now apply to both packet types.
- `tst/RtcpFunctionalityTest.cpp` — new unit tests covering SRs with embedded report blocks.

*Why was it changed?*
- Per [RFC 3550 §6.4.1](https://tools.ietf.org/html/rfc3550#section-6.4.1), a peer that both sends and receives media embeds its reception report blocks in its Sender Reports rather than emitting separate Receiver Reports. The previous `onRtcpSenderReport()` bailed out on any SR that was not exactly `RTCP_PACKET_SENDER_REPORT_MINLEN` (24 bytes), so every embedded report block was dropped (the code carried a `TODO: handle sender report containing receiver report blocks`).
- The practical impact: `remoteInboundStats` (`reportsReceived`, `fractionLost`, `roundTripTime`, …) freezes as soon as the remote peer becomes a sender. Observed live against the media storage backend — it switches from RRs to SRs with embedded blocks the moment it starts sending audio on the sendrecv audio transceiver, after which the master receives no remote-inbound updates. #2367 fixed multi-block parsing for standalone RRs; this closes the remaining gap for SRs.

*How was it changed?*
- The RR and SR block formats are identical; only the offset of the first block differs (4 bytes after the sender SSRC for RRs, 24 bytes for SRs due to the sender-info section). `parseRtcpReceptionReportBlocks()` takes that offset as a parameter, and both packet handlers delegate to it.
- `onRtcpSenderReport()` keeps its existing sender-info handling (NTP/RTP timestamp, packet/octet counts) and processes embedded blocks afterwards; malformed packets that claim more blocks than the payload carries are rejected with a warning, mirroring the RR path.

*What testing was done for the changes?*
- New unit tests in `RtcpFunctionalityTest`: SR with one embedded report block (verifying stats and RTT computation), SR with two embedded blocks for different SSRCs (audio + video transceivers both updated), and a malformed SR claiming more blocks than its payload carries (rejected without stats corruption).
- Full `RtcpFunctionalityTest` suite passes locally: 49/49 tests.
- Verified live against the media storage backend: with this change, the master's remote-inbound stats continue updating after the backend transitions from RRs to SRs (previously they froze at that point).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
