### PR TITLE
Ice/TURN: don't wait the per-state timeout for peers rejected by the TURN server

### DIFF
--- a/src/source/Ice/TurnConnectionStateMachine.c
+++ b/src/source/Ice/TurnConnectionStateMachine.c
@@ -376,7 +376,7 @@ STATUS fromCreatePermissionTurnState(UINT64 customData, PUINT64 pState)
     STATUS retStatus = STATUS_SUCCESS;
     PTurnConnection pTurnConnection = (PTurnConnection) customData;
     UINT64 state = TURN_STATE_CREATE_PERMISSION, currentTime;
-    UINT32 channelWithPermissionCount = 0, i = 0;
+    UINT32 channelWithPermissionCount = 0, failedPeerCount = 0, i = 0;
     BOOL locked = FALSE;
 
     CHK(pTurnConnection != NULL && pState != NULL, STATUS_NULL_ARG);
@@ -399,6 +399,8 @@ STATUS fromCreatePermissionTurnState(UINT64 customData, PUINT64 pState)
         if (pTurnConnection->turnPeerList[i].connectionState == TURN_PEER_CONN_STATE_BIND_CHANNEL ||
             pTurnConnection->turnPeerList[i].connectionState == TURN_PEER_CONN_STATE_READY) {
             channelWithPermissionCount++;
+        } else if (pTurnConnection->turnPeerList[i].connectionState == TURN_PEER_CONN_STATE_FAILED) {
+            failedPeerCount++;
         }
     }
 
@@ -408,7 +410,7 @@ STATUS fromCreatePermissionTurnState(UINT64 customData, PUINT64 pState)
         CHK(FALSE, retStatus);
     }
 
-    if (currentTime > pTurnConnection->stateTimeoutTime || channelWithPermissionCount == pTurnConnection->turnPeerCount) {
+    if (currentTime > pTurnConnection->stateTimeoutTime || channelWithPermissionCount + failedPeerCount == pTurnConnection->turnPeerCount) {
         CHK(channelWithPermissionCount > 0, STATUS_TURN_CONNECTION_FAILED_TO_CREATE_PERMISSION);
 
         // go to next state if we have at least one ready peer
@@ -501,7 +503,7 @@ STATUS fromBindChannelTurnState(UINT64 customData, PUINT64 pState)
     UINT64 state = TURN_STATE_BIND_CHANNEL;
     UINT64 currentTime;
     BOOL locked = FALSE;
-    UINT32 readyPeerCount = 0, i = 0;
+    UINT32 readyPeerCount = 0, failedPeerCount = 0, i = 0;
 
     CHK(pTurnConnection != NULL && pState != NULL, STATUS_NULL_ARG);
 
@@ -517,9 +519,11 @@ STATUS fromBindChannelTurnState(UINT64 customData, PUINT64 pState)
     for (i = 0; i < pTurnConnection->turnPeerCount; ++i) {
         if (pTurnConnection->turnPeerList[i].connectionState == TURN_PEER_CONN_STATE_READY) {
             readyPeerCount++;
+        } else if (pTurnConnection->turnPeerList[i].connectionState == TURN_PEER_CONN_STATE_FAILED) {
+            failedPeerCount++;
         }
     }
-    if (currentTime > pTurnConnection->stateTimeoutTime || readyPeerCount == pTurnConnection->turnPeerCount) {
+    if (currentTime > pTurnConnection->stateTimeoutTime || readyPeerCount + failedPeerCount == pTurnConnection->turnPeerCount) {
         CHK(readyPeerCount > 0, STATUS_TURN_CONNECTION_FAILED_TO_BIND_CHANNEL);
         // go to next state if we have at least one ready peer
         state = TURN_STATE_READY;


### PR DESCRIPTION
### Issue #, if available
Fixes #2386

### Description of changes
`fromCreatePermissionTurnState()` and `fromBindChannelTurnState()` advance the TURN connection early only when **all** peers reached the ready side (`channelWithPermissionCount == turnPeerCount` / `readyPeerCount == turnPeerCount`).

When a peer's `CreatePermission` is rejected by the TURN server (e.g. `403 Forbidden IP` for a non-routable remote candidate), the peer is set to `TURN_PEER_CONN_STATE_FAILED` in `turnConnectionHandleStunError()` but kept in `turnPeerList` (`turnPeerCount` is not decremented). Because a failed peer is never counted as ready, `== turnPeerCount` can never be reached, and the state machine always waits the full `DEFAULT_TURN_CREATE_PERMISSION_TIMEOUT` (5s) then `DEFAULT_TURN_BIND_CHANNEL_TIMEOUT` (5s) — ~10s to reach `TURN_STATE_READY` — even when the reachable peer's permission and channel bind succeeded immediately.

While the TURN connection is not `READY`, its relay candidate stays pending, so `pendingCandidateCount != 0` prevents `iceAgentGatherCandidateTimerCallback()` from completing gathering early; gathering only finishes at `iceLocalCandidateGatheringTimeout`. For **non-trickle** sessions (where the answer is serialized/sent at gathering-complete) this delays every answer by ~10s. Reproduced with **Amazon Alexa Smart Home**, whose `InitiateSessionWithOffer` offer is non-trickle and includes the device's private/link-local candidates that the TURN server rejects with `403 Forbidden IP`. See #2386 for a full trace.

This change counts `TURN_PEER_CONN_STATE_FAILED` peers as terminal and advances as soon as every peer is either ready or failed, keeping the existing guard that at least one peer is ready. Failed peers can never be relayed to, and peers added later still get their permission/channel created while in `TURN_STATE_READY`, so nothing is lost. When no peer fails (`failedPeerCount == 0`) the condition is identical to before.

### How was this change tested
- On device (aarch64 / Yocto, KVS 1.15.0): a non-trickle Alexa live-view session previously reported `ICE candidate gathering complete` at ~10s; with the patch the TURN connections reach `READY` right after the first channel bind and gathering completes early, so the answer is sent without the timeout wait.
- Verified no behavior change for the all-peers-succeed and single-peer cases (`failedPeerCount == 0`).

### License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
