### PR TITLE
test(ice): stress-test non-routable peer filter under flood (#2386)

### DIFF
--- a/tst/TurnConnectionFunctionalityTest.cpp
+++ b/tst/TurnConnectionFunctionalityTest.cpp
@@ -1177,6 +1177,159 @@ TEST_F(TurnConnectionFunctionalityTest, turnConnectionCallMultipleTurnSendDataIn
     freeTestTurnConnection();
 }
 
+// ---------------------------------------------------------------------------
+// Injection / stress tests for the non-routable peer filter (issue #2386, PR #2388).
+//
+// A flood of local / non-routable peer candidates must be absorbed cheaply. Each is rejected by
+// turnConnectionAddPeer at O(1) -- before the lock, the duplicate scan and the transaction-id-store
+// allocation -- so it never enters turnPeerList and never produces a CreatePermission that the TURN
+// server would reject with 403 Forbidden IP, and so cannot stall the state machine until the
+// ~5s-per-state timeout. These are pure logic (no network / credentials), so they are not gated on
+// mAccessKeyIdSet and always run. Exhaustive per-range coverage of the classifier itself lives in
+// NetworkApiTest.IsNonRoutableAddr*; here the focus is scale and behaviour under a flood.
+
+// Allocates a minimal TurnConnection usable by turnConnectionAddPeer and the state-machine
+// predicates. stateTimeoutTime is pushed far into the future so advance decisions reflect
+// peer-state counting, not a timeout fallthrough.
+static PTurnConnection allocStressTestTurnConnection()
+{
+    PTurnConnection pTurnConnection = (PTurnConnection) MEMCALLOC(1, SIZEOF(TurnConnection));
+    EXPECT_TRUE(pTurnConnection != NULL);
+    if (pTurnConnection != NULL) {
+        pTurnConnection->lock = MUTEX_CREATE(FALSE);
+        pTurnConnection->state = TURN_STATE_CREATE_PERMISSION;
+        pTurnConnection->stateTimeoutTime = GETTIME() + 100 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+        pTurnConnection->ipFamilyType = KVS_IP_FAMILY_TYPE_IPV4;
+        pTurnConnection->disableNonRoutablePeersFilterForRelay = FALSE; // filter on (default)
+    }
+    return pTurnConnection;
+}
+
+// Frees a stress-test TurnConnection, including any transaction-id stores held by peers that were
+// actually added (so CI sanitizer builds do not flag a leak).
+static VOID freeStressTestTurnConnection(PTurnConnection pTurnConnection)
+{
+    if (pTurnConnection != NULL) {
+        for (UINT32 i = 0; i < pTurnConnection->turnPeerCount; ++i) {
+            if (pTurnConnection->turnPeerList[i].pTransactionIdStore != NULL) {
+                freeTransactionIdStore(&pTurnConnection->turnPeerList[i].pTransactionIdStore);
+            }
+        }
+        MUTEX_FREE(pTurnConnection->lock);
+        MEMFREE(pTurnConnection);
+    }
+}
+
+// Flooding turnConnectionAddPeer with a huge number of DISTINCT non-routable IPv4 addresses must be
+// absorbed at O(1) each: none enter the peer list, all are counted as filtered, and the whole flood
+// finishes in a tiny fraction of even a single ~5s per-state timeout.
+TEST_F(TurnConnectionFunctionalityTest, turnConnectionFiltersDistinctNonRoutableFloodFast)
+{
+    const UINT32 floodCount = 500000; // all distinct within 10.0.0.0/8 (16.7M addresses)
+
+    PTurnConnection pTurnConnection = allocStressTestTurnConnection();
+    ASSERT_TRUE(pTurnConnection != NULL);
+
+    KvsIpAddress peer;
+    MEMSET(&peer, 0x00, SIZEOF(KvsIpAddress));
+    peer.family = KVS_IP_FAMILY_TYPE_IPV4;
+    peer.port = (UINT16) getInt16(8080);
+    peer.address[0] = 10; // 10.0.0.0/8 private
+
+    // The filter logs at INFO on every skip; silence it during the flood so the timing reflects the
+    // filter cost, not 500k log writes. The fixture restores the level for the next test.
+    SET_LOGGER_LOG_LEVEL(LOG_LEVEL_WARN);
+
+    BOOL allFiltered = TRUE;
+    UINT64 startTime = GETTIME();
+    for (UINT32 i = 0; i < floodCount; ++i) {
+        // Pack i across the low three octets so every address is unique: 10.a.b.c.
+        peer.address[1] = (BYTE) (i >> 16);
+        peer.address[2] = (BYTE) (i >> 8);
+        peer.address[3] = (BYTE) i;
+        // A filtered peer is a successful no-op; accumulate instead of asserting 500k times so the
+        // timed region reflects only the filter cost.
+        allFiltered = (BOOL) (allFiltered && (turnConnectionAddPeer(pTurnConnection, &peer) == STATUS_SUCCESS));
+    }
+    UINT64 floodElapsed = GETTIME() - startTime;
+
+    SET_LOGGER_LOG_LEVEL(mLogLevel);
+
+    EXPECT_TRUE(allFiltered);
+    // None of the flood entered the peer list; every one was counted as filtered.
+    EXPECT_EQ((UINT32) 0, pTurnConnection->turnPeerCount);
+    EXPECT_EQ(floodCount, pTurnConnection->nonRoutablePeersFilteredCount);
+
+    // "Finishes fast": half a million distinct non-routable peers absorbed in well under a single
+    // ~5s per-state timeout. Bounded generously to stay robust under CI sanitizer builds while still
+    // catching a regression to a per-peer network / allocation path.
+    EXPECT_LT(floodElapsed, 3 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    freeStressTestTurnConnection(pTurnConnection);
+}
+
+// A flood of non-routable peers interleaved with a few genuinely routable ones must not crowd out or
+// delay the real peers: only the routable peers are added, and the state machine's advance condition
+// is satisfiable immediately once they succeed -- it never waits on the doomed non-routable peers.
+TEST_F(TurnConnectionFunctionalityTest, turnConnectionFloodDoesNotDelayRoutablePeers)
+{
+    const UINT32 floodCount = 100000;
+    const UINT32 routableCount = 3; // stays under DEFAULT_TURN_MAX_PEER_COUNT
+
+    PTurnConnection pTurnConnection = allocStressTestTurnConnection();
+    ASSERT_TRUE(pTurnConnection != NULL);
+
+    KvsIpAddress peer;
+    MEMSET(&peer, 0x00, SIZEOF(KvsIpAddress));
+    peer.family = KVS_IP_FAMILY_TYPE_IPV4;
+    peer.port = (UINT16) getInt16(8080);
+
+    SET_LOGGER_LOG_LEVEL(LOG_LEVEL_WARN);
+
+    BOOL allOk = TRUE;
+    UINT32 routableAdded = 0;
+    UINT64 startTime = GETTIME();
+    for (UINT32 i = 0; i < floodCount; ++i) {
+        // Every (floodCount / routableCount)-th peer is a distinct public/routable address; the rest
+        // are distinct non-routable 10/8 addresses.
+        if (routableAdded < routableCount && (i % (floodCount / routableCount)) == 0) {
+            peer.address[0] = 77; // 77.0.0.0/8 is public/routable
+            peer.address[1] = 0x01;
+            peer.address[2] = 0x01;
+            peer.address[3] = (BYTE) (routableAdded + 1); // 77.1.1.1, 77.1.1.2, 77.1.1.3
+            allOk = (BOOL) (allOk && (turnConnectionAddPeer(pTurnConnection, &peer) == STATUS_SUCCESS));
+            routableAdded++;
+        } else {
+            peer.address[0] = 10; // 10.0.0.0/8 private
+            peer.address[1] = (BYTE) (i >> 16);
+            peer.address[2] = (BYTE) (i >> 8);
+            peer.address[3] = (BYTE) i;
+            allOk = (BOOL) (allOk && (turnConnectionAddPeer(pTurnConnection, &peer) == STATUS_SUCCESS));
+        }
+    }
+    UINT64 floodElapsed = GETTIME() - startTime;
+
+    SET_LOGGER_LOG_LEVEL(mLogLevel);
+
+    EXPECT_TRUE(allOk);
+    // Only the routable peers were added; every non-routable one was filtered.
+    EXPECT_EQ(routableCount, pTurnConnection->turnPeerCount);
+    EXPECT_EQ(floodCount - routableCount, pTurnConnection->nonRoutablePeersFilteredCount);
+
+    // Once the routable peers succeed, the advance condition (all peers accounted for) is met with a
+    // tiny peer set -- the flood never inflated turnPeerCount, so there is nothing doomed to wait on.
+    for (UINT32 i = 0; i < pTurnConnection->turnPeerCount; ++i) {
+        pTurnConnection->turnPeerList[i].connectionState = TURN_PEER_CONN_STATE_READY;
+    }
+    UINT64 nextState = TURN_STATE_NONE;
+    EXPECT_EQ(STATUS_SUCCESS, fromCreatePermissionTurnState((UINT64) pTurnConnection, &nextState));
+    EXPECT_EQ(TURN_STATE_BIND_CHANNEL, nextState);
+
+    EXPECT_LT(floodElapsed, 2 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    freeStressTestTurnConnection(pTurnConnection);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*

- #2386 (TURN `403 Forbidden IP` stalls ICE gathering). Adds stress/scale coverage for the non-routable peer filter delivered in #2388.

*What was changed?*

- Added two injection/stress unit tests to `tst/TurnConnectionFunctionalityTest.cpp` for the non-routable TURN peer filter:
  - `turnConnectionFiltersDistinctNonRoutableFloodFast`
  - `turnConnectionFloodDoesNotDelayRoutablePeers`
- Added shared `allocStressTestTurnConnection` / `freeStressTestTurnConnection` test helpers.
- Test-only change; no production code modified.

*Why was it changed?*

- The filter's whole point is that a large number of local/non-routable peer candidates can be rejected up front so they never trigger a `CreatePermission` the TURN server would answer with `403 Forbidden IP` (which otherwise stalls the state machine until the ~5s-per-state timeout). Prior tests confirmed the single-peer behavior but not that the filter holds up under scale.
- These lock in two properties a regression could silently break: (1) a huge flood of distinct non-routable peers is absorbed cheaply and never enters the peer list, and (2) a flood does not crowd out or delay genuinely routable peers — the state machine still advances immediately once the real peers succeed.
- Per-range coverage of the classifier itself already lives in `NetworkApiTest.IsNonRoutableAddr*`, so these tests deliberately focus on scale and flood behavior rather than duplicating range checks.

*How was it changed?*

- Both tests build a minimal heap `TurnConnection` (live mutex, `stateTimeoutTime` pushed far into the future so results reflect peer-state counting rather than a timeout fallthrough) and drive `turnConnectionAddPeer` directly — no network or credentials, so they are not gated on `mAccessKeyIdSet` and always run.
- `turnConnectionFiltersDistinctNonRoutableFloodFast` injects 500,000 **distinct** non-routable IPv4 addresses (packed across `10.0.0.0/8`) and asserts every call is a successful no-op, `turnPeerCount == 0`, `nonRoutablePeersFilteredCount == 500000`, and the flood completes well under a single per-state timeout.
- `turnConnectionFloodDoesNotDelayRoutablePeers` interleaves 100,000 non-routable peers with 3 genuinely routable ones, then asserts only the routable peers are added (`turnPeerCount == 3`, the rest filtered) and that `fromCreatePermissionTurnState` advances to `TURN_STATE_BIND_CHANNEL` once they succeed.
- The per-skip `INFO` log is silenced during the flood (`SET_LOGGER_LOG_LEVEL(LOG_LEVEL_WARN)`, restored to `mLogLevel`) so timing reflects filter cost, not log I/O; teardown frees each added peer's transaction-id store to keep the CI sanitizer jobs clean.

*What testing was done for the changes?*

- Built `webrtc_client_test` locally (`-DBUILD_TEST=ON`) and ran both new cases:
  `./tst/webrtc_client_test --gtest_filter='TurnConnectionFunctionalityTest.turnConnectionFiltersDistinctNonRoutableFloodFast:TurnConnectionFunctionalityTest.turnConnectionFloodDoesNotDelayRoutablePeers'` — 2/2 passed.
- Confirmed the functional assertions are the real regression guards (if the filter were removed, adds would fill the 32-peer cap then return errors, `turnPeerCount` would be non-zero, and `nonRoutablePeersFilteredCount` would be 0 — all caught independently of timing).
- Tests are pure logic (no network/credentials), so they run identically in CI across the OS/TLS/compiler build matrix, including the sanitizer jobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
