### PR TITLE
Crypto: take RNG from PSA when mbedTLS is built without the entropy module

### DIFF
--- a/src/source/Crypto/Crypto.h
+++ b/src/source/Crypto/Crypto.h
@@ -95,10 +95,11 @@ typedef enum {
 #define KVS_SHA1_HMAC(k, klen, m, mlen, ob, plen)                                                                                                    \
     CHK(0 == mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1), (k), (klen), (m), (mlen), (ob)), STATUS_HMAC_GENERATION_ERROR);             \
     *(plen) = mbedtls_md_get_size(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1));
-#if MBEDTLS_VERSION_MAJOR >= 4
+#if MBEDTLS_VERSION_MAJOR >= 4 || !MBEDTLS_HAS_ENTROPY
 /* PSA Crypto must be initialised before any psa_* call. psa_crypto_init() is
  * idempotent; calling it once from the SDK init path avoids the per-session
- * race on builds without MBEDTLS_THREADING_C. */
+ * race on builds without MBEDTLS_THREADING_C. Entropy-less builds source their
+ * randomness from PSA on every mbedTLS version, so they need this too. */
 #define KVS_CRYPTO_INIT()                                                                                                                            \
     do {                                                                                                                                             \
         (void) psa_crypto_init();                                                                                                                    \

--- a/src/source/Crypto/Dtls.h
+++ b/src/source/Crypto/Dtls.h
@@ -124,6 +124,13 @@ typedef struct {
 #error "A Crypto implementation is required."
 #endif
 
+/* Entropy-less builds have no DRBG to hand out; callers fall back to PSA. */
+#if MBEDTLS_HAS_ENTROPY
+#define KVS_MBEDTLS_DRBG(pSession) (&(pSession)->ctrDrbg)
+#else
+#define KVS_MBEDTLS_DRBG(pSession) (NULL)
+#endif
+
 typedef struct __DtlsSession DtlsSession, *PDtlsSession;
 struct __DtlsSession {
     volatile ATOMIC_BOOL isStarted;
@@ -157,8 +164,10 @@ struct __DtlsSession {
     TlsKeys tlsKeys;
     PIOBuffer pReadBuffer;
 
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_context entropy;
     mbedtls_ctr_drbg_context ctrDrbg;
+#endif
     mbedtls_ssl_config sslCtxConfig;
     mbedtls_ssl_context sslCtx;
     mbedtls_x509_crt trustedCaCert;

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -1047,6 +1047,8 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
 #if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_context* pEntropy = NULL;
     mbedtls_ctr_drbg_context* pCtrDrbg = NULL;
+#else
+    psa_status_t psaStatus;
 #endif
     /* RNG handed to key generation and certificate signing below. */
     int (*fRng)(void*, unsigned char*, size_t);
@@ -1080,7 +1082,12 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     fRng = mbedtls_ctr_drbg_random;
     pRng = pCtrDrbg;
 #else
-    /* PSA is the RNG; KVS_CRYPTO_INIT() in initKvsWebRtc() has initialised it. */
+    /* PSA is the RNG. Idempotent; guards against callers reaching here before
+     * initKvsWebRtc() has run KVS_CRYPTO_INIT(). */
+    if ((psaStatus = psa_crypto_init()) != PSA_SUCCESS) {
+        DLOGE("psa_crypto_init failed (status %d)", (int) psaStatus);
+    }
+    CHK(psaStatus == PSA_SUCCESS, STATUS_CERTIFICATE_GENERATION_FAILED);
     fRng = mbedtls_psa_get_random;
     pRng = MBEDTLS_PSA_RANDOM_STATE;
 #endif

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -168,13 +168,19 @@ STATUS createDtlsSessionWithOptions(PDtlsSessionCallbacks pDtlsSessionCallbacks,
     CHK(pDtlsSession != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
     // initialize mbedtls stuff with sane values
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_init(&pDtlsSession->entropy);
     mbedtls_ctr_drbg_init(&pDtlsSession->ctrDrbg);
+#endif
     mbedtls_ssl_config_init(&pDtlsSession->sslCtxConfig);
     mbedtls_ssl_init(&pDtlsSession->sslCtx);
     mbedtls_x509_crt_init(&pDtlsSession->trustedCaCert);
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_ctr_drbg_set_prediction_resistance(&pDtlsSession->ctrDrbg, MBEDTLS_CTR_DRBG_PR_ON);
     CHK(mbedtls_ctr_drbg_seed(&pDtlsSession->ctrDrbg, mbedtls_entropy_func, &pDtlsSession->entropy, NULL, 0) == 0, STATUS_CREATE_SSL_FAILED);
+#endif
+    /* Without the entropy module there is no DRBG to seed: PSA is the RNG, and
+     * KVS_CRYPTO_INIT() in initKvsWebRtc() has already initialised it. */
 
     CHK_STATUS(createIOBuffer(DEFAULT_MTU_SIZE_BYTES, &pDtlsSession->pReadBuffer));
     pDtlsSession->timerQueueHandle = timerQueueHandle;
@@ -195,7 +201,7 @@ STATUS createDtlsSessionWithOptions(PDtlsSessionCallbacks pDtlsSessionCallbacks,
         for (i = 0; i < certCount; i++) {
             CHK_STATUS(copyCertificateAndKey((mbedtls_x509_crt*) pRtcCertificates[i].pCertificate,
                                              (mbedtls_pk_context*) pRtcCertificates[i].pPrivateKey, &pDtlsSession->certificates[i],
-                                             &pDtlsSession->ctrDrbg));
+                                             KVS_MBEDTLS_DRBG(pDtlsSession)));
             // in case of a failure in between, we'll only free up to current position
             pDtlsSession->certificateCount++;
         }
@@ -242,8 +248,10 @@ STATUS freeDtlsSession(PDtlsSession* ppDtlsSession)
         freeCertificateAndKey(&pCertInfo->cert, &pCertInfo->privateKey);
     }
     mbedtls_x509_crt_free(&pDtlsSession->trustedCaCert);
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_free(&pDtlsSession->entropy);
     mbedtls_ctr_drbg_free(&pDtlsSession->ctrDrbg);
+#endif
     mbedtls_ssl_config_free(&pDtlsSession->sslCtxConfig);
     mbedtls_ssl_free(&pDtlsSession->sslCtx);
 
@@ -469,7 +477,11 @@ STATUS dtlsSessionStart(PDtlsSession pDtlsSession, BOOL isServer)
     CHK_STATUS(dtlsSessionConfigureRemoteCertificateValidation(pDtlsSession));
 #if !MBEDTLS_V4_OR_LATER
     /* mbedTLS 4 removes mbedtls_ssl_conf_rng() — PSA Crypto handles RNG internally. */
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_ssl_conf_rng(&pDtlsSession->sslCtxConfig, mbedtls_ctr_drbg_random, &pDtlsSession->ctrDrbg);
+#else
+    mbedtls_ssl_conf_rng(&pDtlsSession->sslCtxConfig, mbedtls_psa_get_random, MBEDTLS_PSA_RANDOM_STATE);
+#endif
 #endif
 
     for (i = 0; i < pDtlsSession->certificateCount; i++) {
@@ -795,7 +807,12 @@ STATUS copyCertificateAndKey(mbedtls_x509_crt* pCert, mbedtls_pk_context* pKey, 
     UNUSED_PARAM(pCtrDrbg);
     CHK(mbedtls_pk_check_pair(&pCert->pk, pKey) == 0, STATUS_CERTIFICATE_GENERATION_FAILED);
 #else
+#if MBEDTLS_HAS_ENTROPY
     CHK(mbedtls_pk_check_pair(&pCert->pk, pKey, mbedtls_ctr_drbg_random, pCtrDrbg) == 0, STATUS_CERTIFICATE_GENERATION_FAILED);
+#else
+    UNUSED_PARAM(pCtrDrbg);
+    CHK(mbedtls_pk_check_pair(&pCert->pk, pKey, mbedtls_psa_get_random, MBEDTLS_PSA_RANDOM_STATE) == 0, STATUS_CERTIFICATE_GENERATION_FAILED);
+#endif
 #endif
 
     mbedtls_x509_crt_init(&pDst->cert);
@@ -1027,8 +1044,13 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     UINT64 now, notAfter;
     UINT32 written;
     INT32 len;
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_context* pEntropy = NULL;
     mbedtls_ctr_drbg_context* pCtrDrbg = NULL;
+#endif
+    /* RNG handed to key generation and certificate signing below. */
+    int (*fRng)(void*, unsigned char*, size_t);
+    void* pRng;
     mbedtls_mpi serial;
     mbedtls_x509write_cert* pWriteCert = NULL;
     BYTE certSn[DTLS_CERT_MAX_SERIAL_NUM_SIZE];
@@ -1036,29 +1058,41 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     CHK(pCert != NULL && pKey != NULL, STATUS_NULL_ARG);
 
     CHK(NULL != (pCertBuf = (PCHAR) MEMALLOC(GENERATED_CERTIFICATE_MAX_SIZE)), STATUS_NOT_ENOUGH_MEMORY);
+#if MBEDTLS_HAS_ENTROPY
     CHK(NULL != (pEntropy = (mbedtls_entropy_context*) MEMALLOC(SIZEOF(mbedtls_entropy_context))), STATUS_NOT_ENOUGH_MEMORY);
     CHK(NULL != (pCtrDrbg = (mbedtls_ctr_drbg_context*) MEMALLOC(SIZEOF(mbedtls_ctr_drbg_context))), STATUS_NOT_ENOUGH_MEMORY);
+#endif
     CHK(NULL != (pWriteCert = (mbedtls_x509write_cert*) MEMALLOC(SIZEOF(mbedtls_x509write_cert))), STATUS_NOT_ENOUGH_MEMORY);
     CHK_STATUS(dtlsFillPseudoRandomBits(certSn, SIZEOF(certSn)));
 
     // initialize to sane values
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_init(pEntropy);
     mbedtls_ctr_drbg_init(pCtrDrbg);
+#endif
     mbedtls_mpi_init(&serial);
     mbedtls_x509write_crt_init(pWriteCert);
     mbedtls_x509_crt_init(pCert);
     mbedtls_pk_init(pKey);
     initialized = TRUE;
+#if MBEDTLS_HAS_ENTROPY
     CHK(mbedtls_ctr_drbg_seed(pCtrDrbg, mbedtls_entropy_func, pEntropy, NULL, 0) == 0, STATUS_CERTIFICATE_GENERATION_FAILED);
+    fRng = mbedtls_ctr_drbg_random;
+    pRng = pCtrDrbg;
+#else
+    /* PSA is the RNG; KVS_CRYPTO_INIT() in initKvsWebRtc() has initialised it. */
+    fRng = mbedtls_psa_get_random;
+    pRng = MBEDTLS_PSA_RANDOM_STATE;
+#endif
 
     // generate a key
     if (generateRSACertificate) {
         CHK(mbedtls_pk_setup(pKey, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) == 0 &&
-                mbedtls_rsa_gen_key(mbedtls_pk_rsa(*pKey), mbedtls_ctr_drbg_random, pCtrDrbg, certificateBits, KVS_RSA_F4) == 0,
+                mbedtls_rsa_gen_key(mbedtls_pk_rsa(*pKey), fRng, pRng, certificateBits, KVS_RSA_F4) == 0,
             STATUS_CERTIFICATE_GENERATION_FAILED);
     } else {
         CHK(mbedtls_pk_setup(pKey, mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)) == 0 &&
-                mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, mbedtls_pk_ec(*pKey), mbedtls_ctr_drbg_random, pCtrDrbg) == 0,
+                mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, mbedtls_pk_ec(*pKey), fRng, pRng) == 0,
             STATUS_CERTIFICATE_GENERATION_FAILED);
     }
 
@@ -1084,7 +1118,7 @@ STATUS createCertificateAndKey(INT32 certificateBits, BOOL generateRSACertificat
     mbedtls_x509write_crt_set_md_alg(pWriteCert, MBEDTLS_MD_SHA1);
 
     MEMSET(pCertBuf, 0, GENERATED_CERTIFICATE_MAX_SIZE);
-    len = mbedtls_x509write_crt_der(pWriteCert, (PVOID) pCertBuf, GENERATED_CERTIFICATE_MAX_SIZE, mbedtls_ctr_drbg_random, pCtrDrbg);
+    len = mbedtls_x509write_crt_der(pWriteCert, (PVOID) pCertBuf, GENERATED_CERTIFICATE_MAX_SIZE, fRng, pRng);
     CHK(len >= 0, STATUS_CERTIFICATE_GENERATION_FAILED);
 
     // mbedtls_x509write_crt_der starts writing from behind, so we need to use the return len
@@ -1101,16 +1135,20 @@ CleanUp:
     if (initialized) {
         mbedtls_x509write_crt_free(pWriteCert);
         mbedtls_mpi_free(&serial);
+#if MBEDTLS_HAS_ENTROPY
         mbedtls_ctr_drbg_free(pCtrDrbg);
         mbedtls_entropy_free(pEntropy);
+#endif
 
         if (STATUS_FAILED(retStatus)) {
             freeCertificateAndKey(pCert, pKey);
         }
     }
     SAFE_MEMFREE(pCertBuf);
+#if MBEDTLS_HAS_ENTROPY
     SAFE_MEMFREE(pEntropy);
     SAFE_MEMFREE(pCtrDrbg);
+#endif
     SAFE_MEMFREE(pWriteCert);
     LEAVES();
     return retStatus;

--- a/src/source/Crypto/Tls.h
+++ b/src/source/Crypto/Tls.h
@@ -42,8 +42,10 @@ struct __TlsSession {
 
     mbedtls_ssl_context sslCtx;
     mbedtls_ssl_config sslCtxConfig;
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_context entropy;
     mbedtls_ctr_drbg_context ctrDrbg;
+#endif
     mbedtls_x509_crt cacert;
 #else
 #error "A Crypto implementation is required."

--- a/src/source/Crypto/Tls_mbedtls.c
+++ b/src/source/Crypto/Tls_mbedtls.c
@@ -51,12 +51,17 @@ STATUS createTlsSession(PTlsSessionCallbacks pCallbacks, PTlsSession* ppTlsSessi
     pTlsSession->state = TLS_SESSION_STATE_NEW;
 
     // initialize mbedtls stuff with sane values
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_init(&pTlsSession->entropy);
     mbedtls_ctr_drbg_init(&pTlsSession->ctrDrbg);
+#endif
     mbedtls_x509_crt_init(&pTlsSession->cacert);
     mbedtls_ssl_config_init(&pTlsSession->sslCtxConfig);
     mbedtls_ssl_init(&pTlsSession->sslCtx);
+#if MBEDTLS_HAS_ENTROPY
     CHK(mbedtls_ctr_drbg_seed(&pTlsSession->ctrDrbg, mbedtls_entropy_func, &pTlsSession->entropy, NULL, 0) == 0, STATUS_CREATE_SSL_FAILED);
+#endif
+    /* Without the entropy module PSA is the RNG, initialised by KVS_CRYPTO_INIT(). */
 
     CHK_STATUS(readAndParseCACertificate(pTlsSession));
 
@@ -85,8 +90,10 @@ STATUS freeTlsSession(PTlsSession* ppTlsSession)
     pTlsSession = *ppTlsSession;
     CHK(pTlsSession != NULL, retStatus);
 
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_entropy_free(&pTlsSession->entropy);
     mbedtls_ctr_drbg_free(&pTlsSession->ctrDrbg);
+#endif
     mbedtls_x509_crt_free(&pTlsSession->cacert);
     mbedtls_ssl_config_free(&pTlsSession->sslCtxConfig);
     mbedtls_ssl_free(&pTlsSession->sslCtx);
@@ -160,7 +167,11 @@ STATUS tlsSessionStartWithHostname(PTlsSession pTlsSession, BOOL isServer, PCHAR
 #if !MBEDTLS_V4_OR_LATER
     /* mbedTLS 4 removes mbedtls_ssl_conf_rng() — PSA Crypto provides the RNG
      * internally once psa_crypto_init() has run, so no explicit binding is needed. */
+#if MBEDTLS_HAS_ENTROPY
     mbedtls_ssl_conf_rng(&pTlsSession->sslCtxConfig, mbedtls_ctr_drbg_random, &pTlsSession->ctrDrbg);
+#else
+    mbedtls_ssl_conf_rng(&pTlsSession->sslCtxConfig, mbedtls_psa_get_random, MBEDTLS_PSA_RANDOM_STATE);
+#endif
 #endif
     CHK(mbedtls_ssl_setup(&pTlsSession->sslCtx, &pTlsSession->sslCtxConfig) == 0, STATUS_SSL_CTX_CREATION_FAILED);
 

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -79,6 +79,21 @@ extern "C" {
 #include <mbedtls/sha256.h>
 #include <mbedtls/md5.h>
 #endif
+
+/* Randomness source. A build that supplies randomness through a PSA driver
+ * (MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG, the default on ESP-IDF v6 targets) compiles the
+ * entropy module out, and is permitted to drop CTR-DRBG with it, so
+ * mbedtls_entropy_* / mbedtls_ctr_drbg_* do not exist at link time. Such builds take
+ * their RNG from PSA instead. This is a build-configuration question rather than a
+ * version one: stock mbedTLS 4 still ships both modules. */
+#if defined(MBEDTLS_ENTROPY_C) && defined(MBEDTLS_CTR_DRBG_C)
+#define MBEDTLS_HAS_ENTROPY (1)
+#elif defined(MBEDTLS_PSA_CRYPTO_CLIENT) || defined(MBEDTLS_PSA_CRYPTO_C)
+#define MBEDTLS_HAS_ENTROPY (0)
+#include <mbedtls/psa_util.h>
+#else
+#error "mbedTLS must provide either the entropy and CTR-DRBG modules or PSA Crypto for randomness"
+#endif
 #endif
 
 #ifdef USE_LIBSRTP3


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- `Include_i.h` derives a new `MBEDTLS_HAS_ENTROPY` from the mbedTLS configuration, and the DTLS/TLS session paths plus the pre-v4 `createCertificateAndKey()` no longer assume the entropy module exists.
- Builds without it source randomness from PSA. Where entropy is present, behaviour is unchanged.

*Why was it changed?*
- A build that supplies randomness through a PSA driver — `MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG`, the default on ESP-IDF v6 targets — compiles mbedTLS's entropy module out entirely, and is permitted to drop CTR-DRBG with it. `MBEDTLS_ENTROPY_C` is then undefined and the symbols do not exist, so the SDK fails to link:
  ```
  undefined reference to `mbedtls_entropy_init'
  undefined reference to `mbedtls_entropy_func'
  undefined reference to `mbedtls_entropy_free'
  ```
- This is a build-*configuration* question rather than a version one, which is why the guard is `MBEDTLS_ENTROPY_C` and not `MBEDTLS_VERSION_MAJOR`: stock mbedTLS 4 still ships the entropy module, so CI does not encounter this.
- Beyond the link error, two paths would have gone wrong silently once entropy was absent. `copyCertificateAndKey()` passes the session DRBG to `mbedtls_pk_check_pair()` on mbedTLS 3.2–3.6; an `init()`-only DRBG has `reseed_counter == -1`, so it never reseeds and drives an unkeyed cipher operation. And the pre-v4 `createCertificateAndKey()` — the default path whenever no `RtcCertificate` is supplied — seeds its own local DRBG from entropy, so guarding only the session paths would have left mbedTLS 3.x unbuildable anyway.

*How was it changed?*
- `Include_i.h`: `MBEDTLS_HAS_ENTROPY` is `1` when both `MBEDTLS_ENTROPY_C` and `MBEDTLS_CTR_DRBG_C` are defined, `0` when PSA Crypto is available instead (`MBEDTLS_PSA_CRYPTO_CLIENT` / `MBEDTLS_PSA_CRYPTO_C`, which is also where `<mbedtls/psa_util.h>` is pulled in), and `#error` when neither can provide randomness. It sits with the other mbedTLS includes so it is defined before the structs that use it.
- `Dtls.h` / `Tls.h`: the `entropy` and `ctrDrbg` members are compiled out when absent, so any future use in such a build is a compile error rather than a silently weak RNG. `KVS_MBEDTLS_DRBG()` yields the DRBG or `NULL`.
- `Dtls_mbedtls.c` / `Tls_mbedtls.c`: entropy/DRBG init, seeding and teardown are guarded. `mbedtls_ssl_conf_rng()` and `mbedtls_pk_check_pair()` receive `mbedtls_psa_get_random`/`MBEDTLS_PSA_RANDOM_STATE` instead of an unseeded DRBG, and the pre-v4 `createCertificateAndKey()` drives RSA/ECP key generation and `mbedtls_x509write_crt_der()` through the same pair.
- `Crypto.h`: `KVS_CRYPTO_INIT()` now also covers entropy-less pre-v4 builds, so `psa_crypto_init()` still happens once from `initKvsWebRtc()`. Calling it per session would have reintroduced the race on builds without `MBEDTLS_THREADING_C` that the existing v4 comment warns about.

*What testing was done for the changes?*
- Desktop mbedTLS build (`-DUSE_MBEDTLS=ON -DBUILD_TEST=ON`), entropy present: `webrtc_client_test` passes, 18/18 across `DtlsApiTest`, `DtlsFunctionalityTest`, `PeerConnectionApiTest` — the path this change must leave untouched.
- ESP32-P4 with ESP-IDF v6.0.2 (mbedTLS 4.1.1, external RNG, no entropy module): previously failed to link; now links, the DTLS handshake completes in ~1.1 s, and SRTP video/audio plus a data channel flow to a browser viewer over a KVS signaling channel.
- ESP-IDF v5.5 (mbedTLS 3.x, entropy present): builds and streams unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
