### PR TITLE
Log which section exceeded MAX_SDP_ATTRIBUTES_COUNT

### DIFF
--- a/src/source/Sdp/Deserialize.c
+++ b/src/source/Sdp/Deserialize.c
@@ -23,7 +23,9 @@ STATUS parseSessionAttributes(PSessionDescription pSessionDescription, PCHAR pch
     STATUS retStatus = STATUS_SUCCESS;
     PCHAR search;
 
-    CHK(pSessionDescription->sessionAttributesCount < MAX_SDP_ATTRIBUTES_COUNT, STATUS_SDP_ATTRIBUTE_MAX_EXCEEDED);
+    CHK_ERR(pSessionDescription->sessionAttributesCount < MAX_SDP_ATTRIBUTES_COUNT, STATUS_SDP_ATTRIBUTE_MAX_EXCEEDED,
+            "Session-level SDP attribute count exceeded the MAX_SDP_ATTRIBUTES_COUNT limit of %u. Raise it in CMake to accept this SDP.",
+            MAX_SDP_ATTRIBUTES_COUNT);
 
     if ((search = STRNCHR(pch, lineLen, ':')) == NULL) {
         STRNCPY(pSessionDescription->sdpAttributes[pSessionDescription->sessionAttributesCount].attributeName, pch + SDP_ATTRIBUTE_LENGTH,
@@ -52,7 +54,10 @@ STATUS parseMediaAttributes(PSessionDescription pSessionDescription, PCHAR pch, 
 
     currentMediaAttributesCount = pSessionDescription->mediaDescriptions[pSessionDescription->mediaCount - 1].mediaAttributesCount;
 
-    CHK(currentMediaAttributesCount < MAX_SDP_ATTRIBUTES_COUNT, STATUS_SDP_ATTRIBUTE_MAX_EXCEEDED);
+    CHK_ERR(currentMediaAttributesCount < MAX_SDP_ATTRIBUTES_COUNT, STATUS_SDP_ATTRIBUTE_MAX_EXCEEDED,
+            "SDP attribute count in media section %u exceeded the MAX_SDP_ATTRIBUTES_COUNT limit of %u. Raise it in CMake, or reduce the codecs "
+            "the remote peer offers.",
+            (UINT32) (pSessionDescription->mediaCount - 1), MAX_SDP_ATTRIBUTES_COUNT);
 
     if ((search = STRNCHR(pch, lineLen, ':')) == NULL) {
         STRNCPY(pSessionDescription->mediaDescriptions[pSessionDescription->mediaCount - 1].sdpAttributes[currentMediaAttributesCount].attributeName,


### PR DESCRIPTION
*Issue #, if available:*
- Follow-up to #2373: https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/2373#issuecomment-5313581693

*What was changed?*
- `parseSessionAttributes()` and `parseMediaAttributes()` in `src/source/Sdp/Deserialize.c` now use `CHK_ERR` instead of a bare `CHK` for the `MAX_SDP_ATTRIBUTES_COUNT` bounds check. Exceeding the cap now logs which limit was hit, and the media-section message carries the section index.

*Why was it changed?*
- #2381 made `MAX_SDP_ATTRIBUTES_COUNT` a build-time knob, but nothing in the logs pointed at it. `parseMediaName()` in the same file already reports its limit through `CHK_ERR`, while these two paths used a bare `CHK`, so the only signal was the raw status code from `CHK_LOG_ERR` at the end of `setRemoteDescription()`.

*How was it changed?*
- Only the two `CHK` calls changed; no parsing logic or control flow was touched. The messages name `MAX_SDP_ATTRIBUTES_COUNT` and point at CMake, following the existing `MAX_SESSION_DESCRIPTION_INIT_SDP_LEN` message in `SessionDescription.c`.
- The media message reports `(UINT32) (mediaCount - 1)`, which cannot underflow because `deserializeSessionDescription()` only calls `parseMediaAttributes()` inside the `mediaCount != 0` branch.

*What testing was done for the changes?*
- Built and ran the SDP suites on macOS 26.5 (arm64, Apple clang 21). `SdpApiTest`, `SdpFunctionalityTest` and `SdpBufferSizeConfigTest` pass 94 tests, with no new compiler warnings, and `scripts/check-clang.sh` passes.
- `deserializeSessionDescription_MediaAttributesExceedingMaxCountIsRejected` now logs:

  ```
  ERROR   parseMediaAttributes(): SDP attribute count in media section 0 exceeded the MAX_SDP_ATTRIBUTES_COUNT limit of 256. Raise it in CMake, or reduce the codecs the remote peer offers.
  ```

  The at-the-cap test stays silent, so the new log doesn't fire below the limit. Rebuilt with `-DMAX_SDP_ATTRIBUTES_COUNT=320` and it reports `limit of 320`, so the value tracks the configured cap.
- The session-level path has no test in the suite, so I checked it with a throwaway case:

  ```
  ERROR   parseSessionAttributes(): Session-level SDP attribute count exceeded the MAX_SDP_ATTRIBUTES_COUNT limit of 256. Raise it in CMake to accept this SDP.
  ```

  Happy to add that as a permanent test if you want coverage for the session-level cap.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
