### PR TITLE
Crypto: hash DTLS certificate via mbedtls_md instead of mbedtls_sha256

### DIFF
--- a/src/source/Crypto/Crypto.h
+++ b/src/source/Crypto/Crypto.h
@@ -78,20 +78,9 @@ typedef enum {
 #define KVS_RSA_F4             0x10001L
 #define KVS_MD5_DIGEST_LENGTH  16
 #define KVS_SHA1_DIGEST_LENGTH 20
-#if MBEDTLS_VERSION_MAJOR >= 4
-/* TF-PSA-Crypto 1.0 (mbedTLS 4) removed the legacy MBEDTLS_MD5_C module and the
- * one-shot mbedtls_md5(); MD5 is reachable only through PSA (PSA_WANT_ALG_MD5). */
-#define KVS_MD5_DIGEST(m, mlen, ob)                                                                                                                  \
-    do {                                                                                                                                             \
-        size_t _kvsMd5Len = 0;                                                                                                                       \
-        (void) psa_crypto_init();                                                                                                                    \
-        (void) psa_hash_compute(PSA_ALG_MD5, (const unsigned char*) (m), (mlen), (unsigned char*) (ob), KVS_MD5_DIGEST_LENGTH, &_kvsMd5Len);         \
-    } while (0);
-#elif MBEDTLS_VERSION_NUMBER >= 0x03000000
-#define KVS_MD5_DIGEST(m, mlen, ob) mbedtls_md5((m), (mlen), (ob));
-#else
-#define KVS_MD5_DIGEST(m, mlen, ob) mbedtls_md5_ret((m), (mlen), (ob));
-#endif
+
+/* go through the generic message-digest layer rather than the MD5 module. */
+#define KVS_MD5_DIGEST(m, mlen, ob) mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_MD5), (m), (mlen), (ob));
 #define KVS_SHA1_HMAC(k, klen, m, mlen, ob, plen)                                                                                                    \
     CHK(0 == mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1), (k), (klen), (m), (mlen), (ob)), STATUS_HMAC_GENERATION_ERROR);             \
     *(plen) = mbedtls_md_get_size(mbedtls_md_info_from_type(MBEDTLS_MD_SHA1));

--- a/src/source/Crypto/Dtls_mbedtls.c
+++ b/src/source/Crypto/Dtls_mbedtls.c
@@ -1147,11 +1147,9 @@ STATUS dtlsCertificateFingerprint(mbedtls_x509_crt* pCert, PCHAR pBuff)
     pMdInfo = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
     CHK(pMdInfo != NULL, STATUS_INTERNAL_ERROR);
 
-#if MBEDTLS_BEFORE_V3
-    sslRet = mbedtls_sha256_ret(pCert->raw.p, pCert->raw.len, fingerprint, 0);
-#else
-    sslRet = mbedtls_sha256(pCert->raw.p, pCert->raw.len, fingerprint, 0);
-#endif
+    /* Go through the generic message-digest layer rather than the SHA-256 module
+     * directly. */
+    sslRet = mbedtls_md(pMdInfo, pCert->raw.p, pCert->raw.len, fingerprint);
     CHK(sslRet == 0, STATUS_INTERNAL_ERROR);
 
     size = mbedtls_md_get_size(pMdInfo);

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -63,8 +63,6 @@ extern "C" {
 #if defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_MAJOR >= 4
 #include <mbedtls/private/entropy.h>
 #include <mbedtls/private/ctr_drbg.h>
-#include <mbedtls/private/sha256.h>
-#include <mbedtls/private/md5.h>
 #include <mbedtls/md.h>
 #include <mbedtls/pk.h>
 #include <mbedtls/private/rsa.h>
@@ -76,8 +74,7 @@ extern "C" {
 #if MBEDTLS_VERSION_NUMBER < 0x03000000
 #include <mbedtls/certs.h>
 #endif
-#include <mbedtls/sha256.h>
-#include <mbedtls/md5.h>
+#include <mbedtls/md.h>
 #endif
 #endif
 


### PR DESCRIPTION

*Issue #, if available:*
- N/A

*What was changed?*
- Use of public mbedtls_md() API instead of private mbedtls_sha256()

*Why was it changed?*
- mbedTLS 4 moved mbedtls_sha256() into a private header and only builds it when the builtin SHA-256 driver is used, so a build with a PSA accelerator (e.g. ESP-IDF hardware SHA) fails to link. mbedtls_md() is public in mbedTLS 2/3/4 and dispatches to the active driver, dropping the version fork.

*How was it changed?*
- By using public mbedtls_md() API

*What testing was done for the changes?*
- Tested on IDF examples

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
