### PR TITLE
Fix issue 2386 - #2388  (Adding filter for Relay candidates)

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1472,6 +1472,11 @@ typedef struct {
     BOOL enableIceStats; //!< Control whether ICE agent stats are to be calculated. ENABLE_STATS_CALCULATION_CONTROL compiler flag must be defined
                          //!< to use this member, else stats are enabled by default.
 #endif
+    BOOL disableTurnPeerAddressFilter; //!< By default the SDK does not create TURN permissions for non-routable peer addresses
+                                       //!< (RFC 1918 private, RFC 6598 CGNAT, loopback, RFC 3927 link-local, etc.), because a public
+                                       //!< TURN server such as the KVS TURN service rejects them with 403 Forbidden IP. Set this to TRUE
+                                       //!< if you use a TURN server that legitimately relays to such addresses (e.g. an on-prem/LAN TURN),
+                                       //!< so those peers are not filtered. Filtering is enabled by default (this flag defaults to FALSE).
 } KvsRtcConfiguration, *PKvsRtcConfiguration;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1472,11 +1472,11 @@ typedef struct {
     BOOL enableIceStats; //!< Control whether ICE agent stats are to be calculated. ENABLE_STATS_CALCULATION_CONTROL compiler flag must be defined
                          //!< to use this member, else stats are enabled by default.
 #endif
-    BOOL disableTurnPeerAddressFilter; //!< By default the SDK does not create TURN permissions for non-routable peer addresses
-                                       //!< (RFC 1918 private, RFC 6598 CGNAT, loopback, RFC 3927 link-local, etc.), because a public
-                                       //!< TURN server such as the KVS TURN service rejects them with 403 Forbidden IP. Set this to TRUE
-                                       //!< if you use a TURN server that legitimately relays to such addresses (e.g. an on-prem/LAN TURN),
-                                       //!< so those peers are not filtered. Filtering is enabled by default (this flag defaults to FALSE).
+    BOOL disableNonRoutablePeersFilterForRelay; //!< By default the SDK does not create TURN permissions for non-routable peer addresses
+                                                //!< (RFC 1918 private, RFC 6598 CGNAT, loopback, RFC 3927 link-local, etc.), because a public
+                                                //!< TURN server such as the KVS TURN service rejects them with 403 Forbidden IP. Set this to TRUE
+                                                //!< if you use a TURN server that legitimately relays to such addresses (e.g. an on-prem/LAN TURN),
+                                                //!< so those peers are not filtered. Filtering is enabled by default (this flag defaults to FALSE).
 } KvsRtcConfiguration, *PKvsRtcConfiguration;
 
 /**

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2221,7 +2221,7 @@ STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KV
     pNewCandidate->pIceAgent = pIceAgent;
     pNewCandidate->pTurnConnection = pTurnConnection;
     // Propagate the non-routable peer filter policy so turnConnectionAddPeer can honor it.
-    pTurnConnection->disableTurnPeerAddressFilter = pIceAgent->kvsRtcConfiguration.disableTurnPeerAddressFilter;
+    pTurnConnection->disableNonRoutablePeersFilterForRelay = pIceAgent->kvsRtcConfiguration.disableNonRoutablePeersFilterForRelay;
 
     MUTEX_LOCK(pIceAgent->lock);
     locked = TRUE;

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -2220,6 +2220,8 @@ STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KV
                                     pIceAgent->pConnectionListener, turnServerIpFamily, &pTurnConnection));
     pNewCandidate->pIceAgent = pIceAgent;
     pNewCandidate->pTurnConnection = pTurnConnection;
+    // Propagate the non-routable peer filter policy so turnConnectionAddPeer can honor it.
+    pTurnConnection->disableTurnPeerAddressFilter = pIceAgent->kvsRtcConfiguration.disableTurnPeerAddressFilter;
 
     MUTEX_LOCK(pIceAgent->lock);
     locked = TRUE;

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -763,13 +763,18 @@ STATUS turnConnectionAddPeer(PTurnConnection pTurnConnection, PKvsIpAddress pPee
 
     CHK(pTurnConnection != NULL && pPeerAddress != NULL, STATUS_NULL_ARG);
 
-    /* Skip non-routable peers up front: the TURN server would reject CreatePermission for
+    /* Skip non-routable peers up front: a public TURN server would reject CreatePermission for
      * them with 403 Forbidden IP, which otherwise stalls the state machine waiting on a
-     * permission/channel bind that can never succeed. The candidate itself is untouched, so
-     * it can still be used for direct (host/srflx) pairing when a non-relay path exists.
-     * The peer address is intentionally not logged (privacy). */
-    if (IS_NON_ROUTABLE_ADDR(pPeerAddress)) {
-        DLOGD("Skipping TURN permission for non-routable peer (TURN server would reject with 403 Forbidden IP)");
+     * permission/channel bind that can never succeed. The candidate itself is untouched, so it
+     * can still be used for direct (host/srflx) pairing when a non-relay path exists. This is
+     * skipped when disableTurnPeerAddressFilter is set, for TURN servers that relay to private
+     * peers. The running filtered-peer count is logged at INFO so an operator can see when a
+     * relay path is removed. */
+    if (!pTurnConnection->disableTurnPeerAddressFilter && IS_NON_ROUTABLE_ADDR(pPeerAddress)) {
+        pTurnConnection->nonRoutablePeersFiltered++;
+        DLOGI("Skipping TURN permission for non-routable peer (%u filtered so far on this TURN connection; "
+              "TURN server would reject with 403 Forbidden IP)",
+              pTurnConnection->nonRoutablePeersFiltered);
         CHK(FALSE, retStatus); // retStatus == STATUS_SUCCESS: treat as a successful no-op
     }
 

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -767,14 +767,14 @@ STATUS turnConnectionAddPeer(PTurnConnection pTurnConnection, PKvsIpAddress pPee
      * them with 403 Forbidden IP, which otherwise stalls the state machine waiting on a
      * permission/channel bind that can never succeed. The candidate itself is untouched, so it
      * can still be used for direct (host/srflx) pairing when a non-relay path exists. This is
-     * skipped when disableTurnPeerAddressFilter is set, for TURN servers that relay to private
+     * skipped when disableNonRoutablePeersFilterForRelay is set, for TURN servers that relay to private
      * peers. The running filtered-peer count is logged at INFO so an operator can see when a
      * relay path is removed. */
-    if (!pTurnConnection->disableTurnPeerAddressFilter && IS_NON_ROUTABLE_ADDR(pPeerAddress)) {
-        pTurnConnection->nonRoutablePeersFiltered++;
+    if (!pTurnConnection->disableNonRoutablePeersFilterForRelay && IS_NON_ROUTABLE_ADDR(pPeerAddress)) {
+        pTurnConnection->nonRoutablePeersFilteredCount++;
         DLOGI("Skipping TURN permission for non-routable peer (%u filtered so far on this TURN connection; "
               "TURN server would reject with 403 Forbidden IP)",
-              pTurnConnection->nonRoutablePeersFiltered);
+              pTurnConnection->nonRoutablePeersFilteredCount);
         CHK(FALSE, retStatus); // retStatus == STATUS_SUCCESS: treat as a successful no-op
     }
 

--- a/src/source/Ice/TurnConnection.c
+++ b/src/source/Ice/TurnConnection.c
@@ -763,6 +763,16 @@ STATUS turnConnectionAddPeer(PTurnConnection pTurnConnection, PKvsIpAddress pPee
 
     CHK(pTurnConnection != NULL && pPeerAddress != NULL, STATUS_NULL_ARG);
 
+    /* Skip non-routable peers up front: the TURN server would reject CreatePermission for
+     * them with 403 Forbidden IP, which otherwise stalls the state machine waiting on a
+     * permission/channel bind that can never succeed. The candidate itself is untouched, so
+     * it can still be used for direct (host/srflx) pairing when a non-relay path exists.
+     * The peer address is intentionally not logged (privacy). */
+    if (IS_NON_ROUTABLE_ADDR(pPeerAddress)) {
+        DLOGD("Skipping TURN permission for non-routable peer (TURN server would reject with 403 Forbidden IP)");
+        CHK(FALSE, retStatus); // retStatus == STATUS_SUCCESS: treat as a successful no-op
+    }
+
     if (pTurnConnection->ipFamilyType == KVS_IP_FAMILY_TYPE_IPV4) {
         CHK_WARN(IS_IPV4_ADDR(pPeerAddress), STATUS_INVALID_ARG, "Dropping IPv6 peer for IPv4 TURN connection.");
     } else if (pTurnConnection->ipFamilyType == KVS_IP_FAMILY_TYPE_IPV6) {

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -197,6 +197,15 @@ struct __TurnConnection {
     TurnProfileDiagnostics turnProfileDiagnostics;
     PStateMachine pStateMachine;
 
+    // When FALSE (default), turnConnectionAddPeer skips non-routable peer addresses that a public
+    // TURN server would reject with 403 Forbidden IP. Set TRUE (via KvsRtcConfiguration) for TURN
+    // servers that legitimately relay to private/link-local peers (e.g. on-prem/LAN deployments).
+    BOOL disableTurnPeerAddressFilter;
+
+    // Diagnostic counter: number of peers skipped by the non-routable address filter on this
+    // TURN connection. Surfaced in logs so an operator can tell when a relay path was removed.
+    UINT32 nonRoutablePeersFiltered;
+
     KVS_IP_FAMILY_TYPE ipFamilyType;
 };
 typedef struct __TurnConnection* PTurnConnection;

--- a/src/source/Ice/TurnConnection.h
+++ b/src/source/Ice/TurnConnection.h
@@ -200,11 +200,11 @@ struct __TurnConnection {
     // When FALSE (default), turnConnectionAddPeer skips non-routable peer addresses that a public
     // TURN server would reject with 403 Forbidden IP. Set TRUE (via KvsRtcConfiguration) for TURN
     // servers that legitimately relay to private/link-local peers (e.g. on-prem/LAN deployments).
-    BOOL disableTurnPeerAddressFilter;
+    BOOL disableNonRoutablePeersFilterForRelay;
 
     // Diagnostic counter: number of peers skipped by the non-routable address filter on this
     // TURN connection. Surfaced in logs so an operator can tell when a relay path was removed.
-    UINT32 nonRoutablePeersFiltered;
+    UINT32 nonRoutablePeersFilteredCount;
 
     KVS_IP_FAMILY_TYPE ipFamilyType;
 };

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -164,34 +164,96 @@ static inline BOOL IS_IPV6_ADDR(const PKvsIpAddress pAddress)
     return pAddress != NULL && pAddress->family == KVS_IP_FAMILY_TYPE_IPV6;
 }
 
-// Returns TRUE for non-routable IPv4 addresses that a public TURN server (e.g. the KVS
-// TURN service) refuses to create a permission for, responding with "403 Forbidden IP".
-// Covered ranges (address bytes are in network byte order): 10.0.0.0/8, 172.16.0.0/12 and
-// 192.168.0.0/16 (RFC1918 private), 127.0.0.0/8 (loopback), 169.254.0.0/16 (RFC3927
-// link-local). IPv6 addresses return FALSE. NOTE: assumes the TURN server cannot relay to
-// private/link-local peers, which holds for the KVS TURN service; an on-prem TURN server
-// inside a private network may legitimately relay to these and would need this relaxed.
+// Returns TRUE for IP addresses that are not globally reachable, per the IANA Special-Purpose
+// Address Registries (RFC 6890 and the RFCs noted per range). A public TURN server (e.g. the
+// KVS TURN service) cannot relay to these and rejects CreatePermission for them with
+// "403 Forbidden IP". Address bytes are in network byte order. Both IPv4 and IPv6 are covered.
 static inline BOOL IS_NON_ROUTABLE_ADDR(const PKvsIpAddress pAddress)
 {
-    // Only IPv4 ranges are classified here (IS_IPV4_ADDR also handles the NULL check).
+    BYTE b0, b1, b2;
+
+    if (pAddress == NULL) {
+        return FALSE;
+    }
+
+    // IPv6 non-globally-reachable ranges (address is 16 bytes, network byte order).
+    if (IS_IPV6_ADDR(pAddress)) {
+        PBYTE a = pAddress->address;
+        UINT32 i;
+        BOOL allZeroButLast = TRUE;
+
+        if (a[0] == 0xfe && (a[1] & 0xc0) == 0x80) {
+            return TRUE; // fe80::/10       link-local unicast (RFC 4291)
+        }
+        if ((a[0] & 0xfe) == 0xfc) {
+            return TRUE; // fc00::/7        unique local address / ULA (RFC 4193)
+        }
+        if (a[0] == 0x20 && a[1] == 0x01 && a[2] == 0x0d && a[3] == 0xb8) {
+            return TRUE; // 2001:db8::/32   documentation (RFC 3849)
+        }
+        for (i = 0; i < 15; ++i) {
+            if (a[i] != 0) {
+                allZeroButLast = FALSE;
+                break;
+            }
+        }
+        if (allZeroButLast && (a[15] == 0 || a[15] == 1)) {
+            return TRUE; // ::/128 unspecified and ::1/128 loopback (RFC 4291)
+        }
+
+        return FALSE;
+    }
+
+    // Only IPv4 ranges remain (IS_IPV4_ADDR also handles the NULL check).
     if (!IS_IPV4_ADDR(pAddress)) {
         return FALSE;
     }
 
-    if (pAddress->address[0] == 127) {
-        return TRUE; // 127.0.0.0/8 loopback
+    b0 = pAddress->address[0];
+    b1 = pAddress->address[1];
+    b2 = pAddress->address[2];
+
+    if (b0 == 0) {
+        return TRUE; // 0.0.0.0/8        "this host on this network" (RFC 1122)
     }
-    if (pAddress->address[0] == 10) {
-        return TRUE; // 10.0.0.0/8 private
+    if (b0 == 10) {
+        return TRUE; // 10.0.0.0/8       private-use (RFC 1918)
     }
-    if (pAddress->address[0] == 172 && pAddress->address[1] >= 16 && pAddress->address[1] <= 31) {
-        return TRUE; // 172.16.0.0/12 private
+    if (b0 == 100 && b1 >= 64 && b1 <= 127) {
+        return TRUE; // 100.64.0.0/10    shared address space / CGNAT (RFC 6598)
     }
-    if (pAddress->address[0] == 192 && pAddress->address[1] == 168) {
-        return TRUE; // 192.168.0.0/16 private
+    if (b0 == 127) {
+        return TRUE; // 127.0.0.0/8      loopback (RFC 1122)
     }
-    if (pAddress->address[0] == 169 && pAddress->address[1] == 254) {
-        return TRUE; // 169.254.0.0/16 link-local
+    if (b0 == 169 && b1 == 254) {
+        return TRUE; // 169.254.0.0/16   link-local (RFC 3927)
+    }
+    if (b0 == 172 && b1 >= 16 && b1 <= 31) {
+        return TRUE; // 172.16.0.0/12    private-use (RFC 1918)
+    }
+    if (b0 == 192 && b1 == 0 && b2 == 0) {
+        return TRUE; // 192.0.0.0/24     IETF protocol assignments (RFC 6890)
+    }
+    if (b0 == 192 && b1 == 0 && b2 == 2) {
+        return TRUE; // 192.0.2.0/24     documentation TEST-NET-1 (RFC 5737)
+    }
+    if (b0 == 192 && b1 == 88 && b2 == 99) {
+        return TRUE; // 192.88.99.0/24   6to4 relay anycast, deprecated (RFC 7526)
+    }
+    if (b0 == 192 && b1 == 168) {
+        return TRUE; // 192.168.0.0/16   private-use (RFC 1918)
+    }
+    if (b0 == 198 && (b1 == 18 || b1 == 19)) {
+        return TRUE; // 198.18.0.0/15    benchmarking (RFC 2544)
+    }
+    if (b0 == 198 && b1 == 51 && b2 == 100) {
+        return TRUE; // 198.51.100.0/24  documentation TEST-NET-2 (RFC 5737)
+    }
+    if (b0 == 203 && b1 == 0 && b2 == 113) {
+        return TRUE; // 203.0.113.0/24   documentation TEST-NET-3 (RFC 5737)
+    }
+    if (b0 >= 240) {
+        return TRUE; // 240.0.0.0/4      reserved / future use, incl. 255.255.255.255 (RFC 1112)
     }
 
     return FALSE;

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -164,6 +164,39 @@ static inline BOOL IS_IPV6_ADDR(const PKvsIpAddress pAddress)
     return pAddress != NULL && pAddress->family == KVS_IP_FAMILY_TYPE_IPV6;
 }
 
+// Returns TRUE for non-routable IPv4 addresses that a public TURN server (e.g. the KVS
+// TURN service) refuses to create a permission for, responding with "403 Forbidden IP".
+// Covered ranges (address bytes are in network byte order): 10.0.0.0/8, 172.16.0.0/12 and
+// 192.168.0.0/16 (RFC1918 private), 127.0.0.0/8 (loopback), 169.254.0.0/16 (RFC3927
+// link-local). IPv6 addresses return FALSE. NOTE: assumes the TURN server cannot relay to
+// private/link-local peers, which holds for the KVS TURN service; an on-prem TURN server
+// inside a private network may legitimately relay to these and would need this relaxed.
+static inline BOOL IS_NON_ROUTABLE_ADDR(const PKvsIpAddress pAddress)
+{
+    // Only IPv4 ranges are classified here (IS_IPV4_ADDR also handles the NULL check).
+    if (!IS_IPV4_ADDR(pAddress)) {
+        return FALSE;
+    }
+
+    if (pAddress->address[0] == 127) {
+        return TRUE; // 127.0.0.0/8 loopback
+    }
+    if (pAddress->address[0] == 10) {
+        return TRUE; // 10.0.0.0/8 private
+    }
+    if (pAddress->address[0] == 172 && pAddress->address[1] >= 16 && pAddress->address[1] <= 31) {
+        return TRUE; // 172.16.0.0/12 private
+    }
+    if (pAddress->address[0] == 192 && pAddress->address[1] == 168) {
+        return TRUE; // 192.168.0.0/16 private
+    }
+    if (pAddress->address[0] == 169 && pAddress->address[1] == 254) {
+        return TRUE; // 169.254.0.0/16 link-local
+    }
+
+    return FALSE;
+}
+
 // Used for ensuring alignment
 #define ALIGN_UP_TO_MACHINE_WORD(x) ROUND_UP((x), SIZEOF(SIZE_T))
 

--- a/tst/NetworkApiTest.cpp
+++ b/tst/NetworkApiTest.cpp
@@ -338,6 +338,7 @@ TEST_F(NetworkApiTest, IsNonRoutableAddrIpv6RoutableAndBoundaries)
     setKvsV6Addr(&addr, 0xfe, 0xc0, 0, 0, 1);          EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // fec0:: (outside fe80/10 and fc00/7)
     setKvsV6Addr(&addr, 0xfe, 0x7f, 0, 0, 1);          EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // fe7f:: (just below fe80/10)
     setKvsV6Addr(&addr, 0xfe, 0x00, 0, 0, 1);          EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // fe00:: (not ULA, not link-local)
+    setKvsV6Addr(&addr, 0, 0, 0, 0, 2);                EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // ::2 is neither :: (unspecified) nor ::1 (loopback)
 }
 
 } // namespace webrtcclient

--- a/tst/NetworkApiTest.cpp
+++ b/tst/NetworkApiTest.cpp
@@ -234,6 +234,112 @@ TEST_F(NetworkApiTest, GetIpAddrPortStrIpv6BufferTooSmallByOne)
     EXPECT_STREQ("", buffer);
 }
 
+// ------------------------------- IS_NON_ROUTABLE_ADDR ----------------------
+// Unit tests for the non-globally-reachable address classifier used by
+// turnConnectionAddPeer to skip TURN peers a public TURN server would 403.
+
+static VOID setKvsV4Addr(PKvsIpAddress pAddr, UINT8 a, UINT8 b, UINT8 c, UINT8 d)
+{
+    MEMSET(pAddr, 0, SIZEOF(KvsIpAddress));
+    pAddr->family = KVS_IP_FAMILY_TYPE_IPV4;
+    pAddr->address[0] = a;
+    pAddr->address[1] = b;
+    pAddr->address[2] = c;
+    pAddr->address[3] = d;
+}
+
+// Sets IPv6 bytes [0..3] and [15]; remaining bytes are zero. That is enough to
+// exercise every range prefix (and the ::/::1 all-zero cases) the classifier checks.
+static VOID setKvsV6Addr(PKvsIpAddress pAddr, UINT8 b0, UINT8 b1, UINT8 b2, UINT8 b3, UINT8 b15)
+{
+    MEMSET(pAddr, 0, SIZEOF(KvsIpAddress));
+    pAddr->family = KVS_IP_FAMILY_TYPE_IPV6;
+    pAddr->address[0] = b0;
+    pAddr->address[1] = b1;
+    pAddr->address[2] = b2;
+    pAddr->address[3] = b3;
+    pAddr->address[15] = b15;
+}
+
+TEST_F(NetworkApiTest, IsNonRoutableAddrNullAndUnsetFamily)
+{
+    KvsIpAddress addr;
+
+    // NULL is safe and not classified as non-routable.
+    EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(NULL));
+
+    // Family neither IPv4 nor IPv6 -> not classified.
+    MEMSET(&addr, 0, SIZEOF(KvsIpAddress));
+    addr.family = KVS_IP_FAMILY_TYPE_NOT_SET;
+    EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr));
+}
+
+TEST_F(NetworkApiTest, IsNonRoutableAddrIpv4NonRoutable)
+{
+    KvsIpAddress addr;
+
+    setKvsV4Addr(&addr, 0, 1, 2, 3);         EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 0.0.0.0/8
+    setKvsV4Addr(&addr, 10, 0, 0, 1);        EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 10.0.0.0/8
+    setKvsV4Addr(&addr, 100, 64, 0, 1);      EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 100.64.0.0/10 low
+    setKvsV4Addr(&addr, 100, 127, 255, 255); EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 100.64.0.0/10 high
+    setKvsV4Addr(&addr, 127, 0, 0, 1);       EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 127.0.0.0/8 loopback
+    setKvsV4Addr(&addr, 169, 254, 1, 1);     EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 169.254.0.0/16 link-local
+    setKvsV4Addr(&addr, 172, 16, 0, 1);      EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 172.16.0.0/12 low
+    setKvsV4Addr(&addr, 172, 31, 255, 255);  EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 172.16.0.0/12 high
+    setKvsV4Addr(&addr, 192, 0, 0, 1);       EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 192.0.0.0/24
+    setKvsV4Addr(&addr, 192, 0, 2, 5);       EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 192.0.2.0/24 TEST-NET-1
+    setKvsV4Addr(&addr, 192, 88, 99, 1);     EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 192.88.99.0/24
+    setKvsV4Addr(&addr, 192, 168, 1, 1);     EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 192.168.0.0/16
+    setKvsV4Addr(&addr, 198, 18, 0, 1);      EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 198.18.0.0/15 low
+    setKvsV4Addr(&addr, 198, 19, 255, 255);  EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 198.18.0.0/15 high
+    setKvsV4Addr(&addr, 198, 51, 100, 7);    EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 198.51.100.0/24 TEST-NET-2
+    setKvsV4Addr(&addr, 203, 0, 113, 7);     EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 203.0.113.0/24 TEST-NET-3
+    setKvsV4Addr(&addr, 240, 0, 0, 1);       EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 240.0.0.0/4
+    setKvsV4Addr(&addr, 255, 255, 255, 255); EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // limited broadcast
+}
+
+TEST_F(NetworkApiTest, IsNonRoutableAddrIpv4RoutableAndBoundaries)
+{
+    KvsIpAddress addr;
+
+    setKvsV4Addr(&addr, 8, 8, 8, 8);         EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // public
+    setKvsV4Addr(&addr, 1, 1, 1, 1);         EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // public
+    setKvsV4Addr(&addr, 11, 112, 226, 120);  EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // public (seen in live test)
+    setKvsV4Addr(&addr, 100, 63, 255, 255);  EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // just below 100.64/10
+    setKvsV4Addr(&addr, 100, 128, 0, 0);     EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // just above 100.64/10
+    setKvsV4Addr(&addr, 172, 15, 255, 255);  EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // just below 172.16/12
+    setKvsV4Addr(&addr, 172, 32, 0, 0);      EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // just above 172.16/12
+    setKvsV4Addr(&addr, 198, 17, 255, 255);  EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // just below 198.18/15
+    setKvsV4Addr(&addr, 198, 20, 0, 0);      EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // just above 198.18/15
+    setKvsV4Addr(&addr, 239, 255, 255, 255); EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // just below 240/4 (multicast, not filtered)
+    setKvsV4Addr(&addr, 192, 1, 0, 1);       EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // 192.x but not a reserved /24 nor 192.168
+    setKvsV4Addr(&addr, 203, 0, 114, 1);     EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // adjacent to TEST-NET-3
+}
+
+TEST_F(NetworkApiTest, IsNonRoutableAddrIpv6NonRoutable)
+{
+    KvsIpAddress addr;
+
+    setKvsV6Addr(&addr, 0, 0, 0, 0, 0);            EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // ::/128 unspecified
+    setKvsV6Addr(&addr, 0, 0, 0, 0, 1);            EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // ::1/128 loopback
+    setKvsV6Addr(&addr, 0xfe, 0x80, 0, 0, 1);      EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // fe80::/10 low
+    setKvsV6Addr(&addr, 0xfe, 0xbf, 0, 0, 1);      EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // fe80::/10 high
+    setKvsV6Addr(&addr, 0xfc, 0, 0, 0, 1);         EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // fc00::/7 (fc00)
+    setKvsV6Addr(&addr, 0xfd, 0, 0, 0, 1);         EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // fc00::/7 (fd00)
+    setKvsV6Addr(&addr, 0x20, 0x01, 0x0d, 0xb8, 1); EXPECT_TRUE(IS_NON_ROUTABLE_ADDR(&addr)); // 2001:db8::/32 documentation
+}
+
+TEST_F(NetworkApiTest, IsNonRoutableAddrIpv6RoutableAndBoundaries)
+{
+    KvsIpAddress addr;
+
+    setKvsV6Addr(&addr, 0x26, 0x00, 0x03, 0x82, 0x11); EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // 2600:382:: global (live test)
+    setKvsV6Addr(&addr, 0x20, 0x01, 0x48, 0x60, 1);    EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // 2001:4860:: global (not db8)
+    setKvsV6Addr(&addr, 0xfe, 0xc0, 0, 0, 1);          EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // fec0:: (outside fe80/10 and fc00/7)
+    setKvsV6Addr(&addr, 0xfe, 0x7f, 0, 0, 1);          EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // fe7f:: (just below fe80/10)
+    setKvsV6Addr(&addr, 0xfe, 0x00, 0, 0, 1);          EXPECT_FALSE(IS_NON_ROUTABLE_ADDR(&addr)); // fe00:: (not ULA, not link-local)
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/TurnConnectionFunctionalityTest.cpp
+++ b/tst/TurnConnectionFunctionalityTest.cpp
@@ -187,7 +187,7 @@ TEST_F(TurnConnectionFunctionalityTest, turnConnectionReceiveRelayedAddress)
  * turnConnectionAddPeer should skip non-routable peer addresses (which a public TURN server would
  * reject with 403 Forbidden IP): the peer is not added, turnPeerCount is unchanged, and the
  * diagnostic counter is bumped. Routable peers are added normally, and setting
- * disableTurnPeerAddressFilter turns the filter off so non-routable peers are added too.
+ * disableNonRoutablePeersFilterForRelay turns the filter off so non-routable peers are added too.
  */
 TEST_F(TurnConnectionFunctionalityTest, turnConnectionFiltersNonRoutablePeers)
 {
@@ -220,19 +220,19 @@ TEST_F(TurnConnectionFunctionalityTest, turnConnectionFiltersNonRoutablePeers)
     // and the diagnostic counter is incremented.
     EXPECT_EQ(STATUS_SUCCESS, turnConnectionAddPeer(pTurnConnection, &nonRoutablePeer));
     EXPECT_EQ((UINT32) 0, pTurnConnection->turnPeerCount);
-    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFiltered);
+    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFilteredCount);
 
     // A routable peer is added normally.
     EXPECT_EQ(STATUS_SUCCESS, turnConnectionAddPeer(pTurnConnection, &routablePeer));
     EXPECT_EQ((UINT32) 1, pTurnConnection->turnPeerCount);
-    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFiltered);
+    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFilteredCount);
 
     // With the filter disabled (e.g. an on-prem/LAN TURN that relays to private peers), the
     // non-routable peer is added and the counter does not change.
-    pTurnConnection->disableTurnPeerAddressFilter = TRUE;
+    pTurnConnection->disableNonRoutablePeersFilterForRelay = TRUE;
     EXPECT_EQ(STATUS_SUCCESS, turnConnectionAddPeer(pTurnConnection, &nonRoutablePeer));
     EXPECT_EQ((UINT32) 2, pTurnConnection->turnPeerCount);
-    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFiltered);
+    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFilteredCount);
 
     freeTestTurnConnection();
 }

--- a/tst/TurnConnectionFunctionalityTest.cpp
+++ b/tst/TurnConnectionFunctionalityTest.cpp
@@ -184,6 +184,60 @@ TEST_F(TurnConnectionFunctionalityTest, turnConnectionReceiveRelayedAddress)
 }
 
 /*
+ * turnConnectionAddPeer should skip non-routable peer addresses (which a public TURN server would
+ * reject with 403 Forbidden IP): the peer is not added, turnPeerCount is unchanged, and the
+ * diagnostic counter is bumped. Routable peers are added normally, and setting
+ * disableTurnPeerAddressFilter turns the filter off so non-routable peers are added too.
+ */
+TEST_F(TurnConnectionFunctionalityTest, turnConnectionFiltersNonRoutablePeers)
+{
+    if (!mAccessKeyIdSet) {
+        return;
+    }
+
+    KvsIpAddress nonRoutablePeer; // 192.168.1.1 (RFC 1918 private)
+    KvsIpAddress routablePeer;    // 77.1.1.1 (public)
+
+    initializeTestTurnConnection();
+
+    MEMSET(&nonRoutablePeer, 0x00, SIZEOF(KvsIpAddress));
+    nonRoutablePeer.family = KVS_IP_FAMILY_TYPE_IPV4;
+    nonRoutablePeer.port = (UINT16) getInt16(8080);
+    nonRoutablePeer.address[0] = 192;
+    nonRoutablePeer.address[1] = 168;
+    nonRoutablePeer.address[2] = 1;
+    nonRoutablePeer.address[3] = 1;
+
+    MEMSET(&routablePeer, 0x00, SIZEOF(KvsIpAddress));
+    routablePeer.family = KVS_IP_FAMILY_TYPE_IPV4;
+    routablePeer.port = (UINT16) getInt16(8080);
+    routablePeer.address[0] = 0x4d; // 77.1.1.1
+    routablePeer.address[1] = 0x01;
+    routablePeer.address[2] = 0x01;
+    routablePeer.address[3] = 0x01;
+
+    // Filter enabled by default: non-routable peer is skipped (successful no-op), not added,
+    // and the diagnostic counter is incremented.
+    EXPECT_EQ(STATUS_SUCCESS, turnConnectionAddPeer(pTurnConnection, &nonRoutablePeer));
+    EXPECT_EQ((UINT32) 0, pTurnConnection->turnPeerCount);
+    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFiltered);
+
+    // A routable peer is added normally.
+    EXPECT_EQ(STATUS_SUCCESS, turnConnectionAddPeer(pTurnConnection, &routablePeer));
+    EXPECT_EQ((UINT32) 1, pTurnConnection->turnPeerCount);
+    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFiltered);
+
+    // With the filter disabled (e.g. an on-prem/LAN TURN that relays to private peers), the
+    // non-routable peer is added and the counter does not change.
+    pTurnConnection->disableTurnPeerAddressFilter = TRUE;
+    EXPECT_EQ(STATUS_SUCCESS, turnConnectionAddPeer(pTurnConnection, &nonRoutablePeer));
+    EXPECT_EQ((UINT32) 2, pTurnConnection->turnPeerCount);
+    EXPECT_EQ((UINT32) 1, pTurnConnection->nonRoutablePeersFiltered);
+
+    freeTestTurnConnection();
+}
+
+/*
  * Given a valid turn endpoint and credentials, turnConnection should successfully allocate,
  * create permission, and create channel. Then manually trigger permission refresh and allocation refresh
  */


### PR DESCRIPTION
*Issue #, if available:*
- N/A (builds on / complements the issue raised in #2387)

*What was changed?*
- Added a proactive filter that skips creating TURN permissions for **non-routable peer addresses** that a public TURN server (e.g. KVS) rejects with `403 Forbidden IP`.
- New `IS_NON_ROUTABLE_ADDR` classifier in `Include_i.h` covering all not-globally-reachable IPv4 and IPv6 ranges (IANA Special-Purpose registries / RFC 6890).
- New opt-out config flag `KvsRtcConfiguration.disableTurnPeerAddressFilter` (default off = filter on).
- Added a `nonRoutablePeersFiltered` diagnostic counter, logged at INFO on each skip (no peer IP logged).

*Why was it changed?*
- #2387 fixes the symptom reactively: a `403`-failed peer stalls the TURN state machine for the per-state timeouts (~5s + ~5s), delaying ICE gathering and breaking non-trickle answerers.
- This PR removes the root cause for the common case: the `403` is predictable for private/link-local peers, so we never send the doomed `CreatePermission` — no error, no failed peer, no stall.
- Complementary to #2387: this avoids the wasted round-trips; #2387 remains the safety net for any other failure.

*How was it changed?*
- `turnConnectionAddPeer` skips a peer up front when `IS_NON_ROUTABLE_ADDR` matches and the filter isn't disabled; the candidate is untouched, so it can still form direct host/srflx pairs.
- Only the TURN permission is skipped — no change to candidate gathering or ICE pairing.
- The filter can be disabled via config for TURN servers that legitimately relay to private/ULA peers (on-prem/LAN).

*What testing was done for the changes?*
- Unit tests for `IS_NON_ROUTABLE_ADDR` covering every IPv4/IPv6 range, boundary values, routable negatives, and NULL/unset-family (all passing).
- Integration test asserting `turnConnectionAddPeer` skips a non-routable peer, adds a routable one, and adds a non-routable one when the filter is disabled.
- Manual end-to-end run (force-relay master + LAN viewer): `403`s eliminated and TURN reaches `READY` in ~110ms vs the ~4s+ stall without the fix.
BEFORE: 
<img width="1274" height="142" alt="image" src="https://github.com/user-attachments/assets/c58e03cf-e10b-4b36-b337-fdd415fc2d26" />
AFTER: 
<img width="1073" height="202" alt="image" src="https://github.com/user-attachments/assets/0cd5757d-ad65-400c-a4ca-88cbe0ad727d" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
